### PR TITLE
test: add kubernetes CLI installer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ function _mytool_helper() {
 }
 ```
 
+### `_run_command` helper
+
+The `_run_command` wrapper executes system commands with consistent error handling
+and optional `sudo` support. Its general form is:
+
+```
+_run_command [--quiet] [--prefer-sudo|--require-sudo] [--probe '<subcmd>'] -- <prog> [args...]
+```
+
+Examples:
+
+```bash
+# install a package, preferring sudo but falling back to the current user
+_run_command --prefer-sudo -- apt-get install -y jq
+
+# require sudo and abort if it is unavailable
+_run_command --require-sudo -- mkdir /etc/myapp
+
+# probe a subcommand to decide if sudo is needed
+_run_command --probe 'config current-context' -- kubectl get nodes
+```
+
+Use `--` to separate `_run_command` options from the command being executed.
+Unless `--quiet` is specified, failures print the exit code and full command.
+
 ## Security notes
 
 * `_failfast_on`/`_failfast_off` toggle `set -Eeuo pipefail`.

--- a/scripts/tests/lib/install_kubernetes_cli.bats
+++ b/scripts/tests/lib/install_kubernetes_cli.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  source "${BATS_TEST_DIRNAME}/../test_helpers.bash"
+  source "${BATS_TEST_DIRNAME}/../../lib/system.sh"
+  init_test_env
+}
+
+@test "installs kubectl via brew on macOS" {
+  _is_redhat_family() { return 1; }
+  _is_debian_family() { return 1; }
+  _is_wsl() { return 1; }
+  _is_mac() { return 0; }
+  _command_exist() { return 1; }
+  export -f _is_redhat_family _is_debian_family _is_wsl _is_mac _command_exist
+  export_stubs
+
+  run _install_kubernetes_cli
+  [ "$status" -eq 0 ]
+  read_lines "$RUN_LOG" log
+  [ "${log[0]}" = "brew install kubectl" ]
+}
+
+@test "uses non-macOS installers when not on macOS" {
+  _is_redhat_family() { return 1; }
+  _is_debian_family() { return 0; }
+  _is_wsl() { return 1; }
+  _is_mac() { return 1; }
+  _command_exist() { return 1; }
+  export -f _is_redhat_family _is_debian_family _is_wsl _is_mac _command_exist
+  export_stubs
+
+  run _install_kubernetes_cli
+  [ "$status" -eq 0 ]
+  ! grep -q 'brew install kubectl' "$RUN_LOG"
+  grep -q 'sudo apt-get install -y kubectl' "$RUN_LOG"
+}


### PR DESCRIPTION
## Summary
- add Bats tests for kubectl installation helper
- ensure brew install used on macOS and apt path used elsewhere
- document `_run_command` helper with usage examples in README

## Testing
- `bats -r scripts/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c76782ff9c8331ba50b4094f5d625e