### PR TITLE
docs: triage rebuild issues found during v0.3.0 post-merge infra redeploy

### DIFF
--- a/docs/issues/2026-03-01-cluster-name-env-var-not-respected.md
+++ b/docs/issues/2026-03-01-cluster-name-env-var-not-respected.md
@@ -1,0 +1,57 @@
+# P3: `CLUSTER_NAME` Env Var Not Respected by `deploy_cluster`
+
+**Date:** 2026-03-01
+**Reported:** Observed during infra cluster rebuild (post v0.3.0 merge)
+**Status:** OPEN
+**Severity:** P3
+**Type:** Bug — env var override silently ignored
+
+---
+
+## What Happened
+
+When running:
+
+```bash
+CLUSTER_NAME=automation CLUSTER_ROLE=infra ./scripts/k3d-manager deploy_cluster
+```
+
+The cluster was created as `k3d-cluster` instead of `automation`. The `CLUSTER_NAME=automation` env var was silently ignored.
+
+**Observed cluster name:** `k3d-cluster`
+**Expected cluster name:** `automation`
+
+---
+
+## Impact
+
+- Infra cluster is running as `k3d-cluster` instead of `automation`
+- `kubectl` context is `k3d-k3d-cluster` instead of `k3d-automation`
+- CI `check_cluster_health.sh` may reference cluster by context name — needs to be verified
+- Operationally non-blocking (cluster works), but naming is inconsistent with documented plan
+
+---
+
+## Root Cause (Suspected)
+
+`CLUSTER_NAME` is likely defaulted early in the dispatcher or provider before the env var is read, or there is a hardcoded default that overrides the env var. Needs investigation in:
+
+- `scripts/k3d-manager` (dispatcher)
+- `scripts/lib/providers/orbstack.sh` or `scripts/lib/providers/k3d.sh`
+- Any `CLUSTER_NAME` defaulting logic
+
+---
+
+## Workaround
+
+The cluster is functional under the name `k3d-cluster`. All `kubectl` commands work normally. Deployment continues under the current name.
+
+---
+
+## Triage
+
+| Factor | Assessment |
+|---|---|
+| Operational impact | Low — cluster works, wrong name |
+| Fix urgency | P3 — nice to have before next rebuild |
+| Likely fix | Find where `CLUSTER_NAME` is defaulted and ensure env var is checked first |

--- a/docs/issues/2026-03-01-deploy-jenkins-ignores-jenkins-namespace-env-var.md
+++ b/docs/issues/2026-03-01-deploy-jenkins-ignores-jenkins-namespace-env-var.md
@@ -1,0 +1,64 @@
+# P3: `deploy_jenkins` Ignores `JENKINS_NAMESPACE` Env Var
+
+**Date:** 2026-03-01
+**Reported:** Observed during infra cluster rebuild (post v0.3.0 merge)
+**Status:** OPEN
+**Severity:** P3
+**Type:** Bug — env var override silently ignored
+
+---
+
+## What Happened
+
+When running:
+
+```bash
+JENKINS_NAMESPACE=cicd ./scripts/k3d-manager deploy_jenkins --enable-ldap --enable-vault
+```
+
+Jenkins deployed to the `jenkins` namespace instead of `cicd`. The `JENKINS_NAMESPACE=cicd` env var was silently ignored.
+
+---
+
+## Root Cause
+
+**File:** `scripts/plugins/jenkins.sh` line 1281
+
+```bash
+jenkins_namespace="${jenkins_namespace:-jenkins}"   # ← defaults to "jenkins" literal, ignores $JENKINS_NAMESPACE env var
+```
+
+The local variable `jenkins_namespace` is initialized from the `--namespace` CLI flag (or positional arg). If neither is provided, it falls back to the literal string `jenkins` instead of `${JENKINS_NAMESPACE:-jenkins}`.
+
+---
+
+## Fix
+
+**File:** `scripts/plugins/jenkins.sh` line 1281
+
+```bash
+# Before:
+jenkins_namespace="${jenkins_namespace:-jenkins}"
+
+# After:
+jenkins_namespace="${jenkins_namespace:-${JENKINS_NAMESPACE:-jenkins}}"
+```
+
+---
+
+## Impact
+
+- `JENKINS_NAMESPACE=cicd deploy_jenkins` deploys to `jenkins` instead of `cicd`
+- v0.3.0 namespace rename to `cicd` requires `--namespace cicd` CLI flag to work
+- Related to companion bug: PV template hardcoded `namespace: jenkins` (separate issue)
+
+---
+
+## Triage
+
+| Factor | Assessment |
+|---|---|
+| Operational impact | Medium — `--namespace cicd` flag workaround exists |
+| Fix urgency | P3 — workaround available |
+| Fix risk | Low — one-line change with consistent env var pattern |
+| Severity | P3 — inconsistent with other plugins that do check env vars |

