### PR TITLE
docs: add v0.2.0 release notes and Releases table

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,27 @@
 # Changes - k3d-manager
 
+## v0.2.0 - dated 2026-02-27
+
+### OrbStack Provider
+- Added `scripts/lib/providers/orbstack.sh` — k3d lifecycle operations via OrbStack's Docker runtime
+- Auto-detection on macOS: prefers OrbStack when `orb` daemon is running, falls back to k3d
+- Validated on M4 and M2 Macs — full stack (cluster, Vault, Jenkins, Istio, smoke tests) green
+- Stage 2 CI now runs on OrbStack (m2-air self-hosted runner)
+
+### Vault
+- `deploy_vault` now ensures `system:auth-delegator` ClusterRoleBinding exists (idempotent)
+- `test_vault` reverted to hard-fail on pod auth failure — workaround removed
+
+### Jenkins
+- Fixed Kubernetes agents: ServiceAccount mismatch, envsubst placeholders, crumb issuer, port alignment (8080)
+- SMB CSI Phase 1: `deploy_smb_csi` no-ops with warning on macOS (cifs module unavailable)
+
+### Housekeeping
+- Renamed `LDAP_PASSWORD_ROTATOR_IMAGE` → `LDAP_ROTATOR_IMAGE` (GitGuardian false positive fix)
+- Stage 2 CI (`test_vault`, `test_eso`, `test_istio`) green on m2-air
+
+---
+
 ## OrbStack Provider Support - dated 2026-02-24
 
 - Added `scripts/lib/providers/orbstack.sh` to run all k3d lifecycle operations against OrbStack's Docker runtime without touching Colima/Docker Desktop installers.

--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ Detailed design, planning, and troubleshooting references live under `docs/`. Us
 ### Status Tracking
 - **[AD Integration Status](docs/ad-integration-status.md)** - Rolling status board for AD feature parity
 
+## Releases
+
+| Version | Date | Highlights |
+|---|---|---|
+| [v0.2.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.2.0) | 2026-02-27 | OrbStack validated (M4+M2), Vault auth-delegator fix, Jenkins k8s agents, Stage 2 CI green |
+| [v0.1.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.1.0) | 2026-02-27 | Initial release — k3d, k3s, OrbStack providers; Vault PKI; Jenkins; ESO; LDAP/AD |
+
 ## Directory layout
 
 ```


### PR DESCRIPTION
## Summary

- Added v0.2.0 release notes to `CHANGE.md` covering OrbStack, Vault, Jenkins k8s agents, and housekeeping changes
- Added `## Releases` table to `README.md` linking v0.1.0 and v0.2.0 GitHub releases

## Test plan

- [ ] CI lint passes
- [ ] README renders correctly on GitHub
- [ ] CHANGE.md entry is accurate and complete

@copilot please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)