### PR TITLE
docs: mark LDAP_PASSWORD_ROTATOR rename complete

### DIFF
--- a/docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md
+++ b/docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md
@@ -1,7 +1,7 @@
 # GitGuardian False Positive: LDAP_PASSWORD_ROTATOR_IMAGE
 
 **Date:** 2026-02-23
-**Status:** False Positive — No real secret exposed
+**Status:** FIXED — Renamed to `LDAP_ROTATOR_IMAGE` (2026-02-27)
 **GitGuardian Incident:** [#22639636](https://dashboard.gitguardian.com/workspace/359778/incidents/22639636)
 **Flagged Commit:** `625ef0e3cc002a99a3d8b40e2e29e8396db2001f`
 **Flagged File:** `scripts/etc/ldap/vars.sh`, line 99
@@ -54,6 +54,10 @@ related variables:
 
 **Alternative:** Add a `.gitguardian.yml` ignore rule for this variable pattern if renaming
 is not desirable.
+
+**Done (2026-02-27):** All variables renamed in `scripts/` — `LDAP_ROTATOR_IMAGE`,
+`LDAP_ROTATOR_ENABLED`, `LDAP_ROTATION_SCHEDULE`, `LDAP_ROTATION_PORT`. Verified:
+`grep -r "LDAP_PASSWORD_ROTATOR" scripts/` returns no output.
 
 ## Prevention
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -147,27 +147,6 @@ Plan: `docs/plans/ldap-rotator-rename.md`
 
 ---
 
-## Next Step for Codex — LDAP Rotator Rename Docs Cleanup
-
-**Branch:** `fix/ldap-rotator-rename`
-**Goal:** Docs-only cleanup — no code changes. The rename is already done in `scripts/`.
-
-**What to do:** Follow `docs/plans/ldap-rotator-rename.md` exactly:
-
-1. `memory-bank/progress.md` — add note to the `[x]` rename item: `(code renamed 2026-02-23; docs cleaned up 2026-02-27)`
-2. `memory-bank/activeContext.md` — Operational Notes: update "pending rename to `LDAP_ROTATOR_IMAGE`" to reflect rename is complete
-3. `docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md` — change status to `FIXED — Renamed to LDAP_ROTATOR_IMAGE (2026-02-27)`; add "Done" note under Resolution
-
-**Verify before committing:**
-```bash
-grep -r "LDAP_PASSWORD_ROTATOR" scripts/
-# Must return no output
-```
-
-**Do NOT update memory-bank with ✅ until grep confirms no old names in scripts/.**
-
----
-
 ## Next Step for Gemini — Validation Complete ✅
 
 **Branch:** `fix/vault-auth-delegator`
@@ -251,5 +230,5 @@ Cleaning up Vault test resources...
 - **ESO SecretStore**: `mountPath` must be `kubernetes` (not `auth/kubernetes`).
 - **LDAP bind DN**: keep `LDAP_BASE_DN` in sync with LDIF bootstrap base DN.
 - **Jenkins admin password**: contains special chars — always quote `-u "user:$pass"` or use kubectl to fetch. See `docs/issues/2026-02-27-jenkins-admin-password-zsh-glob.md`.
-- **GitGuardian false positive resolved**: `LDAP_PASSWORD_ROTATOR_IMAGE` already renamed to `LDAP_ROTATOR_IMAGE` in all scripts. Docs/memory-bank cleanup pending — see `docs/plans/ldap-rotator-rename.md`.
+- **GitGuardian false positive resolved**: `LDAP_PASSWORD_ROTATOR_IMAGE` renamed to `LDAP_ROTATOR_IMAGE` in all scripts (2026-02-23) and docs updated (2026-02-27). See `docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md`.
 - **SMB CSI Phase 1 evidence**: validated on m4-air 2026-02-27. See evidence block in git history (commit `01f9d77`).

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -147,6 +147,27 @@ Plan: `docs/plans/ldap-rotator-rename.md`
 
 ---
 
+## Next Step for Codex — LDAP Rotator Rename Docs Cleanup
+
+**Branch:** `fix/ldap-rotator-rename`
+**Goal:** Docs-only cleanup — no code changes. The rename is already done in `scripts/`.
+
+**What to do:** Follow `docs/plans/ldap-rotator-rename.md` exactly:
+
+1. `memory-bank/progress.md` — add note to the `[x]` rename item: `(code renamed 2026-02-23; docs cleaned up 2026-02-27)`
+2. `memory-bank/activeContext.md` — Operational Notes: update "pending rename to `LDAP_ROTATOR_IMAGE`" to reflect rename is complete
+3. `docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md` — change status to `FIXED — Renamed to LDAP_ROTATOR_IMAGE (2026-02-27)`; add "Done" note under Resolution
+
+**Verify before committing:**
+```bash
+grep -r "LDAP_PASSWORD_ROTATOR" scripts/
+# Must return no output
+```
+
+**Do NOT update memory-bank with ✅ until grep confirms no old names in scripts/.**
+
+---
+
 ## Next Step for Gemini — Validation Complete ✅
 
 **Branch:** `fix/vault-auth-delegator`

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -150,8 +150,7 @@ Next: add `system:auth-delegator` ClusterRoleBinding to `deploy_vault` (Priority
     - Status: `m2-air` cluster is now a verified Stage 2 CI fixture.
   - [ ] Phase 3: OrbStack native Kubernetes provider (no k3d overhead) — half day
 - [x] **Rename `LDAP_PASSWORD_ROTATOR_*` → `LDAP_ROTATOR_*`** — fix GitGuardian false positive
-  - Code renamed in `scripts/` as of 2026-02-23. Docs/memory-bank cleanup pending.
-  - Plan: `docs/plans/ldap-rotator-rename.md`
+  - Code renamed in `scripts/` as of 2026-02-23; docs cleaned up 2026-02-27.
   - See `docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md`
 
 - [x] **`test_vault` cleanup** — revert non-fatal pod test workaround to hard-fail


### PR DESCRIPTION
## Summary

- Docs-only cleanup — no code changes
- `LDAP_PASSWORD_ROTATOR_*` was already renamed to `LDAP_ROTATOR_*` in all scripts as of 2026-02-23
- Updates memory-bank and issue doc to reflect the rename is complete

## Changes
- `memory-bank/progress.md` — add completion note to rename task
- `memory-bank/activeContext.md` — update Operational Notes
- `docs/issues/2026-02-23-gitguardian-false-positive-ldap-rotator-image.md` — status → FIXED

## Test plan
- [ ] `grep -r "LDAP_PASSWORD_ROTATOR" scripts/` returns no output
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)