--- a/docs/issues/2026-03-01-jenkins-pv-template-hardcoded-namespace.md
+++ b/docs/issues/2026-03-01-jenkins-pv-template-hardcoded-namespace.md
@@ -1,0 +1,104 @@
+# P2: Jenkins PV Template Has Hardcoded `namespace: jenkins`
+
+**Date:** 2026-03-01
+**Reported:** Observed during infra cluster rebuild (post v0.3.0 merge)
+**Status:** OPEN
+**Severity:** P2
+**Type:** Bug — hardcoded namespace breaks `--namespace` override
+
+---
+
+## What Happened
+
+When running `deploy_jenkins --namespace cicd`, the PV/PVC step fails:
+
+```
+error: the namespace from the provided object "jenkins" does not match the namespace "cicd".
+You must pass '--namespace=jenkins' to perform this operation.
+kubectl command failed (1): kubectl apply -f /tmp/jenkins-home-pv.GYjwSM.yaml -n cicd
+ERROR: failed to execute kubectl apply -f /tmp/jenkins-home-pv.GYjwSM.yaml -n cicd: 1
+```
+
+The PVC template (`scripts/etc/jenkins/jenkins-home-pv.yaml.tmpl`) has `namespace: jenkins` hardcoded:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jenkins-home
+  namespace: jenkins   # ← hardcoded; ignores $JENKINS_NAMESPACE
+```
+
+`_create_jenkins_pv_pvc` calls `envsubst < "$jenkins_pv_template"` but the template never references `$JENKINS_NAMESPACE`, so substitution has no effect.
+
+---
+
+## Root Cause
+
+**File:** `scripts/etc/jenkins/jenkins-home-pv.yaml.tmpl` line 13
+
+The namespace field is a string literal `jenkins`, not `$JENKINS_NAMESPACE`.
+
+`_create_jenkins_pv_pvc` in `scripts/plugins/jenkins.sh` (line ~458) calls:
+
+```bash
+envsubst < "$jenkins_pv_template" > "$jenkinsyamfile"
+_kubectl apply -f "$jenkinsyamfile" -n "$jenkins_namespace"
+```
+
+When `jenkins_namespace=cicd`, kubectl sees a metadata namespace of `jenkins` but the `-n cicd` flag and rejects it.
+
+---
+
+## Related Issue
+
+`JENKINS_NAMESPACE` env var also not respected — `deploy_jenkins` defaults to `jenkins` at line 1281:
+```bash
+jenkins_namespace="${jenkins_namespace:-jenkins}"  # never falls back to $JENKINS_NAMESPACE env var
+```
+This is a separate (related) bug — see companion issue.
+
+---
+
+## Fix
+
+**File:** `scripts/etc/jenkins/jenkins-home-pv.yaml.tmpl`
+
+```yaml
+# Before:
+  namespace: jenkins
+
+# After:
+  namespace: $JENKINS_NAMESPACE
+```
+
+Also ensure `JENKINS_NAMESPACE` is exported before `envsubst` is called in `_create_jenkins_pv_pvc`.
+
+---
+
+## Impact
+
+- Jenkins cannot be deployed to `cicd` namespace (or any non-default namespace) without manual workaround
+- v0.3.0 namespace rename to `cicd` is blocked for Jenkins
+- Workaround: manually create the PVC in the target namespace, but deploy still fails at apply step
+
+---
+
+## Workaround (Operational)
+
+Jenkins skipped in current infra rebuild. Deploy to default `jenkins` namespace if Jenkins is needed immediately:
+
+```bash
+VAULT_NS=secrets ./scripts/k3d-manager deploy_jenkins --enable-ldap --enable-vault
+```
+
+---
+
+## Triage
+
+| Factor | Assessment |
+|---|---|
+| Operational impact | High — Jenkins cannot move to `cicd` ns without fix |
+| Fix urgency | P2 — blocks v0.3.0 namespace rename goal for Jenkins |
+| Fix risk | Low — template one-liner + export in function |
+| Severity | P2 — core v0.3.0 feature blocked |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,38 +1,34 @@
 # Active Context – k3d-manager
 
-## Current Branch: `feature/two-cluster-infra` (as of 2026-03-02)
+## Current Branch: `main` (as of 2026-03-01)
 
-**v0.2.1 released** — OrbStack validated, Vault reboot unseal, Jenkins k8s agents, docs.
-**v0.3.0 — PR #8 READY FOR MERGE** — all checks green, Gemini sign-off complete.
+**v0.3.0 merged** — Two-cluster refactor, namespace renames, CLUSTER_ROLE, remote Vault ESO.
 
 ---
 
 ## Current Focus
 
-PR #8 (`feature/two-cluster-infra`) is ready to merge. All 4 code fixes verified:
-- `test_auth_cleanup.bats` sub-calls restored (lint ✅)
-- `deploy_vault` respects `VAULT_NS`
-- `_cleanup_cert_rotation_test` EXIT trap scope fix
-- `deploy_eso` remote SecretStore namespace fix
+Post-merge infra cluster rebuild in progress. Partial success — 3 of 5 components deployed.
+Two new bugs found and documented during rebuild (see Known Bugs section).
 
-After merge: destroy infra cluster → redeploy with new namespaces → deploy app layer on Ubuntu.
+Next: fix Jenkins PV template bug (P2) → redeploy Jenkins to `cicd` → configure Vault for app cluster → deploy app layer on Ubuntu.
 
 ---
 
 ## Cluster State (as of 2026-03-01)
 
-### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-test-orbstack-exists`)
+### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-cluster`)
+**Note:** Cluster name is `k3d-cluster` (CLUSTER_NAME=automation env var ignored — see open bug).
+
 | Component | Status | Notes |
 |---|---|---|
-| Vault | ✅ Running | will be redeployed to `secrets` ns after PR merge |
-| ESO | ✅ Running | will move to `secrets` ns |
-| Jenkins | ✅ Running | will move to `cicd` ns |
-| OpenLDAP | ✅ Running | will move to `identity` ns |
-| Istio | ✅ Running | stays `istio-system` |
-| ArgoCD | ❌ Not deployed | add during infra redeploy |
-| Keycloak | ❌ Not deployed | add during infra redeploy |
-
-Context `k3d-automation` is dead (old cluster, port gone — ignore).
+| Vault | ✅ Running | `secrets` ns, initialized + unsealed |
+| ESO | ✅ Running | `secrets` ns |
+| OpenLDAP | ✅ Running | `identity` ns |
+| Istio | ✅ Running | `istio-system` |
+| Jenkins | ❌ Blocked | PV template has hardcoded `namespace: jenkins` — P2 bug |
+| ArgoCD | ❌ Not deployed | no `deploy_argocd` command yet |
+| Keycloak | ❌ Not deployed | no `deploy_keycloak` command yet |
 
 ### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`, host: `<UBUNTU-IP>`)
 | Component | Status | Notes |
@@ -100,12 +96,21 @@ Context `k3d-automation` is dead (old cluster, port gone — ignore).
 
 ---
 
-## Known Broken Paths (all pre-existing)
+## Known Broken Paths
+
+### Pre-existing
 | Path | Root Cause |
 |---|---|
 | `deploy_jenkins` (no vault) | Policy creation always runs; jenkins-admin secret missing |
 | `--enable-ldap` without `--enable-vault` | LDAP secrets require Vault |
 | Basic LDAP deploys empty directory | No bootstrap LDIF; use `deploy_ad` as workaround |
+
+### New (found during v0.3.0 rebuild — 2026-03-01)
+| Path | Root Cause | Severity | Doc |
+|---|---|---|---|
+| `CLUSTER_NAME=automation` ignored | Cluster created as `k3d-cluster`; env var not picked up in provider | P3 | `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md` |
+| `deploy_jenkins --namespace cicd` fails at PV/PVC | `jenkins-home-pv.yaml.tmpl` has `namespace: jenkins` hardcoded | P2 | `docs/issues/2026-03-01-jenkins-pv-template-hardcoded-namespace.md` |
+| `JENKINS_NAMESPACE=cicd deploy_jenkins` ignored | Line 1281 defaults to `"jenkins"` literal, not `${JENKINS_NAMESPACE:-jenkins}` | P3 | `docs/issues/2026-03-01-deploy-jenkins-ignores-jenkins-namespace-env-var.md` |
 
 ---
 
@@ -116,7 +121,7 @@ Context `k3d-automation` is dead (old cluster, port gone — ignore).
 | v0.1.0 | ✅ released 2026-02-27 | Initial release |
 | v0.2.0 | ✅ released 2026-02-27 | OrbStack, Vault reboot unseal, Jenkins k8s agents |
 | v0.2.1 | ✅ released 2026-02-28 | Docs-only: CHANGE.md + README Releases table |
-| v0.3.0 | ✅ ready to merge | Two-cluster refactor, namespace renames, CLUSTER_ROLE, remote Vault ESO |
+| v0.3.0 | ✅ merged 2026-03-01 | Two-cluster refactor, namespace renames, CLUSTER_ROLE, remote Vault ESO |
 | v1.0.0 | future | Production-hardened, all known-broken paths resolved |
 
 ---

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -70,8 +70,16 @@ Verified by Gemini: shellcheck clean, ESO API v1 fixed, regression tests green o
 
 **Two-Cluster Implementation:**
 - [x] k3d-manager app-cluster mode refactor — **VERIFIED 2026-03-01**
-- [ ] PR merge to `main` — **READY FOR CLAUDE**
-- [ ] Destroy infra cluster → redeploy with new namespaces (secrets/identity/cicd)
+- [x] PR merge to `main` — **MERGED 2026-03-01** (v0.3.0)
+- [x] Destroy old infra cluster (`test-orbstack-exists`)
+- [~] Redeploy infra cluster with new namespaces — **PARTIAL** (Jenkins blocked by PV template bug)
+  - [x] Vault + ESO → `secrets` ns
+  - [x] OpenLDAP → `identity` ns
+  - [x] Istio → `istio-system`
+  - [ ] Jenkins → `cicd` ns (blocked: P2 PV template bug — needs Codex fix)
+  - [ ] ArgoCD → `cicd` ns (no deploy command yet)
+  - [ ] Keycloak → `identity` ns (no deploy command yet)
+- [ ] Configure Vault `kubernetes-app` auth mount for Ubuntu app cluster
 - [ ] ESO deploy on App cluster (remote Vault addr: `https://<mac-ip>:8200`)
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 
@@ -111,3 +119,6 @@ Write articles as milestones are reached. Each post builds on the last.
 | `deploy_vault` ignores `VAULT_NS` env var | FIXED | 2026-03-02: `ns` in `deploy_vault` now initializes from `${VAULT_NS:-$VAULT_NS_DEFAULT}` (commit `4c1a407`). |
 | `_cleanup_cert_rotation_test` uses out-of-scope `jenkins_ns` | FIXED | 2026-03-02: `_cleanup_cert_rotation_test` now references `${JENKINS_NAMESPACE:-cicd}` directly so the EXIT trap no longer errors under `set -u`. |
 | `deploy_eso` remote SecretStore uses wrong namespace | FIXED | 2026-03-02: `_eso_configure_remote_vault` now receives `${ns}` when no override is set; verified via `bats scripts/tests/plugins/eso.bats`. |
+| `CLUSTER_NAME=automation` env var ignored during `deploy_cluster` | OPEN | 2026-03-01: Cluster created as `k3d-cluster` instead of `automation`. See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
+| `jenkins-home-pv.yaml.tmpl` has `namespace: jenkins` hardcoded | OPEN | 2026-03-01: P2 — blocks `deploy_jenkins --namespace cicd`. See `docs/issues/2026-03-01-jenkins-pv-template-hardcoded-namespace.md`. |
+| `deploy_jenkins` ignores `JENKINS_NAMESPACE` env var | OPEN | 2026-03-01: P3 — line 1281 defaults to `jenkins` literal; use `--namespace cicd` flag instead. See `docs/issues/2026-03-01-deploy-jenkins-ignores-jenkins-namespace-env-var.md`. |


### PR DESCRIPTION
## Summary

Three bugs found during infra cluster rebuild after v0.3.0 merge:

- **P3**: `CLUSTER_NAME` env var ignored by `deploy_cluster` — cluster created as `k3d-cluster` instead of `automation`
- **P2**: `jenkins-home-pv.yaml.tmpl` has `namespace: jenkins` hardcoded — blocks `deploy_jenkins --namespace cicd`
- **P3**: `deploy_jenkins` ignores `JENKINS_NAMESPACE` env var (line 1281 defaults to `jenkins` literal)

## Files

- `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md` — P3 triaged
- `docs/issues/2026-03-01-jenkins-pv-template-hardcoded-namespace.md` — P2 triaged
- `docs/issues/2026-03-01-deploy-jenkins-ignores-jenkins-namespace-env-var.md` — P3 triaged
- `memory-bank/activeContext.md` — updated cluster state (post-merge)
- `memory-bank/progress.md` — rebuild progress, known bugs table

## Test plan

- [ ] Docs only — no code changes, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)