### PR TITLE
v0.6.3: Refactoring & Digital Auditor

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+# GitHub Copilot Instructions — k3d-manager
+
+k3d-manager is a modular Bash utility for managing local Kubernetes development clusters.
+Use the rules below to shape all code suggestions and PR reviews.
+
+---
+
+## Architecture
+
+- **Entry point**: `scripts/k3d-manager` — dispatcher with lazy plugin loading.
+- **Core libraries**: `scripts/lib/system.sh`, `scripts/lib/core.sh`, `scripts/lib/agent_rigor.sh`.
+- **Plugins**: `scripts/plugins/` — sourced on demand, no side effects at source time.
+- **Privilege escalation**: always via `_run_command --prefer-sudo` or `--require-sudo` — never bare `sudo`.
+- **OS detection**: always via `_detect_platform` — never inline `_is_mac`/`_is_debian_family` dispatch chains.
+- **Secret backends**: interface in `scripts/lib/secret_backends/` — Vault is complete, others stubbed.
+- **Cluster providers**: `scripts/lib/providers/` — `k3d`, `orbstack`, `k3s`.
+
+---
+
+## Review Focus
+
+### Shell Injection (OWASP A03)
+- All variable expansions in command arguments must be double-quoted: `"$var"`, not `$var`.
+- Never pass user-supplied or external input to `eval`.
+- Use `--` to separate options from arguments where arguments may contain hyphens.
+- Variables expanded via `envsubst` in `*.yaml.tmpl` files must not contain shell metacharacters.
+
+### Privilege Escalation
+- Bare `sudo` calls in production code are a bug — all privilege escalation must go through `_run_command`.
+- `_run_command --prefer-sudo` for operations that may succeed without sudo.
+- `_run_command --require-sudo` for operations that always need root.
+- Flag any multi-attempt permission cascades (trying the same operation 2+ times with escalating privilege).
+
+### Platform Detection
+- `_detect_platform` is the single source of truth for OS detection in `core.sh`.
+- Flag inline dispatch chains (`if _is_mac; elif _is_debian_family; elif ...`) with more than 2 branches — these should route through `_detect_platform`.
+- `linux` returned by `_detect_platform` means an unsupported generic Linux — do not route it into Debian or RedHat install paths.
+
+### Secret Hygiene (OWASP A02)
+- Vault tokens and passwords must never appear in `kubectl exec` command strings — they would be visible in `/proc/*/cmdline` and logs.
+- New sensitive CLI flags (e.g. `--token`, `--password`, `--secret`) must be registered in `_args_have_sensitive_flag` in `system.sh`.
+- No hardcoded credentials, tokens, or IP addresses in any file.
+- Test credentials (`alice/password`, etc.) are dev-only — flag if they appear outside test files.
+
+### Least Privilege (OWASP A01)
+- New Vault policies must grant only the minimum required paths (`read` unless `write` is explicitly needed).
+- New Kubernetes ServiceAccounts must not use `cluster-admin` — use namespace-scoped Role + RoleBinding.
+- Every new deployed service must use its own namespace — never `default`.
+
+### Cryptographic Failures (OWASP A02)
+- `insecureSkipVerify: true` and `TRUST_ALL_CERTIFICATES` are dev-only — flag if introduced in production paths.
+- Vault PKI leaf cert TTL must stay ≤720h — flag increases without justification.
+- Never add `--insecure` or `-k` to scripts that may run against production endpoints.
+
+### Supply Chain (OWASP A08)
+- GitHub Actions steps must pin to a version tag (`@v4`) — never `@main` or `@latest`.
+- Container image references in `*.yaml.tmpl` must use a pinned tag, not `latest`.
+
+### Idempotency
+- Every public function must be safe to run more than once.
+- "Resource already exists" → skip, not error.
+- "Helm release already deployed" → upgrade, not re-install.
+
+---
+
+## Skip / Do Not Flag
+
+- Pre-existing `shellcheck` warnings (SC2164 `pushd`/`popd`, etc.) in lines that were **not changed** by the PR.
+- `_is_mac` / `_is_wsl` guards used as simple feature-skip (1–2 branch guards) — these are legitimate, not bloat.
+- `AD_TLS_CONFIG=TRUST_ALL_CERTIFICATES` and `insecureSkipVerify: true` in existing dev config files — already documented as dev-only.
+- Test stubs and helper overrides in `scripts/tests/` — these intentionally override production functions.
+- `set -euo pipefail` absence in sourced library files (`scripts/lib/`) — these are sourced, not executed directly.
+
+---
+
+## Code Style
+- Public functions: no leading underscore.
+- Private/helper functions: prefix with `_`.
+- All new bash scripts must have `set -euo pipefail`.
+- LF line endings only — no CRLF.
+- No inline comments unless logic is non-obvious.

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,26 @@
 # Changes - k3d-manager
 
+## v0.6.3 — Refactoring & Digital Auditor — dated 2026-03-06
+
+### Refactoring
+- **Permission cascade elimination**: Collapsed 7 multi-attempt sudo escalation patterns across `core.sh` into single `_run_command --prefer-sudo` calls (`_ensure_path_exists`, `_k3s_stage_file`, `_install_k3s`, `_start_k3s_service`, `_install_docker`, `_create_nfs_share`, `deploy_cluster`).
+- **`_detect_platform` helper**: New single source of truth for OS detection in `system.sh` — returns `mac`, `wsl`, `debian`, `redhat`, or `linux`. Replaces scattered inline `_is_mac`/`_is_debian_family` dispatch chains in `core.sh`.
+- **`_create_nfs_share_mac` extracted**: Relocated from `core.sh` to `system.sh` with quoting fixes (`"$HOME/k3d-nfs"`). `core.sh` now delegates via a guarded wrapper.
+- **`_run_command` TTY flakiness fixed**: Removed `auto_interactive` block — `[[ -t 0 ]]` TTY detection caused CI vs local behaviour divergence. Privilege escalation now determined solely by flags (`--prefer-sudo`, `--require-sudo`).
+
+### Added
+- **`_agent_lint`** (`scripts/lib/agent_rigor.sh`): Copilot-backed architectural linter. Gated on `K3DM_ENABLE_AI=1`. Reads rules from `scripts/etc/agent/lint-rules.md` and reviews staged `.sh` files for violations before commit.
+- **`_agent_audit`** (`scripts/lib/agent_rigor.sh`): Pure-bash post-implementation rigor check. Detects test weakening (removed assertions, decreased `@test` count), excessive `if`-density per function, and runs `shellcheck` on changed files.
+- **Agent lint rules** (`scripts/etc/agent/lint-rules.md`): 5 architectural rules enforced by `_agent_lint` — no permission cascades, centralised platform detection, secret hygiene, namespace isolation, prompt scope.
+- **BATS suite** (`scripts/tests/lib/agent_rigor.bats`): Tests for `_agent_checkpoint`, `_agent_lint`, and `_agent_audit`.
+
+### Verification
+- BATS suite: 124/124 passing (1 test removed — sudo-retry behaviour intentionally eliminated by permission cascade de-bloat).
+- Full infra cluster teardown/rebuild verified on OrbStack (macOS ARM64): Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak all healthy.
+- Individual smoke tests passed: `test_vault`, `test_eso`, `test_istio`.
+
+---
+
 ## v0.6.2 — Copilot CLI & Agent Rigor — dated 2026-03-06
 
 ### Added

--- a/docs/plans/v0.6.3-codex-install-k3s-bats-fix.md
+++ b/docs/plans/v0.6.3-codex-install-k3s-bats-fix.md
@@ -1,0 +1,119 @@
+# v0.6.3 — Codex Task: Fix install_k3s.bats Assertion Regressions
+
+## Context
+
+Codex Phase 2 de-bloated permission cascade patterns in `core.sh`. Three tests in
+`scripts/tests/core/install_k3s.bats` now fail because they assert the old multi-path
+sudo-retry behavior that was intentionally removed. All fixes are test-only — no
+production code changes.
+
+---
+
+## Critical Rules
+
+1. **Do not modify any production code** — `scripts/lib/core.sh`, `scripts/lib/system.sh`,
+   or any other non-test file.
+2. **Do not update `memory-bank/`.** Claude owns memory-bank writes.
+3. **Do not commit.** Claude reviews and commits.
+4. **Run `shellcheck scripts/tests/core/install_k3s.bats` after changes and report output.**
+5. **Report each fix individually:** fix letter, file, line numbers changed, what changed.
+
+---
+
+## Fix A — Remove `_ensure_path_exists retries with sudo when passwordless fails`
+
+**File:** `scripts/tests/core/install_k3s.bats`
+
+**Problem:** The test stubs `sudo()` and expects it to be called after `_run_command`
+fails. After de-bloat, `_ensure_path_exists` has a single `_run_command --prefer-sudo`
+call — when it fails, the function calls `_err` immediately. There is no sudo retry path.
+The behavior this test asserted was the cascade anti-pattern that was intentionally removed.
+
+**Fix:** Delete this entire `@test` block.
+
+The surrounding tests (`_ensure_path_exists uses sudo when available` and
+`_ensure_path_exists fails when sudo unavailable`) are sufficient coverage for the
+refactored function.
+
+---
+
+## Fix B — Update expected string in `_start_k3s_service falls back to manual start without systemd`
+
+**File:** `scripts/tests/core/install_k3s.bats`
+
+**Problem:** The `expected` variable includes a `sudo ` prefix:
+
+```bash
+local expected="sudo sh -c nohup k3s server ..."
+```
+
+After refactoring, `_start_k3s_service` calls `_run_command --require-sudo -- sh -c "$start_cmd"`.
+The `_run_command` stub strips all flags and logs the remaining args — it does NOT prepend
+`sudo`. So the logged line is `sh -c nohup k3s server ...` (no `sudo` prefix).
+
+**Fix:** Remove `sudo ` from the beginning of the `expected` string. The line should be:
+
+```bash
+local expected="sh -c nohup k3s server --write-kubeconfig-mode 0644 --config ${K3S_CONFIG_FILE} >> ${K3S_DATA_DIR}/k3s-no-systemd.log 2>&1 &"
+```
+
+---
+
+## Fix C — Fix `_install_k3s renders config and manifest` config file assertion
+
+**File:** `scripts/tests/core/install_k3s.bats`
+
+**Problem:** The test asserts `[ -f "$K3S_CONFIG_FILE" ]` after calling `_install_k3s`.
+After de-bloat, `_k3s_stage_file` routes the file copy through
+`_run_command --prefer-sudo -- install -m "$mode" "$src" "$dest"`. The `_run_command`
+stub is a no-op — it logs the command but does not execute it — so the destination file
+is never written to disk.
+
+**Fix:** Inside the `_install_k3s renders config and manifest` `@test` block, replace the
+local `_run_command` stub with one that, when called with `install -m` arguments, actually
+performs the copy. The stub already handles flag stripping; add a branch after the flag
+loop that detects `install -m` and calls `command install` to perform the real copy:
+
+```bash
+_run_command() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-exit|--soft|--quiet|--prefer-sudo|--require-sudo) shift ;;
+      --probe) shift 2 ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+  echo "$*" >> "$RUN_LOG"
+  # Perform real install/copy so rendered files land on disk for assertions
+  if [[ "$1" == "install" && "$2" == "-m" ]]; then
+    command install -m "$3" "$4" "$5"
+  elif [[ "$1" == "cp" ]]; then
+    command cp "$2" "$3"
+  fi
+  return 0
+}
+export -f _run_command
+```
+
+This stub is local to the test and does not affect other tests.
+
+---
+
+## Verification
+
+After all three fixes, run:
+
+```bash
+./scripts/k3d-manager test install_k3s 2>&1
+```
+
+All tests in the suite must pass. Report the full TAP output.
+
+Also run:
+
+```bash
+./scripts/k3d-manager test all 2>&1
+```
+
+Report total pass count (expected: same or higher than prior baseline of 125).

--- a/docs/plans/v0.6.3-codex-run-command-fix.md
+++ b/docs/plans/v0.6.3-codex-run-command-fix.md
@@ -1,0 +1,94 @@
+# v0.6.3 — Codex Fix Task: Remove `auto_interactive` from `_run_command`
+
+## Context
+
+`_run_command` in `scripts/lib/system.sh` contains a TTY-detection block that
+silently changes behavior depending on whether stdin is a terminal:
+
+```bash
+local auto_interactive=0
+if [[ -t 0 ]] && [[ "${K3DMGR_NONINTERACTIVE:-0}" != "1" ]]; then
+  auto_interactive=1
+fi
+...
+if (( prefer_sudo )) && (( auto_interactive )) && (( interactive_sudo == 0 )); then
+  interactive_sudo=1
+fi
+```
+
+When `auto_interactive=1` (local terminal), `sudo_flags` becomes empty and sudo is
+called without `-n`. The test stubs in `run_command.bats` always `shift` past `-n`,
+so they break when called without it. Result: tests 62 and 63 pass in CI (no TTY)
+but fail locally (TTY present).
+
+**Decision:** Remove `auto_interactive` entirely. Interactive sudo remains available
+via the explicit `--interactive-sudo` flag. `_run_command` must be deterministic
+regardless of environment.
+
+---
+
+## Critical Rules
+
+1. **Fix only what is listed.** Do not refactor surrounding logic.
+2. **Do not modify test files (`*.bats`).** Claude owns those.
+3. **Do not modify `memory-bank/`.** Claude owns memory-bank writes.
+4. **Do not commit.** Claude reviews and commits.
+5. **Run shellcheck on `scripts/lib/system.sh` after the fix and report output.**
+6. **Audit call sites** — grep for `_run_command --prefer-sudo` across all `.sh` files
+   and confirm none rely on implicit interactive sudo promotion. Report findings.
+
+---
+
+## Fix — Remove `auto_interactive` block from `_run_command`
+
+**File:** `scripts/lib/system.sh`
+
+### Step 1 — Remove the TTY-detection block
+
+```
+Before (after `local -a probe_args=()`):
+
+  # Auto-detect interactive mode: use interactive sudo if in a TTY and not explicitly disabled
+  # Can be overridden with K3DMGR_NONINTERACTIVE=1 environment variable
+  local auto_interactive=0
+  if [[ -t 0 ]] && [[ "${K3DMGR_NONINTERACTIVE:-0}" != "1" ]]; then
+    auto_interactive=1
+  fi
+
+After:
+  (remove entirely — 5 lines gone)
+```
+
+### Step 2 — Remove the auto-upgrade block
+
+```
+Before (after the `while` loop):
+
+  # If --prefer-sudo is set and we're in auto-interactive mode, enable interactive sudo
+  if (( prefer_sudo )) && (( auto_interactive )) && (( interactive_sudo == 0 )); then
+    interactive_sudo=1
+  fi
+
+After:
+  (remove entirely — 4 lines gone)
+```
+
+### Step 3 — Audit call sites
+
+Run:
+```bash
+grep -rn "_run_command --prefer-sudo\|_run_command --interactive-sudo" scripts/
+```
+
+Report every match. Flag any caller that appears to need interactive sudo
+(e.g., install operations that prompt for a password). Do not change them —
+just report.
+
+---
+
+## Verification
+
+1. `shellcheck scripts/lib/system.sh` — no new findings
+2. Call-site audit report (see Step 3)
+3. Confirm `auto_interactive` no longer appears in `scripts/lib/system.sh`
+4. Confirm `_run_command` still has `--interactive-sudo` as an explicit opt-in

--- a/docs/plans/v0.6.3-gemini-bats-verify.md
+++ b/docs/plans/v0.6.3-gemini-bats-verify.md
@@ -1,0 +1,65 @@
+# v0.6.3 — Gemini Verification Task: Full BATS Suite
+
+## Context
+
+Codex removed the `auto_interactive` TTY-detection block from `_run_command` in
+`scripts/lib/system.sh` (commit `e9b3b89`). This was causing tests 62 and 63 in
+`run_command.bats` to fail locally (passing in CI only because CI has no TTY).
+
+Claude reviewed and approved the fix. Your job is to run the full BATS suite
+**locally** (not in CI) and confirm:
+- Tests 62 and 63 now pass
+- No regressions elsewhere (all previously passing tests still pass)
+
+---
+
+## Critical Rules
+
+1. **Do not modify any production code (`*.sh`).**
+2. **Do not modify any test files (`*.bats`).**
+3. **Do not modify `memory-bank/`.** Claude owns memory-bank writes.
+4. **Do not commit.** Claude reviews and commits.
+5. **Report pass/fail counts, not just "all passed."** List any failures with
+   the full BATS output for that test.
+
+---
+
+## Task
+
+### Step 1 — Run the full BATS suite locally
+
+```bash
+./scripts/k3d-manager test all 2>&1
+```
+
+Or directly:
+
+```bash
+bats scripts/tests/lib scripts/tests/core scripts/tests/plugins 2>&1
+```
+
+### Step 2 — Confirm tests 62 and 63 specifically
+
+```bash
+bats scripts/tests/lib/run_command.bats --tap 2>&1
+```
+
+All 5 tests in `run_command.bats` must pass.
+
+---
+
+## Verification Report (required)
+
+Report in this format:
+
+```
+Full suite: X/Y passing
+run_command.bats: 5/5 passing
+
+Failures (if any):
+  not ok N  <test name>
+  # <reason>
+```
+
+If any test fails outside `run_command.bats`, report the full BATS output for
+that test and the file it is in. Do not attempt to fix — just report.

--- a/docs/plans/v0.6.3-gemini-cluster-rebuild.md
+++ b/docs/plans/v0.6.3-gemini-cluster-rebuild.md
@@ -1,0 +1,101 @@
+# v0.6.3 — Gemini Task: Full Cluster Teardown & Rebuild
+
+## Context
+
+The `auto_interactive` TTY-detection block was removed from `_run_command` in this
+branch. Before proceeding with further refactor work, we need a full cluster teardown
+and rebuild to verify that all `--prefer-sudo` call sites work correctly without
+implicit interactive sudo promotion.
+
+This is the end-to-end gate for v0.6.3 Phase 1.
+
+---
+
+## Critical Rules
+
+1. **Do not modify any production code or test files.**
+2. **Do not modify `memory-bank/`.** Claude owns memory-bank writes.
+3. **Do not commit.** Claude reviews and commits.
+4. **If any step prompts for a sudo password, stop and hand back to the owner.**
+   Do not attempt to work around it or skip the step.
+5. **Report each phase individually** with pass/fail and any error output.
+
+---
+
+## Task Sequence
+
+### Phase 1 — Destroy existing cluster
+
+```bash
+./scripts/k3d-manager destroy_cluster
+```
+
+Expected: cluster torn down cleanly, no errors.
+
+---
+
+### Phase 2 — Create cluster
+
+```bash
+./scripts/k3d-manager create_cluster
+```
+
+Expected: cluster created, kubeconfig set up.
+
+---
+
+### Phase 3 — Deploy full stack
+
+```bash
+./scripts/k3d-manager deploy_cluster
+```
+
+Expected: Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak all deployed and healthy.
+
+---
+
+### Phase 4 — Smoke tests
+
+Run each in sequence and report pass/fail:
+
+```bash
+./scripts/k3d-manager test_vault
+./scripts/k3d-manager test_eso
+./scripts/k3d-manager test_istio
+```
+
+---
+
+### Phase 5 — Full BATS suite
+
+```bash
+./scripts/k3d-manager test all 2>&1
+```
+
+Report total pass/fail count. Include full output for any failing test.
+
+---
+
+## Verification Report (required)
+
+Report in this format:
+
+```
+Phase 1 — destroy_cluster:  PASS / FAIL
+Phase 2 — create_cluster:   PASS / FAIL
+Phase 3 — deploy_cluster:   PASS / FAIL
+Phase 4 — smoke tests:
+  test_vault:  PASS / FAIL
+  test_eso:    PASS / FAIL
+  test_istio:  PASS / FAIL
+Phase 5 — BATS suite: X/Y passing
+
+Failures (if any):
+  <phase>: <error output>
+```
+
+If a sudo password prompt appears at any point, stop immediately and report:
+```
+SUDO PROMPT at: <phase> — <command that triggered it>
+Handing back to owner.
+```

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,10 +17,43 @@ Plans:
 
 Key objectives:
 1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex) ✅ done 2026-03-06
-2. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex)
-3. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex)
-4. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
-5. Claude: review all diffs, run full BATS suite locally, commit, open PR
+2. **Phase 1 Verification** — BATS 125/125 PASS, E2E Cluster rebuild success (Gemini) ✅ done 2026-03-06
+3. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex)
+4. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex)
+5. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅ done 2026-03-06
+6. Claude: review all diffs, run full BATS suite locally, commit, open PR
+
+---
+
+## Gemini Pending Actions (must complete before Claude commits)
+
+Three gaps identified by Claude review of Phase 1 verification. Fix all three and
+report results. Do not commit. Do not modify memory-bank.
+
+**Action 1 — Confirm run_command.bats tests 1 and 2 pass locally**
+
+Run:
+```bash
+bats scripts/tests/lib/run_command.bats --tap
+```
+
+Report the full TAP output. Tests 1 (`--prefer-sudo uses sudo when available`) and
+2 (`--prefer-sudo falls back when sudo unavailable`) must show `ok`.
+
+**Action 2 — Report smoke test results individually**
+
+Run each and report PASS/FAIL explicitly:
+```bash
+./scripts/k3d-manager test_vault
+./scripts/k3d-manager test_eso
+./scripts/k3d-manager test_istio
+```
+
+**Action 3 — Confirm agent_rigor.bats working tree change is complete**
+
+The improved `command()` stub fix is in the working tree but not committed.
+Verify `git diff scripts/tests/lib/agent_rigor.bats` shows only the stub
+improvement (no other changes). Report the diff output. Claude will commit it.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -27,58 +27,9 @@ Key objectives:
 
 ---
 
-## Codex Next Task — Fix C only (install_k3s.bats)
+## Status — v0.6.3 COMPLETE
 
-Fix A and Fix B were completed correctly. Fix C was applied to the wrong test.
-
-**What went wrong:** The `install`/`cp` execution branch was added to the
-`_start_k3s_service` test's `_run_command` stub. It should be in the
-`_install_k3s renders config and manifest` test, which has no local stub — it uses
-the global `stub_run_command` from `setup()`, which is a no-op.
-
-**Fix C (corrected):**
-
-File: `scripts/tests/core/install_k3s.bats`
-Test: `@test "_install_k3s renders config and manifest"` (currently line 149)
-
-Add a local `_run_command` stub inside this test, before the `_install_k3s mycluster`
-call, that executes real filesystem operations for `mkdir`, `install -m`, and `cp`:
-
-```bash
-_run_command() {
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --no-exit|--soft|--quiet|--prefer-sudo|--require-sudo) shift ;;
-      --probe) shift 2 ;;
-      --) shift; break ;;
-      *) break ;;
-    esac
-  done
-  echo "$*" >> "$RUN_LOG"
-  if [[ "$1" == "mkdir" && "$2" == "-p" ]]; then
-    command mkdir -p "$3"
-  elif [[ "$1" == "install" && "$2" == "-m" ]]; then
-    command install -m "$3" "$4" "$5"
-  elif [[ "$1" == "cp" ]]; then
-    command cp "$2" "$3"
-  fi
-  return 0
-}
-export -f _run_command
-```
-
-Also restore `stub_run_command` at the end of the test (after the assertions) to avoid
-leaking the local stub into subsequent tests.
-
-Also remove the dead `install`/`cp` branch that was incorrectly added to the
-`_start_k3s_service` test stub (lines 48–52 in current file) — it serves no purpose
-there and is misleading.
-
-**Rules:**
-- Test file only — no production code changes.
-- Run `shellcheck scripts/tests/core/install_k3s.bats` and report output.
-- Run `./scripts/k3d-manager test install_k3s 2>&1` and report full TAP output.
-- Commit your changes and update memory-bank to report completion.
+All tasks done. BATS 124/124 passing. PR open — see GitHub for review status.
 
 ---
 
@@ -150,7 +101,7 @@ Agent reads + acts
 |---|---|---|
 | v0.1.0–v0.6.1 | released | See CHANGE.md |
 | v0.6.2 | **released** | AI Tooling + Agent Rigor + Security hardening |
-| v0.6.3 | **active** | Refactoring (De-bloat) + `rigor-cli` Integration |
+| v0.6.3 | **PR open** | Refactoring (De-bloat) + Digital Auditor |
 | v0.6.4 | planned | Linux k3s validation gate + lib-foundation extraction via git subtree |
 | v0.7.0 | planned | Keycloak provider + App Cluster deployment |
 | v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,56 +19,47 @@ Key objectives:
 1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex) ✅ done 2026-03-06
 2. **Phase 1 Verification** — BATS 125/125 PASS, E2E Cluster rebuild success (Gemini) ✅ done 2026-03-06
 3. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex) ✅ done 2026-03-06
-4. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex) ✅ done 2026-03-06
+4. Implement `_agent_lint` + `_agent_audit` in `agent_rigor.sh` (Codex) ✅ done 2026-03-06 — Claude reviewed: PASS
 5. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅ done 2026-03-06
-6. Claude: review all diffs, run full BATS suite locally, commit, open PR
+6. **Phase 2 Verification** — teardown/rebuild gate (Gemini) ⏳ active
+7. Claude: final BATS run, commit, open PR
 
 ---
 
-## Codex Next Tasks (v0.6.3 Phase 2)
+## Gemini Next Task — Phase 2 Rebuild Gate
 
-Phase 1 complete and independently verified by Claude: **125/125 BATS passing locally**,
-`run_command.bats` tests 1 & 2 confirmed passing, smoke tests PASS.
+Codex Phase 2 delivered and reviewed by Claude (PASS). The refactored functions
+(`_ensure_path_exists`, `_k3s_start_server`, `_k3s_stage_file`, `_install_k3s`,
+`_install_docker`, `_create_nfs_share`, `deploy_cluster` platform detection) all
+run during a live cluster lifecycle. A full teardown/rebuild is required to validate
+them before PR.
 
-Codex proceeds with Phase 2. Plan: `docs/plans/v0.6.3-refactor-and-audit.md`.
+Task spec: `docs/plans/v0.6.3-gemini-cluster-rebuild.md` — same procedure as Phase 1.
 
-### Standing Rules (apply to every task)
-- Report each fix individually with file and line numbers changed.
-- Run `shellcheck` on every touched file and report output.
-- Do not modify test files (`*.bats`) — Gemini owns those.
+**Run all 5 phases:**
+1. `./scripts/k3d-manager destroy_cluster`
+2. `./scripts/k3d-manager create_cluster`
+3. `./scripts/k3d-manager deploy_cluster`
+4. `./scripts/k3d-manager test_vault && ./scripts/k3d-manager test_eso && ./scripts/k3d-manager test_istio`
+5. `./scripts/k3d-manager test all`
+
+**Report format (required):**
+```
+Phase 1 — destroy_cluster:  PASS / FAIL
+Phase 2 — create_cluster:   PASS / FAIL
+Phase 3 — deploy_cluster:   PASS / FAIL
+Phase 4 — smoke tests:
+  test_vault:  PASS / FAIL
+  test_eso:    PASS / FAIL
+  test_istio:  PASS / FAIL
+Phase 5 — BATS suite: X/Y passing
+```
+
+**Rules:**
+- Do not modify any production code or test files.
 - Do not modify `memory-bank/` — Claude owns memory-bank writes.
 - Do not commit — Claude reviews and commits.
-- STOP after all listed fixes. Do not proceed to the next task without Claude go-ahead.
-
-### Task 1 — De-bloat `scripts/lib/core.sh` (permission cascade anti-patterns)
-
-Targets (see plan for full before/after):
-- `_ensure_path_exists` — collapse 4-attempt mkdir cascade to single `_run_command --prefer-sudo`
-- `_k3s_start_server` — collapse 4-attempt sh cascade to 2-path (root vs non-root)
-- `_setup_kubeconfig` — collapse dual permission checks to single `_run_command --prefer-sudo` per op
-- `_install_k3s` file ops — collapse dual writable-check pattern to direct `_run_command --prefer-sudo`
-
-After all targets done: `shellcheck scripts/lib/core.sh` — report output.
-
-### Task 2 — De-bloat `scripts/lib/system.sh` (OS dispatch consolidation)
-
-Targets (see plan for full before/after):
-- Add `_detect_platform` helper (returns `mac`/`wsl`/`debian`/`redhat`/`linux` or error)
-- `_install_docker` — replace 4-branch inline switch with `_detect_platform` dispatch
-- `deploy_cluster` platform detection — replace 5-branch cascade with `_detect_platform`
-- `_create_nfs_share` — extract `_create_nfs_share_mac` to system.sh, guard in core.sh
-
-After all targets done: `shellcheck scripts/lib/system.sh` — report output.
-
-### Task 3 — Implement `_agent_lint` in `scripts/lib/agent_rigor.sh`
-
-See plan Component 2 for full spec. Key rules enforced:
-- No permission cascades (>1 sudo escalation path for same op)
-- OS dispatch via `_detect_platform` (not raw inline chains)
-- Secret hygiene (no tokens in kubectl exec args)
-- Namespace isolation (no `kubectl apply` without `-n`)
-
-After implementation: `shellcheck scripts/lib/agent_rigor.sh` — report output.
+- Report each phase individually with full error output on any failure.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -26,40 +26,24 @@ Key objectives:
 
 ---
 
-## Gemini Next Task — Phase 2 Rebuild Gate
+## Codex Next Task — Fix install_k3s.bats Regressions
 
-Codex Phase 2 delivered and reviewed by Claude (PASS). The refactored functions
-(`_ensure_path_exists`, `_k3s_start_server`, `_k3s_stage_file`, `_install_k3s`,
-`_install_docker`, `_create_nfs_share`, `deploy_cluster` platform detection) all
-run during a live cluster lifecycle. A full teardown/rebuild is required to validate
-them before PR.
+Phase 2 rebuild PASS. Gemini found 3 test regressions in `install_k3s.bats` caused by
+the de-bloat refactoring. All fixes are test-only.
 
-Task spec: `docs/plans/v0.6.3-gemini-cluster-rebuild.md` — same procedure as Phase 1.
+Task spec: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`
 
-**Run all 5 phases:**
-1. `./scripts/k3d-manager destroy_cluster`
-2. `./scripts/k3d-manager create_cluster`
-3. `./scripts/k3d-manager deploy_cluster`
-4. `./scripts/k3d-manager test_vault && ./scripts/k3d-manager test_eso && ./scripts/k3d-manager test_istio`
-5. `./scripts/k3d-manager test all`
+**Fixes:**
+- **Fix A**: Delete `@test "_ensure_path_exists retries with sudo when passwordless fails"` — sudo-retry behavior was removed in de-bloat.
+- **Fix B**: Remove `sudo ` prefix from `expected` string in `_start_k3s_service` test — stub logs `sh -c ...` not `sudo sh -c ...`.
+- **Fix C**: In `_install_k3s renders config and manifest`, update local `_run_command` stub to actually execute `command install -m` / `command cp` so the rendered config file lands on disk for `[ -f ]` assertions.
 
-**Report format (required):**
-```
-Phase 1 — destroy_cluster:  PASS / FAIL
-Phase 2 — create_cluster:   PASS / FAIL
-Phase 3 — deploy_cluster:   PASS / FAIL
-Phase 4 — smoke tests:
-  test_vault:  PASS / FAIL
-  test_eso:    PASS / FAIL
-  test_istio:  PASS / FAIL
-Phase 5 — BATS suite: X/Y passing
-```
-
-**Rules:**
-- Do not modify any production code or test files.
-- Do not modify `memory-bank/` — Claude owns memory-bank writes.
-- Do not commit — Claude reviews and commits.
-- Report each phase individually with full error output on any failure.
+**Rules (as always):**
+- Test files only — no production code changes.
+- Do not update `memory-bank/`. Claude owns all memory-bank writes.
+- Do not commit. Claude reviews and commits.
+- Run `shellcheck` on the changed file and report output.
+- Report each fix individually with file + line numbers.
 
 ---
 
@@ -116,7 +100,7 @@ Phase 5 — BATS suite: X/Y passing
 | v0.1.0–v0.6.1 | released | See CHANGE.md |
 | v0.6.2 | **released** | AI Tooling + Agent Rigor + Security hardening |
 | v0.6.3 | **active** | Refactoring (De-bloat) + `rigor-cli` Integration |
-| v0.6.4 | planned | lib-foundation extraction via git subtree |
+| v0.6.4 | planned | Linux k3s validation gate + lib-foundation extraction via git subtree |
 | v0.7.0 | planned | Keycloak provider + App Cluster deployment |
 | v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
 | v1.0.0 | vision | Reassess after v0.7.0; see `docs/plans/roadmap-v1.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -22,28 +22,63 @@ Key objectives:
 4. Implement `_agent_lint` + `_agent_audit` in `agent_rigor.sh` (Codex) ✅ done 2026-03-06 — Claude reviewed: PASS
 5. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅ done 2026-03-06
 6. **Phase 2 Verification** — teardown/rebuild gate (Gemini) ⏳ active
-7. Claude: final BATS run, commit, open PR
+7. **Codex install_k3s.bats fix** — execute manifest staging stub (plan: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`) ✅ done 2026-03-06
+8. Claude: final BATS run, commit, open PR
 
 ---
 
-## Codex Next Task — Fix install_k3s.bats Regressions
+## Codex Next Task — Fix C only (install_k3s.bats)
 
-Phase 2 rebuild PASS. Gemini found 3 test regressions in `install_k3s.bats` caused by
-the de-bloat refactoring. All fixes are test-only.
+Fix A and Fix B were completed correctly. Fix C was applied to the wrong test.
 
-Task spec: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`
+**What went wrong:** The `install`/`cp` execution branch was added to the
+`_start_k3s_service` test's `_run_command` stub. It should be in the
+`_install_k3s renders config and manifest` test, which has no local stub — it uses
+the global `stub_run_command` from `setup()`, which is a no-op.
 
-**Fixes:**
-- **Fix A**: Delete `@test "_ensure_path_exists retries with sudo when passwordless fails"` — sudo-retry behavior was removed in de-bloat.
-- **Fix B**: Remove `sudo ` prefix from `expected` string in `_start_k3s_service` test — stub logs `sh -c ...` not `sudo sh -c ...`.
-- **Fix C**: In `_install_k3s renders config and manifest`, update local `_run_command` stub to actually execute `command install -m` / `command cp` so the rendered config file lands on disk for `[ -f ]` assertions.
+**Fix C (corrected):**
 
-**Rules (as always):**
-- Test files only — no production code changes.
-- Do not update `memory-bank/`. Claude owns all memory-bank writes.
-- Do not commit. Claude reviews and commits.
-- Run `shellcheck` on the changed file and report output.
-- Report each fix individually with file + line numbers.
+File: `scripts/tests/core/install_k3s.bats`
+Test: `@test "_install_k3s renders config and manifest"` (currently line 149)
+
+Add a local `_run_command` stub inside this test, before the `_install_k3s mycluster`
+call, that executes real filesystem operations for `mkdir`, `install -m`, and `cp`:
+
+```bash
+_run_command() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-exit|--soft|--quiet|--prefer-sudo|--require-sudo) shift ;;
+      --probe) shift 2 ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+  echo "$*" >> "$RUN_LOG"
+  if [[ "$1" == "mkdir" && "$2" == "-p" ]]; then
+    command mkdir -p "$3"
+  elif [[ "$1" == "install" && "$2" == "-m" ]]; then
+    command install -m "$3" "$4" "$5"
+  elif [[ "$1" == "cp" ]]; then
+    command cp "$2" "$3"
+  fi
+  return 0
+}
+export -f _run_command
+```
+
+Also restore `stub_run_command` at the end of the test (after the assertions) to avoid
+leaking the local stub into subsequent tests.
+
+Also remove the dead `install`/`cp` branch that was incorrectly added to the
+`_start_k3s_service` test stub (lines 48–52 in current file) — it serves no purpose
+there and is misleading.
+
+**Rules:**
+- Test file only — no production code changes.
+- Run `shellcheck scripts/tests/core/install_k3s.bats` and report output.
+- Run `./scripts/k3d-manager test install_k3s 2>&1` and report full TAP output.
+- Commit your changes and update memory-bank to report completion.
 
 ---
 
@@ -54,14 +89,30 @@ Task spec: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`
 3. **Audit Phase**: Verify no tests weakened after every fix cycle.
 4. **Simplification**: Refactor for minimal logic before final verification.
 
-## Codex Standing Instructions
+## Agent Workflow — Revised Protocol
 
+### Agent responsibilities (Codex / Gemini)
+- **Commit your own work** — self-commit is your sign-off; provides clear attribution in git history.
+- **Update memory-bank to report completion** — this is how you communicate back to Claude. Mark tasks done, note what changed, flag anything unexpected.
 - **Report each fix individually.** State: fix letter, file, line numbers, what changed.
-- **STOP means STOP.** Partial delivery with a complete claim is a protocol violation.
-- **Do not update memory-bank.** Claude owns all memory-bank writes.
-- **Do not commit.** Claude reviews and commits after verifying diffs match spec.
-- **Verification is mandatory.** Run `shellcheck` on every touched file and report output.
-- **No credentials in task specs.** Task specs and reports must never contain actual credential values, cluster addresses, kubeconfig paths, or tokens — reference env var names only (e.g. `$VAULT_ADDR`, not the actual URL). Live values stay on the owner's machine.
+- **Verification is mandatory.** Run `shellcheck` on every touched `.sh` file and report output.
+- **No credentials in task specs or reports.** Reference env var names only (`$VAULT_ADDR`, not the actual URL). Live values stay on the owner's machine.
+
+### Claude responsibilities
+- **Review every agent memory-bank write** — detect overclaiming, stale entries, missing items, inaccuracies before the next agent reads it.
+- **Write corrective/instructional content to memory-bank** — this is what agents act on next.
+- **Open PR when code is ready** — route PR review issues based on scope:
+  - Small/isolated fix → Claude fixes directly in the branch
+  - Logic or test fix → assign back to Codex via memory-bank
+  - Cluster verification needed → assign to Gemini via memory-bank
+
+### Memory-bank communication flow
+```
+Agent  → memory-bank   (report: task complete, what changed, what was unexpected)
+Claude reads           (review: detect gaps, inaccuracies, overclaiming)
+Claude → memory-bank   (instruct: corrections + next task spec)
+Agent reads + acts
+```
 
 ---
 
@@ -145,24 +196,31 @@ Task spec: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`
 
 ```
 Claude
-  -- monitors CI / reviews agent reports for accuracy
-  -- opens PR on owner go-ahead
-  -- owns all memory-bank writes
+  -- reviews all agent memory-bank writes before writing next task
+  -- opens PR on owner go-ahead; routes PR issues back to agents by scope
+  -- writes corrective/instructional content to memory-bank
 
-Gemini
-  -- SDET/Red-Team audits, BATS verification, Ubuntu SSH deployment
-  -- may write stale memory-bank — always verify after
+Gemini  (SDET + Red Team)
+  -- authors BATS unit tests and test_* integration tests
+  -- cluster verification: full teardown/rebuild, smoke tests
+  -- red team: adversarially tests existing security controls (bounded scope)
+  -- commits own work; updates memory-bank to report completion
 
-Codex
-  -- pure logic fixes, no cluster dependency
-  -- STOP at each verification gate
+Codex  (Production Code)
+  -- pure logic fixes and feature implementation, no cluster dependency
+  -- commits own work; updates memory-bank to report completion
+  -- fixes security vulnerabilities found by Gemini red team
 
 Owner
   -- approves and merges PRs
 ```
 
+**Red Team scope (Gemini):**
+- Test existing controls only: `_copilot_prompt_guard`, `_safe_path`, stdin injection, trace isolation
+- Try to bypass, leak credentials, or inject via proc/cmdline
+- Report findings to memory-bank as structured report — Claude routes fixes to Codex
+- Do NOT propose new attack surfaces or modify production code
+
 **Lessons learned:**
-- Gemini ignores hold instructions — use review as the gate
-- Gemini may write stale memory-bank content — verify after every update
-- Codex commit-on-failure is a known failure mode — write explicit STOP guardrails
+- Gemini may write stale memory-bank content — Claude reviews every update before writing next task
 - PR sub-branches from Copilot agent (e.g. `copilot/sub-pr-*`) may conflict with branch work — evaluate and close if our implementation is superior

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,44 +1,23 @@
 # Active Context – k3d-manager
 
-## Current Branch: `k3d-manager-v0.6.2` (as of 2026-03-06)
+## Current Branch: `k3d-manager-v0.6.3` (as of 2026-03-06)
 
-**v0.6.1 merged** — infra rebuild bug fixes integrated.
-**v0.6.2 in progress** — Copilot CLI integration + security hardening.
+**v0.6.2 SHIPPED** — tag `v0.6.2` pushed, PR #19 merged to `main`.
+**v0.6.3 active** — branch cut from `main`; plan at `docs/plans/v0.6.3-refactor-and-audit.md`.
 
 ---
 
 ## Current Focus
 
-**v0.6.2: Codex Fix Cycle → Gemini Phase 2 + 3**
+**v0.6.3: Refactoring & External Audit Integration**
 
-Codex implementation complete (2026-03-06). Gemini Phase 1 audit complete with 4 findings.
-Codex fix cycle complete (2026-03-06). Gemini Phase 2 and Phase 3 are the active gate.
+Plan: `docs/plans/v0.6.3-refactor-and-audit.md`
 
-**Active sequence:**
-1. ✅ Codex implementation (Batches 1–4)
-2. ✅ Gemini Phase 1 — audit findings filed: `docs/issues/2026-03-06-v0.6.2-sdet-audit-findings.md`
-3. ✅ **Codex fix cycle** — 4 Gemini findings resolved (task: `docs/plans/v0.6.2-codex-fix-task.md`)
-4. ✅ **Gemini Phase 2** — BATS 115/115 pass, shellcheck warning at system.sh:149 (pre-existing SC2145)
-5. ✅ **Gemini Phase 3** — RT-1/3/5/6 PASS, RT-3 PARTIAL; RT-2 FAIL (vault stdin), RT-4 FAIL (deny-tool)
-6. ✅ **Codex RT fix cycle** — RT-2 + RT-4 resolved (`docs/plans/v0.6.2-codex-rt-fix-task.md`)
-7. ✅ **Claude** — PR #19 opened, CI green, GitGuardian clean
-8. ✅ **Codex P1 fix cycle** — rc capture, empty PATH, sticky bit (`docs/plans/v0.6.2-codex-copilot-review-task.md`)
-9. ✅ **Codex re-review fix cycle** — fixes A–I implemented (see `docs/plans/v0.6.2-codex-copilot-review2-task.md`)
-10. ✅ **Gemini** — `safe_path.bats` created and aligned with production fixes — task: `docs/plans/v0.6.2-gemini-safe-path-tests.md`
-11. ✅ **Gemini** — All BATS suites aligned and verified (120/120 pass) — task: `docs/plans/v0.6.2-gemini-test-fix-task.md`
-12. ⏳ **Claude** — final review, merge PR
-
-**Phase 2 definition:** Run `shellcheck scripts/lib/system.sh scripts/etc/ldap/ldap-password-rotator.sh`
-and `./scripts/k3d-manager test all`. Report total/pass/fail counts. Confirm no regressions.
-**Codex status:** local shellcheck + targeted BATS suites completed; Gemini full `test all` already run.
-
-**Phase 3 definition:** Structured security audit — one PASS/FAIL/N/A with justification per check:
-- RT-1: PATH poisoning (`_safe_path` with world-writable + relative path + sticky bit)
-- RT-2: Secret exposure in process listing (`ldap-password-rotator.sh` stdin fix)
-- RT-3: Trace isolation for copilot CLI (`_run_command` + `_args_have_sensitive_flag`)
-- RT-4: Deny-tool guardrails completeness + placement
-- RT-5: AI gating bypass (`K3DM_ENABLE_AI` check + no direct copilot calls)
-- RT-6: Prompt injection surface (no credentials passed to copilot)
+Key objectives:
+1. De-bloat `system.sh` and `core.sh` (split oversized files, remove dead code)
+2. Implement `_agent_audit` (test-weakening detection)
+3. Integrate `rigor-cli` for external architectural linting
+4. BATS suite: `scripts/tests/lib/agent_rigor.bats`
 
 ---
 
@@ -46,19 +25,16 @@ and `./scripts/k3d-manager test all`. Report total/pass/fail counts. Confirm no 
 
 1. **Spec-First**: No code without a structured, approved implementation spec.
 2. **Checkpointing**: Git commit before every surgical operation.
-3. **AI-Powered Linting**: Use `copilot-cli` to verify architectural intent (e.g., "Prove the test ran," "Check for price injection") before allowing a commit.
-4. **Audit Phase**: Explicitly verify that no tests were weakened.
-5. **Simplification**: Refactor for minimal logic before final verification.
+3. **Audit Phase**: Verify no tests weakened after every fix cycle.
+4. **Simplification**: Refactor for minimal logic before final verification.
 
 ## Codex Standing Instructions
 
-These rules apply to every Codex task. Non-compliance is a known failure mode.
-
-- **Report each fix individually.** After completing each fix, state: fix letter, file, line numbers changed, what was changed. Do not batch fixes into a single sentence.
-- **STOP means STOP.** Do not mark a task complete until every listed fix is implemented and verified. Partial delivery with a complete claim is a protocol violation.
-- **Do not update memory-bank.** Claude owns all memory-bank writes. Codex writing memory-bank has caused repeated stale-state bugs.
-- **Do not commit.** Claude reviews and commits after verifying diffs match the spec.
-- **Verification is mandatory.** Run `shellcheck` on every touched file and report the output. Do not assume clean.
+- **Report each fix individually.** State: fix letter, file, line numbers, what changed.
+- **STOP means STOP.** Partial delivery with a complete claim is a protocol violation.
+- **Do not update memory-bank.** Claude owns all memory-bank writes.
+- **Do not commit.** Claude reviews and commits after verifying diffs match spec.
+- **Verification is mandatory.** Run `shellcheck` on every touched file and report output.
 
 ---
 
@@ -82,7 +58,7 @@ These rules apply to every Codex task. Non-compliance is a known failure mode.
 |---|---|---|
 | k3s node | Ready | v1.34.4+k3s1 |
 | Istio | Running | IngressGateway + istiod |
-| ESO | Pending | Deploy after PR merges |
+| ESO | Pending | Deploy after infra work stabilizes |
 | shopping-cart-data | Pending | PostgreSQL, Redis, RabbitMQ |
 | shopping-cart-apps | Pending | basket, order, payment, catalog, frontend |
 
@@ -90,35 +66,32 @@ These rules apply to every Codex task. Non-compliance is a known failure mode.
 
 ---
 
+## Version Roadmap
+
 | Version | Status | Notes |
 |---|---|---|
-| v0.1.0–v0.5.0 | released | See CHANGE.md |
-| v0.6.0–v0.6.1 | released | PR #17 merged; infra rebuild verified |
-| v0.6.2 | active | AI Tooling (`copilot-cli`) + Checkpointing Protocol |
-| v0.6.3 | planned | Refactoring (De-bloat) + `rigor-cli` Integration |
+| v0.1.0–v0.6.1 | released | See CHANGE.md |
+| v0.6.2 | **released** | AI Tooling + Agent Rigor + Security hardening |
+| v0.6.3 | **active** | Refactoring (De-bloat) + `rigor-cli` Integration |
 | v0.6.4 | planned | lib-foundation extraction via git subtree |
 | v0.7.0 | planned | Keycloak provider + App Cluster deployment |
-| v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) for Claude Desktop / Codex / Atlas / Comet |
+| v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
 | v1.0.0 | vision | Reassess after v0.7.0; see `docs/plans/roadmap-v1.md` |
 
 ---
 
 ## Open Items
 
-- [x] `configure_vault_app_auth` — implemented + Copilot review resolved (PR #16, CI green, awaiting merge)
-- [ ] ESO deploy on Ubuntu app cluster (Gemini — SSH, after PR merges)
-- [ ] shopping-cart-data / apps deployment on Ubuntu (Gemini — SSH)
+- [ ] ESO deploy on Ubuntu app cluster
+- [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner action)
 - [ ] `scripts/tests/plugins/jenkins.bats` — backlog
-- [x] v0.6.2: `_ensure_node` + `_ensure_copilot_cli` — implemented by Codex (2026-03-06)
-- [x] v0.6.2: SDET/Red-Team audit findings (RT-1, RT-2, RT-3) — see `docs/issues/2026-03-06-v0.6.2-sdet-audit-findings.md`
-- [x] v0.6.2: Gemini Phase 2 & 3 (Verification + Red-Team Audit) — Results: BATS 115/115 Pass, RT-2/RT-4 FAIL
-- [x] v0.6.2: Codex RT fix cycle — RT-2 + RT-4 (task: `docs/plans/v0.6.2-codex-rt-fix-task.md`)
-- [ ] v0.6.2: Codex Copilot fix cycle — per `docs/plans/v0.6.2-codex-copilot-review-task.md`
-- [ ] v0.6.2: Claude review and merge (PR)
-- [ ] v0.7.0: Keycloak provider interface + App Cluster deployment (ESO, shopping-cart stack)
-- [ ] v0.7.0: rename cluster to `infra` + fix `CLUSTER_NAME` env var
-- [ ] v0.8.0: `k3dm-mcp` — lean MCP server for Claude Desktop, Codex, Atlas, Comet
+- [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster` — see `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`
+- [ ] v0.6.3: De-bloat `system.sh` / `core.sh`
+- [ ] v0.6.3: `_agent_audit` implementation
+- [ ] v0.6.3: `rigor-cli` integration
+- [ ] v0.7.0: Keycloak provider interface + App Cluster deployment
+- [ ] v0.8.0: `k3dm-mcp` lean MCP server
 
 ---
 
@@ -127,17 +100,16 @@ These rules apply to every Codex task. Non-compliance is a known failure mode.
 - **Pipe all command output to `scratch/logs/<cmd>-<timestamp>.log`** — always print log path before starting
 - **Always run `reunseal_vault`** after any cluster restart before other deployments
 - **ESO SecretStore**: `mountPath` must be `kubernetes` (not `auth/kubernetes`)
-- **Vault reboot unseal**: dual-path — macOS Keychain + Linux libsecret; k8s `vault-unseal` secret is fallback
 - **New namespace defaults**: `secrets`, `identity`, `cicd` — old names still work via env var override
 - **Branch protection**: `enforce_admins` permanently disabled — owner can self-merge
 - **Istio + Jobs**: `sidecar.istio.io/inject: "false"` required on Helm pre-install job pods
-- **Bitnami images**: use `docker.io/bitnamilegacy/*` for ARM64 — `docker.io/bitnami/*` and `public.ecr.aws/bitnami/*` are broken/amd64-only
+- **Bitnami images**: use `docker.io/bitnamilegacy/*` for ARM64
 
-### Keycloak Known Failure Patterns (deploy_keycloak)
+### Keycloak Known Failure Patterns
 
-1. **Istio sidecar blocks `keycloak-config-cli` job** — job hangs indefinitely; look for `keycloak-keycloak-config-cli` pod stuck in Running. Already mitigated in `values.yaml.tmpl` via `sidecar.istio.io/inject: "false"` — verify the annotation is present if job hangs again.
-2. **ARM64 image pull failures** — `docker.io/bitnami/*` and `public.ecr.aws/bitnami/*` are amd64-only; `values.yaml.tmpl` must use `docker.io/bitnamilegacy/*` for Keycloak, PostgreSQL, and Keycloak Config CLI.
-3. **Stale PVCs block retry** — a failed deploy leaves `data-keycloak-postgresql-0` PVC in the `identity` namespace; Helm reinstall will hang waiting for PostgreSQL. Delete the PVC before retrying: `kubectl -n identity delete pvc data-keycloak-postgresql-0`.
+1. **Istio sidecar blocks `keycloak-config-cli` job** — already mitigated via `sidecar.istio.io/inject: "false"` in `values.yaml.tmpl`.
+2. **ARM64 image pull failures** — `docker.io/bitnami/*` is amd64-only; use `docker.io/bitnamilegacy/*`.
+3. **Stale PVCs block retry** — delete `data-keycloak-postgresql-0` PVC in `identity` ns before retrying.
 
 ---
 
@@ -147,22 +119,22 @@ These rules apply to every Codex task. Non-compliance is a known failure mode.
 Claude
   -- monitors CI / reviews agent reports for accuracy
   -- opens PR on owner go-ahead
-  -- when CI fails: identifies root cause → writes bug report → hands to Gemini
+  -- owns all memory-bank writes
 
 Gemini
-  -- investigates, fixes code, verifies live (shellcheck + bats + cluster)
-  -- handles Ubuntu SSH deployment (interactive)
-  -- may write back stale memory bank — always verify after
+  -- SDET/Red-Team audits, BATS verification, Ubuntu SSH deployment
+  -- may write stale memory-bank — always verify after
 
 Codex
-  -- pure logic fixes with no cluster dependency
-  -- STOP at each verification gate; do not rationalize partial fixes
+  -- pure logic fixes, no cluster dependency
+  -- STOP at each verification gate
 
 Owner
   -- approves and merges PRs
 ```
 
 **Lessons learned:**
-- Gemini ignores hold instructions — accept it, use review as the gate
-- Gemini may write back stale memory bank content — verify file state after every update
+- Gemini ignores hold instructions — use review as the gate
+- Gemini may write stale memory-bank content — verify after every update
 - Codex commit-on-failure is a known failure mode — write explicit STOP guardrails
+- PR sub-branches from Copilot agent (e.g. `copilot/sub-pr-*`) may conflict with branch work — evaluate and close if our implementation is superior

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -18,8 +18,8 @@ Plans:
 Key objectives:
 1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex) ✅ done 2026-03-06
 2. **Phase 1 Verification** — BATS 125/125 PASS, E2E Cluster rebuild success (Gemini) ✅ done 2026-03-06
-3. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex)
-4. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex)
+3. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex) ✅ done 2026-03-06
+4. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex) ✅ done 2026-03-06
 5. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅ done 2026-03-06
 6. Claude: review all diffs, run full BATS suite locally, commit, open PR
 
@@ -86,6 +86,7 @@ After implementation: `shellcheck scripts/lib/agent_rigor.sh` — report output.
 - **Do not update memory-bank.** Claude owns all memory-bank writes.
 - **Do not commit.** Claude reviews and commits after verifying diffs match spec.
 - **Verification is mandatory.** Run `shellcheck` on every touched file and report output.
+- **No credentials in task specs.** Task specs and reports must never contain actual credential values, cluster addresses, kubeconfig paths, or tokens — reference env var names only (e.g. `$VAULT_ADDR`, not the actual URL). Live values stay on the owner's machine.
 
 ---
 
@@ -138,7 +139,8 @@ After implementation: `shellcheck scripts/lib/agent_rigor.sh` — report output.
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner action)
 - [ ] `scripts/tests/plugins/jenkins.bats` — backlog
 - [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster` — see `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`
-- [ ] v0.6.3: De-bloat `system.sh` / `core.sh`
+- [x] v0.6.3: De-bloat `system.sh` / `core.sh`
+- [x] v0.6.3: `_agent_lint` implementation (Digital Auditor)
 - [ ] v0.6.3: `_agent_audit` implementation
 - [ ] v0.6.3: `rigor-cli` integration
 - [ ] v0.7.0: Keycloak provider interface + App Cluster deployment

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,7 +16,7 @@ Plans:
 - `docs/plans/v0.6.3-codex-run-command-fix.md` — active Codex task (see below)
 
 Key objectives:
-1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex)
+1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex) ✅ done 2026-03-06
 2. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex)
 3. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex)
 4. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -25,13 +25,50 @@ Key objectives:
 
 ---
 
-## Gemini Pending Actions (Completed)
+## Codex Next Tasks (v0.6.3 Phase 2)
 
-All gaps identified by Claude review of Phase 1 verification are resolved and verified.
+Phase 1 complete and independently verified by Claude: **125/125 BATS passing locally**,
+`run_command.bats` tests 1 & 2 confirmed passing, smoke tests PASS.
 
-1. ✅ **Action 1** — `run_command.bats` tests 1 and 2 PASS locally.
-2. ✅ **Action 2** — Smoke tests (vault, eso, istio) all PASS individually.
-3. ✅ **Action 3** — `agent_rigor.bats` diff verified (stub improvement complete).
+Codex proceeds with Phase 2. Plan: `docs/plans/v0.6.3-refactor-and-audit.md`.
+
+### Standing Rules (apply to every task)
+- Report each fix individually with file and line numbers changed.
+- Run `shellcheck` on every touched file and report output.
+- Do not modify test files (`*.bats`) — Gemini owns those.
+- Do not modify `memory-bank/` — Claude owns memory-bank writes.
+- Do not commit — Claude reviews and commits.
+- STOP after all listed fixes. Do not proceed to the next task without Claude go-ahead.
+
+### Task 1 — De-bloat `scripts/lib/core.sh` (permission cascade anti-patterns)
+
+Targets (see plan for full before/after):
+- `_ensure_path_exists` — collapse 4-attempt mkdir cascade to single `_run_command --prefer-sudo`
+- `_k3s_start_server` — collapse 4-attempt sh cascade to 2-path (root vs non-root)
+- `_setup_kubeconfig` — collapse dual permission checks to single `_run_command --prefer-sudo` per op
+- `_install_k3s` file ops — collapse dual writable-check pattern to direct `_run_command --prefer-sudo`
+
+After all targets done: `shellcheck scripts/lib/core.sh` — report output.
+
+### Task 2 — De-bloat `scripts/lib/system.sh` (OS dispatch consolidation)
+
+Targets (see plan for full before/after):
+- Add `_detect_platform` helper (returns `mac`/`wsl`/`debian`/`redhat`/`linux` or error)
+- `_install_docker` — replace 4-branch inline switch with `_detect_platform` dispatch
+- `deploy_cluster` platform detection — replace 5-branch cascade with `_detect_platform`
+- `_create_nfs_share` — extract `_create_nfs_share_mac` to system.sh, guard in core.sh
+
+After all targets done: `shellcheck scripts/lib/system.sh` — report output.
+
+### Task 3 — Implement `_agent_lint` in `scripts/lib/agent_rigor.sh`
+
+See plan Component 2 for full spec. Key rules enforced:
+- No permission cascades (>1 sudo escalation path for same op)
+- OS dispatch via `_detect_platform` (not raw inline chains)
+- Secret hygiene (no tokens in kubectl exec args)
+- Namespace isolation (no `kubectl apply` without `-n`)
+
+After implementation: `shellcheck scripts/lib/agent_rigor.sh` — report output.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -11,13 +11,16 @@
 
 **v0.6.3: Refactoring & External Audit Integration**
 
-Plan: `docs/plans/v0.6.3-refactor-and-audit.md`
+Plans:
+- `docs/plans/v0.6.3-refactor-and-audit.md` — main refactor plan
+- `docs/plans/v0.6.3-codex-run-command-fix.md` — active Codex task (see below)
 
 Key objectives:
-1. De-bloat `system.sh` and `core.sh` (split oversized files, remove dead code)
-2. Implement `_agent_audit` (test-weakening detection)
-3. Integrate `rigor-cli` for external architectural linting
-4. BATS suite: `scripts/tests/lib/agent_rigor.bats`
+1. **Fix `_run_command` TTY flakiness** — remove `auto_interactive` block (Codex)
+2. De-bloat `system.sh` and `core.sh` — remove permission cascade anti-patterns (Codex)
+3. Implement `_agent_lint` in `agent_rigor.sh` — digital auditor via copilot-cli (Codex)
+4. BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
+5. Claude: review all diffs, run full BATS suite locally, commit, open PR
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -25,35 +25,13 @@ Key objectives:
 
 ---
 
-## Gemini Pending Actions (must complete before Claude commits)
+## Gemini Pending Actions (Completed)
 
-Three gaps identified by Claude review of Phase 1 verification. Fix all three and
-report results. Do not commit. Do not modify memory-bank.
+All gaps identified by Claude review of Phase 1 verification are resolved and verified.
 
-**Action 1 — Confirm run_command.bats tests 1 and 2 pass locally**
-
-Run:
-```bash
-bats scripts/tests/lib/run_command.bats --tap
-```
-
-Report the full TAP output. Tests 1 (`--prefer-sudo uses sudo when available`) and
-2 (`--prefer-sudo falls back when sudo unavailable`) must show `ok`.
-
-**Action 2 — Report smoke test results individually**
-
-Run each and report PASS/FAIL explicitly:
-```bash
-./scripts/k3d-manager test_vault
-./scripts/k3d-manager test_eso
-./scripts/k3d-manager test_istio
-```
-
-**Action 3 — Confirm agent_rigor.bats working tree change is complete**
-
-The improved `command()` stub fix is in the working tree but not committed.
-Verify `git diff scripts/tests/lib/agent_rigor.bats` shows only the stub
-improvement (no other changes). Report the diff output. Claude will commit it.
+1. ✅ **Action 1** — `run_command.bats` tests 1 and 2 PASS locally.
+2. ✅ **Action 2** — Smoke tests (vault, eso, istio) all PASS individually.
+3. ✅ **Action 3** — `agent_rigor.bats` diff verified (stub improvement complete).
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -29,13 +29,20 @@
 
 ### Priority 1 — v0.6.3 (active)
 
-Plan: `docs/plans/v0.6.3-refactor-and-audit.md`
+Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-command-fix.md`
 
-- [ ] De-bloat `scripts/lib/system.sh` (split into focused modules)
-- [ ] De-bloat `scripts/lib/core.sh` (extract cluster lifecycle helpers)
-- [ ] Implement `_agent_audit` (test-weakening detection)
-- [ ] Integrate `rigor-cli` for external architectural linting
-- [ ] BATS suite: `scripts/tests/lib/agent_rigor.bats`
+**Who does what:**
+- **Codex**: all production code changes (system.sh, core.sh, agent_rigor.sh)
+- **Gemini**: BATS suite for agent_rigor.bats; verify full suite locally after Codex delivers
+- **Claude**: review diffs, run BATS locally, commit, open PR
+
+- [ ] Remove `auto_interactive` TTY-detection from `_run_command` (Codex — task: `docs/plans/v0.6.3-codex-run-command-fix.md`)
+- [ ] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (Codex — same task)
+- [ ] De-bloat `scripts/lib/core.sh` — collapse permission cascade anti-patterns (Codex)
+- [ ] De-bloat `scripts/lib/system.sh` — add `_detect_platform` helper, consolidate OS dispatch (Codex)
+- [ ] Implement `_agent_lint` in `scripts/lib/agent_rigor.sh` (Codex)
+- [ ] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
+- [ ] Claude: full BATS run locally, review, commit, PR
 
 ### Priority 2 — v0.6.4
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -45,7 +45,7 @@ Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-c
 - [x] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅
 - [x] Gemini Phase 2: Teardown/Rebuild verification — PASS; found 3 regressions in install_k3s.bats
 - [x] Codex: Fix install_k3s.bats regressions A, B, C (task: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`)
-- [ ] Claude: final BATS run locally, review, commit, PR
+- [x] Claude: BATS 124/124 PASS, changelog written, PR open
 
 ### Priority 2 — v0.6.4
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -36,8 +36,8 @@ Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-c
 - **Gemini**: BATS suite for agent_rigor.bats; verify full suite locally after Codex delivers
 - **Claude**: review diffs, run BATS locally, commit, open PR
 
-- [ ] Remove `auto_interactive` TTY-detection from `_run_command` (Codex — task: `docs/plans/v0.6.3-codex-run-command-fix.md`)
-- [ ] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (Codex — same task)
+- [x] Remove `auto_interactive` TTY-detection from `_run_command` (Codex — task: `docs/plans/v0.6.3-codex-run-command-fix.md`)
+- [x] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (no callers require auto-promotion)
 - [ ] De-bloat `scripts/lib/core.sh` — collapse permission cascade anti-patterns (Codex)
 - [ ] De-bloat `scripts/lib/system.sh` — add `_detect_platform` helper, consolidate OS dispatch (Codex)
 - [ ] Implement `_agent_lint` in `scripts/lib/agent_rigor.sh` (Codex)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,83 +2,58 @@
 
 ## Overall Status
 
-`ldap-develop` merged to `main` via PR #2 (2026-02-27). **v0.1.0 released.**
-
-**v0.6.2 IN PROGRESS 🔄 (2026-03-06)**
-Codex implementation complete. Gemini SDET + red-team audit is the active gate before PR.
-
-**v0.6.1 MERGED ✅ (2026-03-02)**
-Critical fixes for ArgoCD/Jenkins Istio hangs, LDAP defaults, and Jenkins namespace bugs.
-
-**ArgoCD Phase 1 — MERGED ✅ (v0.4.0, 2026-03-02)**
-Deployed live to infra cluster. ArgoCD running in `cicd` ns.
+**v0.6.2 SHIPPED** — tag `v0.6.2` pushed, PR #19 merged 2026-03-06.
+**v0.6.3 ACTIVE** — branch `k3d-manager-v0.6.3` cut from main 2026-03-06.
 
 ---
 
-## What Is Complete ✅
+## What Is Complete
 
-### App Cluster Foundation
-- [x] k3d-manager app-cluster mode refactor (v0.3.0)
-- [x] End-to-end Infra Cluster Rebuild (v0.6.0)
-- [x] Configure Vault `kubernetes-app` auth mount for Ubuntu app cluster
-- [x] High-Rigor Engineering Protocol activated (v0.6.2)
+### Released (v0.1.0 – v0.6.2)
 
-### Bug Fixes (v0.6.1)
-- [x] `destroy_cluster` default name fix
-- [x] `deploy_ldap` no-args default fix
-- [x] ArgoCD `redis-secret-init` Istio sidecar fix
-- [x] ArgoCD Istio annotation string type fix (Copilot review)
-- [x] Jenkins hardcoded LDAP namespace fix
-- [x] Jenkins `cert-rotator` Istio sidecar fix
-- [x] Task plan `--enable-ldap` typo fix (Copilot review)
+- [x] k3d/OrbStack/k3s cluster provider abstraction
+- [x] Vault PKI, ESO, Istio, Jenkins, OpenLDAP, ArgoCD, Keycloak (infra cluster)
+- [x] Active Directory provider (external-only, 36 tests passing)
+- [x] Two-cluster architecture (`CLUSTER_ROLE=infra|app`)
+- [x] Cross-cluster Vault auth (`configure_vault_app_auth`)
+- [x] `_agent_checkpoint` + Agent Rigor Protocol (`scripts/lib/agent_rigor.sh`)
+- [x] `_ensure_copilot_cli` / `_ensure_node` auto-install helpers
+- [x] `_k3d_manager_copilot` scoped wrapper (8-fragment deny list, `K3DM_ENABLE_AI` gate)
+- [x] `_safe_path` / `_is_world_writable_dir` PATH poisoning defense (sticky-bit exemption removed)
+- [x] VAULT_TOKEN stdin injection in `ldap-password-rotator.sh`
+- [x] BATS suites: `ensure_node`, `ensure_copilot_cli`, `k3d_manager_copilot`, `safe_path` — 120/120 passing
 
 ---
 
-## What Is Pending ⏳
+## What Is Pending
 
-### Priority 1 (Current focus — v0.6.2)
+### Priority 1 — v0.6.3 (active)
 
-**v0.6.2 — AI Tooling & Safety Protocol:**
-- [x] Implement `_agent_checkpoint` in `scripts/lib/agent_rigor.sh`
-- [x] Implement `_ensure_node` + `_install_node_from_release` in `scripts/lib/system.sh`
-- [x] Implement `_ensure_copilot_cli` in `scripts/lib/system.sh`
-- [x] Implement `_k3d_manager_copilot` with generic params and implicit gating
-- [x] Verify via `scripts/tests/lib/ensure_node.bats` and `ensure_copilot_cli.bats`
-- [x] Gemini Phase 1: Audit complete — 4 findings in `docs/issues/2026-03-06-v0.6.2-sdet-audit-findings.md`
-- [x] Codex fix cycle: fix sticky bit, relative PATH, deny-tool placement, mock integrity — task: `docs/plans/v0.6.2-codex-fix-task.md`
-- [x] Gemini Phase 2: Full BATS suite pass + shellcheck (Findings: 115/115 pass with K3DMGR_NONINTERACTIVE=1, shellcheck issues at system.sh:149)
-- [x] Gemini Phase 3: Structured RT-1 through RT-6 audit (Findings: RT-2 FAIL, RT-4 FAIL, RT-3 PARTIAL PASS)
-- [x] Codex RT fix cycle: RT-2 (vault stdin injection) + RT-4 (deny-tool completeness) — task: `docs/plans/v0.6.2-codex-rt-fix-task.md`
-- [x] Codex Copilot fix cycle: rc propagation, empty PATH, sticky bit — task: `docs/plans/v0.6.2-codex-copilot-review-task.md`
-- [x] Claude: PR #19 opened; CI green; GitGuardian clean; doc fixes (CHANGE.md, techContext.md)
-- [x] Codex re-review fix cycle: fixes A–I all delivered — task: `docs/plans/v0.6.2-codex-copilot-review2-task.md`
-- [x] Gemini: fix assertion drift in `safe_path.bats` (Fix B/C message strings) + fix CI failure in `k3d_manager_copilot.bats:23` (implemented and verified 120/120 pass) — task: `docs/plans/v0.6.2-gemini-test-fix-task.md`
-- [ ] Claude: final review, run BATS, push, merge PR
-- Task spec: `docs/plans/v0.6.2-gemini-task.md`
-- Implementation plan: `docs/plans/v0.6.2-ensure-copilot-cli.md`
+Plan: `docs/plans/v0.6.3-refactor-and-audit.md`
 
-**v0.6.3 — Refactoring & External Audit Integration:**
-- [ ] Refactor `core.sh` and `system.sh` to eliminate "Defensive Bloat"
-- [ ] Implement `_agent_audit` (Test weakening check)
-- [ ] Integrate with `rigor-cli` for external architectural linting
-- [ ] Verify via `scripts/tests/lib/agent_rigor.bats`
+- [ ] De-bloat `scripts/lib/system.sh` (split into focused modules)
+- [ ] De-bloat `scripts/lib/core.sh` (extract cluster lifecycle helpers)
+- [ ] Implement `_agent_audit` (test-weakening detection)
+- [ ] Integrate `rigor-cli` for external architectural linting
+- [ ] BATS suite: `scripts/tests/lib/agent_rigor.bats`
 
-**v0.6.4 — Shared Library Foundation:**
+### Priority 2 — v0.6.4
+
 - [ ] Create `lib-foundation` repository
-- [ ] Extract `core.sh` and `system.sh` from `k3d-manager`
-- [ ] Implement bi-directional git subtree integration across project ecosystem
+- [ ] Extract `core.sh` and `system.sh` via git subtree
 
-**v0.7.0 — Keycloak + App Cluster Deployment:**
-- [ ] Keycloak provider interface (Bitnami + Operator support)
-- [ ] ESO deploy on App cluster (Ubuntu)
-- [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) deployment on Ubuntu
-- [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) deployment on Ubuntu
+### Priority 3 — v0.7.0
 
-**v0.8.0 — MCP Server (`k3dm-mcp`):**
-- [ ] Lean MCP server wrapping `k3d-manager` CLI
-- [ ] Target clients: Claude Desktop, OpenAI Codex, ChatGPT Atlas, Perplexity Comet
-- [ ] Expose core operations as MCP tools (deploy, destroy, test, unseal)
-- [ ] Sovereignty gating for destructive actions
+- [ ] ESO deploy on Ubuntu app cluster (SSH)
+- [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) on Ubuntu
+- [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) on Ubuntu
+- [ ] Rename infra cluster to `infra`; fix `CLUSTER_NAME` env var
+
+### Priority 4 — v0.8.0
+
+- [ ] `k3dm-mcp` — lean MCP server wrapping k3d-manager CLI
+- [ ] Target clients: Claude Desktop, Codex, Atlas, Comet
+- [ ] Expose: deploy, destroy, test, unseal as MCP tools
 
 ---
 
@@ -86,6 +61,7 @@ Deployed live to infra cluster. ArgoCD running in `cicd` ns.
 
 | Item | Status | Notes |
 |---|---|---|
-| GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | No real secrets — likely IPs in docs. Mark false positive in dashboard. See `docs/issues/2026-02-28-gitguardian-internal-ip-addresses-in-docs.md`. |
-| `CLUSTER_NAME=automation` env var ignored during `deploy_cluster` | OPEN | 2026-03-01: Cluster created as `k3d-cluster` instead of `automation`. See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
-| No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | Jenkins plugin has no dedicated bats suite. `test_auth_cleanup.bats` covers auth flow. Full plugin suite (flag parsing, namespace resolution, mutual exclusivity) is a future improvement — not a gate for current work. |
+| GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | False positive — IPs in docs. Mark in dashboard. See `docs/issues/2026-02-28-gitguardian-internal-ip-addresses-in-docs.md`. |
+| `CLUSTER_NAME` env var ignored during `deploy_cluster` | OPEN | Cluster created as `k3d-cluster` instead of override value. See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
+| `deploy_jenkins` (no flags) broken | OPEN | Policy creation always runs; `jenkins-admin` Vault secret absent. Use `--enable-vault`. |
+| No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | `test_auth_cleanup.bats` covers auth flow. Full suite is future work. |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -37,11 +37,12 @@ Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-c
 - **Claude**: review diffs, run BATS locally, commit, open PR
 
 - [x] Remove `auto_interactive` TTY-detection from `_run_command` (Codex — task: `docs/plans/v0.6.3-codex-run-command-fix.md`)
-- [x] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (no callers require auto-promotion)
+- [x] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (E2E rebuild verified)
+- [x] Gemini: Verification tasks (BATS pass 125/125, E2E cluster rebuild, individual smoke tests PASS)
 - [ ] De-bloat `scripts/lib/core.sh` — collapse permission cascade anti-patterns (Codex)
 - [ ] De-bloat `scripts/lib/system.sh` — add `_detect_platform` helper, consolidate OS dispatch (Codex)
 - [ ] Implement `_agent_lint` in `scripts/lib/agent_rigor.sh` (Codex)
-- [ ] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
+- [x] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
 - [ ] Claude: full BATS run locally, review, commit, PR
 
 ### Priority 2 — v0.6.4

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -39,14 +39,17 @@ Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-c
 - [x] Remove `auto_interactive` TTY-detection from `_run_command` (Codex — task: `docs/plans/v0.6.3-codex-run-command-fix.md`)
 - [x] Audit `--prefer-sudo` call sites for implicit interactive-sudo dependency (E2E rebuild verified)
 - [x] Gemini: Verification tasks (BATS pass 125/125, E2E cluster rebuild, individual smoke tests PASS)
-- [ ] De-bloat `scripts/lib/core.sh` — collapse permission cascade anti-patterns (Codex)
-- [ ] De-bloat `scripts/lib/system.sh` — add `_detect_platform` helper, consolidate OS dispatch (Codex)
-- [ ] Implement `_agent_lint` in `scripts/lib/agent_rigor.sh` (Codex)
-- [x] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini)
-- [ ] Claude: full BATS run locally, review, commit, PR
+- [x] De-bloat `scripts/lib/core.sh` — collapse permission cascade anti-patterns (Codex) ✅
+- [x] De-bloat `scripts/lib/system.sh` — add `_detect_platform` helper (Codex) ✅
+- [x] Implement `_agent_lint` + `_agent_audit` in `agent_rigor.sh` (Codex) ✅
+- [x] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅
+- [x] Gemini Phase 2: Teardown/Rebuild verification — PASS; found 3 regressions in install_k3s.bats
+- [ ] Codex: Fix install_k3s.bats regressions A, B, C (task: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`)
+- [ ] Claude: final BATS run locally, review, commit, PR
 
 ### Priority 2 — v0.6.4
 
+- [ ] Linux k3s validation gate — Gemini runs full 5-phase teardown/rebuild on Ubuntu VM (`ssh ubuntu`, `CLUSTER_PROVIDER=k3s`) to validate refactored `_install_k3s`, `_start_k3s_service`, `_ensure_path_exists`, `_detect_platform`, `_install_docker` under real Linux conditions
 - [ ] Create `lib-foundation` repository
 - [ ] Extract `core.sh` and `system.sh` via git subtree
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -44,7 +44,7 @@ Plans: `docs/plans/v0.6.3-refactor-and-audit.md`, `docs/plans/v0.6.3-codex-run-c
 - [x] Implement `_agent_lint` + `_agent_audit` in `agent_rigor.sh` (Codex) ✅
 - [x] BATS suite: `scripts/tests/lib/agent_rigor.bats` (Gemini) ✅
 - [x] Gemini Phase 2: Teardown/Rebuild verification — PASS; found 3 regressions in install_k3s.bats
-- [ ] Codex: Fix install_k3s.bats regressions A, B, C (task: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`)
+- [x] Codex: Fix install_k3s.bats regressions A, B, C (task: `docs/plans/v0.6.3-codex-install-k3s-bats-fix.md`)
 - [ ] Claude: final BATS run locally, review, commit, PR
 
 ### Priority 2 — v0.6.4

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -35,14 +35,13 @@ Each component exists because of a real gap, reasoned through sequentially — n
 
 - **Jenkins** → needed a CI/CD target that mirrors enterprise reality
 - **Credentials problem** → Jenkins needs passwords; where to store them safely?
-  - Tried **BitWarden** first (already used personally) — `eso_config_bitwarden` was actually implemented
-  - Considered **LastPass** (used at work via `lastpass-cli`) — not suitable for automation
+  - Tried **BitWarden** first — `eso_config_bitwarden` was actually implemented
   - Landed on **Vault** — proper secret store for programmatic access
 - **ESO** → Vault doesn't inject secrets into pods natively; ESO bridges Vault → Kubernetes secrets
 - **Istio** → needed real service mesh to validate enterprise-like networking locally
 - **LDAP/AD** → enterprises authenticate against directory services; needed local testing without a real AD
 
-The `SECRET_BACKEND` abstraction exists because backends were *actually swapped* during development — the commit history shows BitWarden and Azure ESO plugins built before Vault became the primary backend. Git log is the lab notebook.
+The `SECRET_BACKEND` abstraction exists because backends were *actually swapped* during development.
 
 ## Primary Users
 
@@ -60,19 +59,17 @@ k3d-manager/
 │   ├── etc/                 ← config templates & var files
 │   └── tests/               ← Bats test suites
 ├── docs/
-│   ├── plans/               ← design docs (interfaces, integration plans, priorities)
-│   ├── tests/               ← test plans (cert rotation, AD testing instructions)
+│   ├── plans/               ← design docs and task specs
+│   ├── tests/               ← test plans and results
 │   └── issues/              ← post-mortems and resolved bugs
-├── bin/                     ← standalone helper scripts (smoke-test-jenkins.sh)
+├── bin/                     ← standalone helper scripts
 ├── memory-bank/             ← cross-agent documentation substrate
-├── CLAUDE.md                ← authoritative dev guide and current WIP
-├── .clinerules              ← agent rules derived from docs/ (2026-02-19)
+├── CLAUDE.md                ← authoritative dev guide
 └── scratch/                 ← test logs and temp artifacts (gitignored)
 ```
 
 ## Branch Strategy
 
-- `main` – stable, merged state.
-- `ldap-develop` – **active development branch** for AD integration and cert rotation.
-- `ldap-develop` merges to `main` after Priority 1 (cert rotation) + Priority 2 (E2E AD
-  testing) complete and all Bats tests pass.
+- `main` — stable, released state. Protected; owner merges via PR.
+- `k3d-manager-v<X.Y.Z>` — feature branch per milestone; PR back to `main` on completion.
+- Tags: `v<X.Y.Z>` annotated tag on the branch tip commit before merge.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -19,7 +19,7 @@ Three environment variables select the active implementation at runtime:
 
 Consumer code calls a generic interface function; the abstraction layer dispatches to the
 provider-specific implementation. Adding a new provider requires a single new file — no
-changes to consumers. This is the Bash equivalent of the Strategy OOP pattern.
+changes to consumers.
 
 ## 3) Provider Interface Contracts
 
@@ -62,9 +62,8 @@ Vault (K8s auth enabled)
                  └─► Service Pod (mounts secret as env or volume)
 ```
 
-Each service plugin is responsible for creating its own ExternalSecret resources.
-Vault policies are created by the `deploy_vault` step and must allow each service's
-service account to read its secrets path.
+Each service plugin creates its own ExternalSecret resources.
+Vault policies must allow each service's service account to read its secrets path.
 
 ## 5) Jenkins Certificate Rotation Pattern
 
@@ -80,10 +79,6 @@ deploy_jenkins
                  └─► Rolling restart of Jenkins pods
 ```
 
-Cert rotation has been validated via short-TTL/manual-job workflows (see
-`docs/issues/2025-11-21-cert-rotation-fixes.md` and cert rotation test result docs).
-The remaining gap is improving/validating dispatcher-driven cert-rotation test UX.
-
 ## 6) Jenkins Deployment Modes
 
 | Command | Status | Notes |
@@ -93,7 +88,6 @@ The remaining gap is improving/validating dispatcher-driven cert-rotation test U
 | `deploy_jenkins --enable-vault --enable-ldap` | WORKING | + OpenLDAP standard schema |
 | `deploy_jenkins --enable-vault --enable-ad` | WORKING | + OpenLDAP with AD schema |
 | `deploy_jenkins --enable-vault --enable-ad-prod` | WORKING* | + real AD (requires `AD_DOMAIN`) |
-| `deploy_jenkins --enable-ldap` (no vault) | **BROKEN** | LDAP requires Vault for secrets |
 
 ## 7) JCasC Authorization Format
 
@@ -108,19 +102,14 @@ authorizationStrategy:
       - "Overall/Administer:group:Jenkins Admins"
 ```
 
-Do NOT use the nested `entries:` format — it causes silent parsing failures with
-the matrix-auth plugin.
+Do NOT use the nested `entries:` format — causes silent parsing failures.
 
 ## 8) Active Directory Integration Pattern
 
 - AD is always an **external service** (never deployed in-cluster).
-- `_dirservice_activedirectory_init` validates connectivity (DNS + LDAP port probe);
-  it does not deploy anything.
-- **Local testing path**: use `deploy_ad` to stand up OpenLDAP with
-  `bootstrap-ad-schema.ldif` (AD-compatible DNs, sAMAccountName attrs). Test users:
-  `alice` (admin), `bob` (developer), `charlie` (read-only). All password: `password`.
-- **Production path**: set `AD_DOMAIN`, use `--enable-ad-prod`. `TOKENGROUPS`
-  strategy is faster for real AD nested group resolution.
+- `_dirservice_activedirectory_init` validates connectivity (DNS + LDAP port probe).
+- **Local testing path**: `deploy_ad` — OpenLDAP with `bootstrap-ad-schema.ldif`. Test users: `alice` (admin), `bob` (developer), `charlie` (read-only). All password: `password`.
+- **Production path**: set `AD_DOMAIN`, use `--enable-ad-prod`. `TOKENGROUPS` strategy is faster for nested group resolution.
 - `AD_TEST_MODE=1` bypasses connectivity checks for unit testing.
 
 ## 9) `_run_command` Privilege Escalation Pattern
@@ -139,7 +128,7 @@ automatically disables `ENABLE_TRACE` for that command.
 
 ## 10) Idempotency Mandate
 
-Every public function must be safe to run more than once. Implement checks like:
+Every public function must be safe to run more than once:
 - "resource already exists" → skip, not error.
 - "helm release already deployed" → upgrade, not re-install.
 - "Vault already initialized" → skip init, read existing unseal keys.
@@ -147,36 +136,36 @@ Every public function must be safe to run more than once. Implement checks like:
 ## 11) Cross-Agent Documentation Pattern
 
 `memory-bank/` is the collaboration substrate across AI agent sessions.
-- `projectbrief.md` – immutable project scope and goals.
-- `techContext.md` – technologies, paths, key files.
-- `systemPatterns.md` – architecture and design decisions.
-- `activeContext.md` – current work, open blockers, decisions in flight.
-- `progress.md` – done / pending tracker; must be updated at session end.
+- `projectbrief.md` — immutable project scope and goals.
+- `techContext.md` — technologies, paths, key files.
+- `systemPatterns.md` — architecture and design decisions.
+- `activeContext.md` — current branch, open items, decisions in flight.
+- `progress.md` — done / pending tracker; update at session end.
 
 `activeContext.md` must capture **what changed AND why decisions were made**.
-`progress.md` must maintain pending TODOs to prevent session-handoff loss.
 
-## 12) Test Strategy Pattern (Post-Overhaul)
+## 12) Test Strategy Pattern
 
 - Avoid mock-heavy orchestration tests that assert internal call sequences.
-- Keep BATS for pure logic (deterministic, offline checks).
+- Keep BATS for pure logic (deterministic, offline, no cluster required).
 - Use live-cluster E2E smoke tests for integration confidence.
-
-Smoke entrypoint:
 
 ```bash
 ./scripts/k3d-manager test smoke
 ./scripts/k3d-manager test smoke jenkins
 ```
 
-Implemented in `scripts/lib/help/utils.sh`; runs available scripts in `bin/` and skips
-missing/non-executable ones.
+## 13) Red-Team Defensive Patterns
 
-## 14) Red-Team Defensive Patterns
+- **PATH Sanitization**: `_safe_path` validates `PATH` before any copilot/agent invocation. Rejects world-writable dirs (sticky-bit is NOT an exemption) and relative/empty entries. Uses glob-safe `IFS=':' read -r -a` array split.
+- **Secret Injection via stdin**: Token + payload piped into pod's bash via stdin; extracted with `while IFS="=" read -r key value` loop. Token never appears in `kubectl exec` args or `/proc/*/cmdline`.
+- **Prompt Guard**: `_copilot_prompt_guard` checks 8 forbidden shell fragments before any copilot invocation.
+- **Trace Isolation**: `ENABLE_TRACE`/`DEBUG` auto-disabled by `_args_have_sensitive_flag` for commands with `--password`, `--token`, `--username`.
+- **AI Gate**: `K3DM_ENABLE_AI=1` must be explicitly set; all copilot invocations route through `_k3d_manager_copilot`.
 
-To mitigate the risk of sophisticated side-channel and environment attacks:
+## 14) Agent Rigor Protocol
 
-- **PATH Sanitization**: Sensitive operations (Vault unseal, credential retrieval) must either use absolute binary paths or explicitly validate the environment's `PATH` integrity before execution.
-- **Context Integrity Guard**: The `memory-bank/` and `docs/plans/` directories are treated as "Instruction Code." Any changes must be audited by a human to prevent "Context Injection" (poisoning the agent's instructions).
-- **Safe Secret Injection**: Favor `stdin` (piping) over command-line arguments for all secret-heavy operations to prevent `/proc` sniffing.
-- **Trace Isolation**: Ensure `ENABLE_TRACE` and `DEBUG` modes are strictly gated by `_args_have_sensitive_flag` across all library functions.
+`scripts/lib/agent_rigor.sh` — requires `system.sh` sourced first (dependency guard via `declare -f _err`).
+
+- `_agent_checkpoint` — commits the current working state with a spec-derived message before any surgical operation. Prevents partial-fix loss.
+- Pattern: spec → checkpoint → implement → verify → Claude review → commit.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -144,6 +144,25 @@ Every public function must be safe to run more than once:
 
 `activeContext.md` must capture **what changed AND why decisions were made**.
 
+## 12) Agent Role Boundaries
+
+| Agent | Owns | Never does |
+|---|---|---|
+| **Codex** | Production code, security vulnerability fixes | Cluster ops, test authorship |
+| **Gemini** | BATS test authorship, integration tests, cluster verification, red team | Production code changes |
+| **Claude** | memory-bank instructional writes, PR management, issue routing | Takes action without owner go-ahead |
+
+**Gemini test ownership:**
+- BATS unit tests (`scripts/tests/`) — written after Codex delivers production code
+- Integration tests (`test_vault`, `test_eso`, `test_istio`, etc.) — owned and maintained by Gemini; only Gemini has live cluster access to validate them
+- Red team tests — adversarial, bounded to existing security controls
+
+**Gemini red team scope:**
+- Test `_copilot_prompt_guard`, `_safe_path`, stdin injection, trace isolation
+- Attempt credential leakage via proc/cmdline, PATH poisoning, prompt bypass
+- Report findings as structured report in memory-bank — never modify production code
+- Claude reviews findings and routes fixes to Codex
+
 ## 12) Test Strategy Pattern
 
 - Avoid mock-heavy orchestration tests that assert internal call sequences.
@@ -179,6 +198,24 @@ as a network perimeter crossing. Rules:
 - **Prompt Guard**: `_copilot_prompt_guard` checks 8 forbidden shell fragments before any copilot invocation.
 - **Trace Isolation**: `ENABLE_TRACE`/`DEBUG` auto-disabled by `_args_have_sensitive_flag` for commands with `--password`, `--token`, `--username`.
 - **AI Gate**: `K3DM_ENABLE_AI=1` must be explicitly set; all copilot invocations route through `_k3d_manager_copilot`.
+
+## 15) Agent Commit & Communication Protocol
+
+Agents (Codex, Gemini) **self-commit their own work** as a sign-off. Claude does not
+re-commit on their behalf.
+
+**Memory-bank is the two-way communication channel:**
+- Agents write to memory-bank to report completion — Claude reads this to detect issues.
+- Claude writes to memory-bank to instruct next steps — agents read this to act.
+
+**PR review routing** — after Claude opens a PR, issues are routed by scope:
+- Small/isolated → Claude fixes directly in the branch
+- Logic/test fix → back to Codex via memory-bank task
+- Cluster verification → Gemini via memory-bank task
+
+**Claude's review gate remains**: Claude reads every agent memory-bank update before
+writing the next task. This is where inaccuracies, overclaiming, and stale entries are
+caught — not by blocking agent writes.
 
 ## 14) Agent Rigor Protocol
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -155,7 +155,24 @@ Every public function must be safe to run more than once:
 ./scripts/k3d-manager test smoke jenkins
 ```
 
-## 13) Red-Team Defensive Patterns
+## 13) Agent Boundary Security
+
+Every agent handoff (Claude → Codex, Claude → Gemini, memory-bank reads) is treated
+as a network perimeter crossing. Rules:
+
+- **No credentials in task specs or reports.** Actual credential values, cluster
+  addresses, kubeconfig paths, and tokens must never appear in `docs/plans/`,
+  `memory-bank/`, or agent output. Reference env var names only (`$VAULT_ADDR`,
+  `$KUBECONFIG`, etc.). Live values stay on the owner's machine.
+- **memory-bank and docs/plans/ are Instruction Code.** Any agent write to these
+  files must be reviewed by Claude before the next agent reads them — they are a
+  prompt injection surface.
+- **Minimize context to sub-agents.** Task specs include only what the agent needs
+  for the specific task — not full project history, not cluster state, not credentials.
+- **Validate agent output before acting.** Claude reviews every Codex/Gemini diff
+  before commit. `_agent_lint` (when implemented) automates architectural validation.
+
+## 14) Red-Team Defensive Patterns
 
 - **PATH Sanitization**: `_safe_path` validates `PATH` before any copilot/agent invocation. Rejects world-writable dirs (sticky-bit is NOT an exemption) and relative/empty entries. Uses glob-safe `IFS=':' read -r -a` array split.
 - **Secret Injection via stdin**: Token + payload piped into pod's bash via stdin; extracted with `while IFS="=" read -r key value` loop. Token never appears in `kubectl exec` args or `/proc/*/cmdline`.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -109,14 +109,18 @@ DEBUG=1 ./scripts/k3d-manager <command>           # bash -x mode
 - Mock-heavy orchestration suites were removed due to drift; integration confidence is
   driven by live-cluster smoke tests.
 
-Current BATS files in repo:
+Current BATS files in repo (120/120 passing as of v0.6.2):
 - `scripts/tests/core/install_k3s.bats`
 - `scripts/tests/lib/cleanup_on_success.bats`
 - `scripts/tests/lib/dirservices_activedirectory.bats`
 - `scripts/tests/lib/ensure_bats.bats`
+- `scripts/tests/lib/ensure_copilot_cli.bats`
+- `scripts/tests/lib/ensure_node.bats`
 - `scripts/tests/lib/install_kubernetes_cli.bats`
+- `scripts/tests/lib/k3d_manager_copilot.bats`
 - `scripts/tests/lib/read_lines.bats`
 - `scripts/tests/lib/run_command.bats`
+- `scripts/tests/lib/safe_path.bats`
 - `scripts/tests/lib/sha256_12.bats`
 - `scripts/tests/lib/test_auth_cleanup.bats`
 - `scripts/tests/plugins/eso.bats`

--- a/scripts/etc/agent/lint-rules.md
+++ b/scripts/etc/agent/lint-rules.md
@@ -1,0 +1,7 @@
+# Digital Auditor Rules
+
+1. **No Permission Cascades** – a function must not attempt the same privileged action through multiple ad-hoc sudo paths. Use `_run_command --prefer-sudo` once per operation.
+2. **Centralized Platform Detection** – branching on `_is_mac` / `_is_debian_family` / `_is_redhat_family` outside `_detect_platform()` is forbidden unless gating unsupported features.
+3. **Secret Hygiene** – tokens and passwords must never appear in command arguments (e.g., `kubectl exec -- VAULT_TOKEN=...`). Use stdin payloads or env files.
+4. **Namespace Isolation** – every `kubectl apply` or `kubectl create` must include an explicit `-n <namespace>` flag.
+5. **Prompt Scope** – Copilot prompts must reject shell escape fragments (`shell(cd …)`, `shell(git push …)`, `shell(rm -rf …)`, `shell(sudo …)`, `shell(eval …)`, `shell(curl …)`, `shell(wget …)`).

--- a/scripts/lib/agent_rigor.sh
+++ b/scripts/lib/agent_rigor.sh
@@ -48,3 +48,96 @@ function _agent_checkpoint() {
 
    _err "Checkpoint commit failed; resolve git errors and retry"
 }
+
+function _agent_lint() {
+   if [[ "${K3DM_ENABLE_AI:-0}" != "1" ]]; then
+      return 0
+   fi
+
+   if ! command -v git >/dev/null 2>&1; then
+      _warn "git not available; skipping agent lint"
+      return 0
+   fi
+
+   local staged_files
+   staged_files="$(git diff --cached --name-only --diff-filter=ACM -- '*.sh' 2>/dev/null || true)"
+   if [[ -z "$staged_files" ]]; then
+      return 0
+   fi
+
+   local rules_file="${SCRIPT_DIR}/etc/agent/lint-rules.md"
+   if [[ ! -r "$rules_file" ]]; then
+      _warn "Lint rules file missing; skipping agent lint"
+      return 0
+   fi
+
+   local prompt
+   prompt="Review the following staged shell files for architectural violations.\n\nRules:\n$(cat "$rules_file")\n\nFiles:\n$staged_files"
+
+   _k3d_manager_copilot -p "$prompt"
+}
+
+function _agent_audit() {
+   if ! command -v git >/dev/null 2>&1; then
+      _warn "git not available; skipping agent audit"
+      return 0
+   fi
+
+   local status=0
+   local diff_bats
+   diff_bats="$(git diff -- '*.bats' 2>/dev/null || true)"
+   if [[ -n "$diff_bats" ]]; then
+      if grep -q '^-[[:space:]]*assert_' <<<"$diff_bats"; then
+         _warn "Agent audit: assertions removed from BATS files"
+         status=1
+      fi
+
+      local removed_tests added_tests
+      removed_tests=$(grep -c '^-[[:space:]]*@test ' <<<"$diff_bats" || true)
+      added_tests=$(grep -c '^+[[:space:]]*@test ' <<<"$diff_bats" || true)
+      if (( removed_tests > added_tests )); then
+         _warn "Agent audit: number of @test blocks decreased in BATS files"
+         status=1
+      fi
+   fi
+
+   local changed_sh
+   changed_sh="$(git diff --name-only -- '*.sh' 2>/dev/null || true)"
+   if [[ -n "$changed_sh" ]]; then
+      local max_if="${AGENT_AUDIT_MAX_IF:-8}"
+      local file
+      for file in $changed_sh; do
+         [[ -f "$file" ]] || continue
+         local offenders
+         offenders=$(awk -v max_if="$max_if" '
+            function emit(func,count){
+              if(func != "" && count > max_if){printf "%s:%d\n", func, count}
+            }
+            /^[ \t]*function[ \t]+/ {
+              line=$0
+              gsub(/^[ \t]*function[ \t]+/, "", line)
+              func=line
+              gsub(/\(.*/, "", func)
+              emit(current_func, if_count)
+              current_func=func
+              if_count=0
+              next
+            }
+            /\bif\b/ {
+              count=gsub(/\bif\b/, "&")
+              if_count+=count
+            }
+            END {
+              emit(current_func, if_count)
+            }
+         ' "$file")
+
+         if [[ -n "$offenders" ]]; then
+            _warn "Agent audit: $file exceeds if-count threshold in: $offenders"
+            status=1
+         fi
+      done
+   fi
+
+   return "$status"
+}

--- a/scripts/lib/agent_rigor.sh
+++ b/scripts/lib/agent_rigor.sh
@@ -123,9 +123,8 @@ function _agent_audit() {
               if_count=0
               next
             }
-            /\bif\b/ {
-              count=gsub(/\bif\b/, "&")
-              if_count+=count
+            /^[[:space:]]*if[[:space:](]/ {
+              if_count++
             }
             END {
               emit(current_func, if_count)

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -33,30 +33,8 @@ function _ensure_path_exists() {
       return 0
    fi
 
-   if mkdir -p "$dir" 2>/dev/null; then
+   if _run_command --prefer-sudo -- mkdir -p "$dir"; then
       return 0
-   fi
-
-   if _run_command --quiet --soft --prefer-sudo -- mkdir -p "$dir"; then
-      return 0
-   fi
-
-   if command -v sudo >/dev/null 2>&1; then
-      local sudo_checked=0
-
-      if declare -f _sudo_available >/dev/null 2>&1; then
-         sudo_checked=1
-         if _sudo_available; then
-            if sudo mkdir -p "$dir"; then
-               return 0
-            fi
-            _err "Failed to create directory '$dir' using sudo"
-         fi
-      fi
-
-      if sudo mkdir -p "$dir"; then
-         return 0
-      fi
    fi
 
    _err "Cannot create directory '$dir'. Create it manually, configure sudo, or set K3S_CONFIG_DIR to a writable path."
@@ -148,17 +126,7 @@ function _k3s_stage_file() {
    fi
 
    if command -v install >/dev/null 2>&1; then
-      if install -m "$mode" "$src" "$dest" 2>/dev/null; then
-         rm -f "$src"
-         return 0
-      fi
       _run_command --prefer-sudo -- install -m "$mode" "$src" "$dest"
-      rm -f "$src"
-      return 0
-   fi
-
-   if cp "$src" "$dest" 2>/dev/null; then
-      chmod "$mode" "$dest" 2>/dev/null || _run_command --prefer-sudo -- chmod "$mode" "$dest"
       rm -f "$src"
       return 0
    fi
@@ -241,17 +209,8 @@ function _install_k3s() {
 
       _ensure_path_exists "$K3S_INSTALL_DIR"
 
-      if [[ -w "$K3S_INSTALL_DIR" ]]; then
-         mv "$tmpfile" "$dest"
-      else
-         _run_command --prefer-sudo -- mv "$tmpfile" "$dest"
-      fi
-
-      if [[ -w "$dest" ]]; then
-         chmod 0755 "$dest"
-      else
-         _run_command --prefer-sudo -- chmod 0755 "$dest"
-      fi
+      _run_command --prefer-sudo -- mv "$tmpfile" "$dest"
+      _run_command --prefer-sudo -- chmod 0755 "$dest"
 
       _info "Installed k3s binary at $dest"
       return 0
@@ -382,33 +341,13 @@ function _start_k3s_service() {
       return 0
    fi
 
-   local tried_non_interactive=0
-   if declare -f _sudo_available >/dev/null 2>&1 && _sudo_available; then
-      tried_non_interactive=1
-      if _run_command --prefer-sudo -- sh -c "$start_cmd"; then
-         return 0
-      fi
-   fi
-
-   if command -v sudo >/dev/null 2>&1; then
-      if sudo sh -c "$start_cmd"; then
-         return 0
-      fi
-   fi
-
-   if (( ! tried_non_interactive )); then
-      local instruction
-      instruction="nohup ${manual_cmd} >> ${log_file} 2>&1 &"
-      _err "systemd not available and sudo access is required to start k3s automatically. Run manually as root: ${instruction}"
-   fi
-
-   if _run_command --soft -- sh -c "$start_cmd"; then
+   if _run_command --require-sudo -- sh -c "$start_cmd"; then
       return 0
    fi
 
    local instruction
    instruction="nohup ${manual_cmd} >> ${log_file} 2>&1 &"
-   _err "systemd not available and automatic elevation failed. Run manually as root: ${instruction}"
+   _err "systemd not available and sudo access is required to start k3s automatically. Run manually as root: ${instruction}"
 }
 
 function _deploy_k3s_cluster() {
@@ -433,16 +372,10 @@ function _deploy_k3s_cluster() {
    local timeout=60
    local kubeconfig_ready=1
    while (( timeout > 0 )); do
-      if [[ -r "$kubeconfig_src" ]]; then
-         kubeconfig_ready=0
-         break
-      fi
-
       if _run_command --soft --quiet --prefer-sudo -- test -r "$kubeconfig_src"; then
          kubeconfig_ready=0
          break
       fi
-
       sleep 2
       timeout=$((timeout - 2))
    done
@@ -472,32 +405,35 @@ function _deploy_k3s_cluster() {
    local dest_kubeconfig="${KUBECONFIG:-$HOME/.kube/config}"
    _ensure_path_exists "$(dirname "$dest_kubeconfig")"
 
-   if [[ -w "$dest_kubeconfig" || ! -e "$dest_kubeconfig" ]]; then
-      cp "$kubeconfig_src" "$dest_kubeconfig"
-   else
-      _run_command --prefer-sudo -- cp "$kubeconfig_src" "$dest_kubeconfig"
-   fi
+   _run_command --prefer-sudo -- cp "$kubeconfig_src" "$dest_kubeconfig"
 
    if ! _is_wsl; then
       _run_command --prefer-sudo -- chown "$(id -u):$(id -g)" "$dest_kubeconfig" 2>/dev/null || true
    fi
-   chmod 0600 "$dest_kubeconfig" 2>/dev/null || true
+   _run_command --prefer-sudo -- chmod 0600 "$dest_kubeconfig" 2>/dev/null || true
 
    export KUBECONFIG="$dest_kubeconfig"
 
    _info "k3s cluster '$CLUSTER_NAME' is ready"
 }
 function _install_docker() {
-   if _is_mac; then
-      _install_mac_docker
-   elif _is_debian_family; then
-      _install_debian_docker
-   elif _is_redhat_family ; then
-      _install_redhat_docker
-   else
-      echo "Unsupported Linux distribution. Please install Docker manually."
-      exit 1
-   fi
+   local platform
+   platform="$(_detect_platform)"
+
+   case "$platform" in
+      mac)
+         _install_mac_docker
+         ;;
+      debian|linux|wsl)
+         _install_debian_docker
+         ;;
+      redhat)
+         _install_redhat_docker
+         ;;
+      *)
+         _err "Unsupported platform for Docker installation: $platform"
+         ;;
+   esac
 }
 
 function _install_istioctl() {
@@ -593,27 +529,8 @@ function _install_smb_csi_driver() {
 }
 
 function _create_nfs_share() {
-
-   if grep -q "k3d-nfs" /etc/exports ; then
-      echo "NFS share already exists, skip"
-      return 0
-   fi
-
-   if _is_mac ; then
-      echo "Creating NFS share on macOS"
-      mkdir -p $HOME/k3d-nfs
-      if ! grep "$HOME/k3d-nfs" /etc/exports 2>&1 > /dev/null; then
-         ip=$(ipconfig getifaddr en0)
-         mask=$(ipconfig getoption en0 subnet_mask)
-         prefix=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('0.0.0.0/$mask').prefixlen)")
-         network=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('$ip/$prefix', strict=False).network_address)")
-         export_line="/Users/$USER/k3d-nfs -alldirs -rw -insecure -mapall=$(id -u):$(id -g) -network $network -mask $mask"
-         echo "$export_line" | \
-            sudo tee -a /etc/exports
-         sudo nfsd enable
-         sudo nfsd restart  # Full restart instead of update
-         showmount -e localhost
-      fi
+   if _is_mac; then
+      _create_nfs_share_mac "$HOME/k3d-nfs"
    fi
 }
 
@@ -760,24 +677,24 @@ EOF
    fi
 
    local platform="" platform_msg=""
-   if _is_mac; then
-      platform="mac"
-      platform_msg="Detected macOS environment."
-   elif _is_wsl; then
-      platform="wsl"
-      platform_msg="Detected Windows Subsystem for Linux environment."
-   elif _is_debian_family; then
-      platform="debian"
-      platform_msg="Detected Debian-based Linux environment."
-   elif _is_redhat_family; then
-      platform="redhat"
-      platform_msg="Detected Red Hat-based Linux environment."
-   elif _is_linux; then
-      platform="linux"
-      platform_msg="Detected generic Linux environment."
-   else
-      _err "Unsupported platform: $(uname -s)."
-   fi
+   platform="$(_detect_platform)"
+   case "$platform" in
+      mac)
+         platform_msg="Detected macOS environment."
+         ;;
+      wsl)
+         platform_msg="Detected Windows Subsystem for Linux environment."
+         ;;
+      debian)
+         platform_msg="Detected Debian-based Linux environment."
+         ;;
+      redhat)
+         platform_msg="Detected Red Hat-based Linux environment."
+         ;;
+      linux)
+         platform_msg="Detected generic Linux environment."
+         ;;
+   esac
 
    if [[ -n "$platform_msg" ]]; then
       _info "$platform_msg"

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -406,10 +406,7 @@ function _deploy_k3s_cluster() {
    _ensure_path_exists "$(dirname "$dest_kubeconfig")"
 
    _run_command --prefer-sudo -- cp "$kubeconfig_src" "$dest_kubeconfig"
-
-   if ! _is_wsl; then
-      _run_command --prefer-sudo -- chown "$(id -u):$(id -g)" "$dest_kubeconfig" 2>/dev/null || true
-   fi
+   _run_command --prefer-sudo -- chown "$(id -u):$(id -g)" "$dest_kubeconfig" 2>/dev/null || true
    _run_command --prefer-sudo -- chmod 0600 "$dest_kubeconfig" 2>/dev/null || true
 
    export KUBECONFIG="$dest_kubeconfig"
@@ -424,7 +421,7 @@ function _install_docker() {
       mac)
          _install_mac_docker
          ;;
-      debian|linux|wsl)
+      debian|wsl)
          _install_debian_docker
          ;;
       redhat)

--- a/scripts/lib/system.sh
+++ b/scripts/lib/system.sh
@@ -678,6 +678,35 @@ function _is_wsl() {
    fi
 }
 
+function _detect_platform() {
+   if _is_mac; then
+      printf 'mac\n'
+      return 0
+   fi
+
+   if _is_wsl; then
+      printf 'wsl\n'
+      return 0
+   fi
+
+   if _is_debian_family; then
+      printf 'debian\n'
+      return 0
+   fi
+
+   if _is_redhat_family; then
+      printf 'redhat\n'
+      return 0
+   fi
+
+   if _is_linux; then
+      printf 'linux\n'
+      return 0
+   fi
+
+   _err "Unsupported platform: $(uname -s)"
+}
+
 function _install_colima() {
    if ! _command_exist colima ; then
       echo colima does not exist, install it
@@ -688,9 +717,9 @@ function _install_colima() {
 }
 
 function _install_mac_docker() {
-   local cpu="${1:-${COLIMA_CPU:-4}}"
-   local memory="${2:-${COLIMA_MEMORY:-8}}"
-   local disk="${3:-${COLIMA_DISK:-20}}"
+  local cpu="${1:-${COLIMA_CPU:-4}}"
+  local memory="${2:-${COLIMA_MEMORY:-8}}"
+  local disk="${3:-${COLIMA_DISK:-20}}"
 
    if  ! _command_exist docker && _is_mac ; then
       echo docker does not exist, install it
@@ -713,6 +742,35 @@ function _install_mac_docker() {
    #    echo "export DOCKER_CONTEXT=colima" >> $HOME/.zsh/zshrc
    #    echo "restart your shell to apply the changes"
    # fi
+}
+
+function _create_nfs_share_mac() {
+   local share_path="${1:-${HOME}/k3d-nfs}"
+   _ensure_path_exists "$share_path"
+
+   if grep -q "$share_path" /etc/exports 2>/dev/null; then
+      _info "NFS share already exists at $share_path"
+      return 0
+   fi
+
+   local ip mask prefix network
+   ip=$(ipconfig getifaddr en0 2>/dev/null || true)
+   mask=$(ipconfig getoption en0 subnet_mask 2>/dev/null || true)
+
+   if [[ -z "$ip" || -z "$mask" ]]; then
+      _err "Unable to determine network info for NFS share"
+   fi
+
+   prefix=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('0.0.0.0/$mask').prefixlen)" 2>/dev/null || true)
+   network=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('$ip/$prefix', strict=False).network_address)" 2>/dev/null || true)
+
+   local export_line
+   export_line="${share_path} -alldirs -rw -insecure -mapall=$(id -u):$(id -g) -network $network -mask $mask"
+
+   printf '%s\n' "$export_line" | _run_command --prefer-sudo -- tee -a /etc/exports >/dev/null
+   _run_command --prefer-sudo -- nfsd enable
+   _run_command --prefer-sudo -- nfsd restart
+   _run_command --soft -- showmount -e localhost >/dev/null || true
 }
 
 function _orbstack_cli_ready() {

--- a/scripts/lib/system.sh
+++ b/scripts/lib/system.sh
@@ -50,13 +50,6 @@ function _run_command() {
   local quiet=0 prefer_sudo=0 require_sudo=0 interactive_sudo=0 probe= soft=0
   local -a probe_args=()
 
-  # Auto-detect interactive mode: use interactive sudo if in a TTY and not explicitly disabled
-  # Can be overridden with K3DMGR_NONINTERACTIVE=1 environment variable
-  local auto_interactive=0
-  if [[ -t 0 ]] && [[ "${K3DMGR_NONINTERACTIVE:-0}" != "1" ]]; then
-    auto_interactive=1
-  fi
-
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --no-exit|--soft) soft=1; shift;;
@@ -69,11 +62,6 @@ function _run_command() {
       *)              break;;
     esac
   done
-
-  # If --prefer-sudo is set and we're in auto-interactive mode, enable interactive sudo
-  if (( prefer_sudo )) && (( auto_interactive )) && (( interactive_sudo == 0 )); then
-    interactive_sudo=1
-  fi
 
   local prog="${1:?usage: _run_command [opts] -- <prog> [args...]}"
   shift

--- a/scripts/tests/core/install_k3s.bats
+++ b/scripts/tests/core/install_k3s.bats
@@ -45,6 +45,11 @@ setup() {
       esac
     done
     echo "$*" >> "$RUN_LOG"
+    if [[ "$1" == install && "$2" == -m ]]; then
+      command install -m "$3" "$4" "$5"
+    elif [[ "$1" == cp ]]; then
+      command cp "$2" "$3"
+    fi
     return 0
   }
   export -f _run_command
@@ -53,7 +58,7 @@ setup() {
   [ "$status" -eq 0 ]
 
   read_lines "$RUN_LOG" run_calls
-  local expected="sudo sh -c nohup k3s server --write-kubeconfig-mode 0644 --config ${K3S_CONFIG_FILE} >> ${K3S_DATA_DIR}/k3s-no-systemd.log 2>&1 &"
+  local expected="sh -c nohup k3s server --write-kubeconfig-mode 0644 --config ${K3S_CONFIG_FILE} >> ${K3S_DATA_DIR}/k3s-no-systemd.log 2>&1 &"
   local match=1
   for line in "${run_calls[@]}"; do
     if [[ "$line" == "$expected" ]]; then
@@ -117,35 +122,6 @@ setup() {
   chmod 755 "$parent"
   unset -f _run_command
   stub_run_command
-}
-
-@test "_ensure_path_exists retries with sudo when passwordless fails" {
-  local parent="$BATS_TEST_TMPDIR/protected-interactive"
-  local target="$parent/needs-sudo"
-  mkdir -p "$parent"
-  chmod 000 "$parent"
-
-  RUN_EXIT_CODES=(1)
-
-  sudo_calls_log="$BATS_TEST_TMPDIR/sudo.log"
-  : > "$sudo_calls_log"
-
-  sudo() {
-    echo "$*" >> "$sudo_calls_log"
-    chmod 755 "$parent"
-    command mkdir -p "$target"
-    return 0
-  }
-  export -f sudo
-
-  _ensure_path_exists "$target"
-
-  [ -d "$target" ]
-  grep -q '^mkdir -p ' "$sudo_calls_log"
-
-  chmod 755 "$parent"
-  unset -f sudo
-  RUN_EXIT_CODES=()
 }
 
 @test "_ensure_path_exists fails when sudo unavailable" {

--- a/scripts/tests/core/install_k3s.bats
+++ b/scripts/tests/core/install_k3s.bats
@@ -45,11 +45,6 @@ setup() {
       esac
     done
     echo "$*" >> "$RUN_LOG"
-    if [[ "$1" == install && "$2" == -m ]]; then
-      command install -m "$3" "$4" "$5"
-    elif [[ "$1" == cp ]]; then
-      command cp "$2" "$3"
-    fi
     return 0
   }
   export -f _run_command
@@ -178,6 +173,31 @@ sys.stdout.write(pattern.sub(lambda match: os.environ.get(match.group(1), ""), d
   }
   export -f _command_exist
 
+  _run_command() {
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --no-exit|--soft|--quiet|--prefer-sudo|--require-sudo) shift ;;
+        --probe) shift 2 ;;
+        --) shift; break ;;
+        *) break ;;
+      esac
+    done
+    echo "$*" >> "$RUN_LOG"
+    if [[ "$1" == mkdir ]]; then
+      if [[ "$2" == -p ]]; then
+        command mkdir -p "$3"
+      else
+        command mkdir "$2"
+      fi
+    elif [[ "$1" == install && "$2" == -m ]]; then
+      command install -m "$3" "$4" "$5"
+    elif [[ "$1" == cp ]]; then
+      command cp "$2" "$3"
+    fi
+    return 0
+  }
+  export -f _run_command
+
   _ip() { echo 198.51.100.10; }
   export -f _ip
 
@@ -229,4 +249,7 @@ sys.stdout.write(pattern.sub(lambda match: os.environ.get(match.group(1), ""), d
     fi
   done
   [ "$found" -eq 0 ]
+
+  unset -f _run_command
+  stub_run_command
 }

--- a/scripts/tests/lib/agent_rigor.bats
+++ b/scripts/tests/lib/agent_rigor.bats
@@ -15,7 +15,11 @@ setup() {
   export_stubs
   
   # Stub command to return 1 for git
-  command() { if [[ "$1" == git ]]; then return 1; fi; builtin command "$@"; }
+  command() { 
+    if [[ "$1" == "-v" && "$2" == "git" ]]; then return 1; fi
+    if [[ "$1" == "git" ]]; then return 1; fi
+    builtin command "$@"; 
+  }
   export -f command
   
   run _agent_checkpoint

--- a/scripts/tests/lib/agent_rigor.bats
+++ b/scripts/tests/lib/agent_rigor.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  source "${BATS_TEST_DIRNAME}/../test_helpers.bash"
+  init_test_env
+  # shellcheck disable=SC1090
+  source "${SCRIPT_DIR}/lib/system.sh"
+  # shellcheck disable=SC1090
+  source "${SCRIPT_DIR}/lib/agent_rigor.sh"
+}
+
+@test "_agent_checkpoint: fails when git missing" {
+  export_stubs
+  
+  # Stub command to return 1 for git
+  command() { if [[ "$1" == git ]]; then return 1; fi; builtin command "$@"; }
+  export -f command
+  
+  run _agent_checkpoint
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires git"* ]]
+}
+
+@test "_agent_checkpoint: skips when working tree clean" {
+  export_stubs
+  
+  _k3dm_repo_root() { echo "$BATS_TEST_TMPDIR"; }
+  git() {
+    local args=("$@")
+    if [[ "${args[0]}" == "-C" ]]; then
+      shift 2
+    fi
+    case "$1" in
+      rev-parse) return 0 ;;
+      status) echo ""; return 0 ;;
+    esac
+    return 1
+  }
+  export -f _k3dm_repo_root git
+  
+  run _agent_checkpoint
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Working tree clean"* ]]
+}
+
+@test "_agent_checkpoint: commits when working tree dirty" {
+  export_stubs
+  
+  _k3dm_repo_root() { echo "$BATS_TEST_TMPDIR"; }
+  git() {
+    local args=("$@")
+    if [[ "${args[0]}" == "-C" ]]; then
+      shift 2
+    fi
+    case "$1" in
+      rev-parse) return 0 ;;
+      status) echo "M file.sh"; return 0 ;;
+      add) return 0 ;;
+      commit) return 0 ;;
+    esac
+    return 1
+  }
+  export -f _k3dm_repo_root git
+  
+  run _agent_checkpoint "test op"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Created agent checkpoint: checkpoint: before test op"* ]]
+}
+
+@test "_agent_lint: skips when AI disabled" {
+  export_stubs
+  export K3DM_ENABLE_AI=0
+  
+  if ! declare -f _agent_lint >/dev/null; then
+    skip "_agent_lint not implemented yet"
+  fi
+
+  run _agent_lint
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_agent_audit: detects test weakening (placeholder)" {
+  # This will likely fail if _agent_audit isn't implemented
+  if ! declare -f _agent_audit >/dev/null; then
+    skip "_agent_audit not implemented yet"
+  fi
+  
+  run _agent_audit
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- **Permission cascade elimination** — collapsed 7 multi-attempt sudo escalation patterns in `core.sh` into single `_run_command --prefer-sudo` calls
- **`_detect_platform` helper** — single source of truth for OS detection in `system.sh`; replaces scattered inline dispatch chains
- **`_run_command` TTY fix** — removed `auto_interactive` block; CI/local behaviour divergence eliminated
- **Digital Auditor** — `_agent_lint` (Copilot-backed architectural linter) + `_agent_audit` (pure-bash test weakening detector) in `agent_rigor.sh`
- **BATS suite** — `agent_rigor.bats` + `install_k3s.bats` aligned to refactored behaviour; 124/124 passing

## Verification

- BATS: 124/124 passing (1 test removed — sudo-retry behaviour intentionally eliminated by de-bloat)
- Full infra cluster teardown/rebuild on OrbStack (macOS ARM64): all components healthy
- Smoke tests: `test_vault`, `test_eso`, `test_istio` — all PASS

## Test plan

- [ ] Review `scripts/lib/core.sh` — permission cascade collapses
- [ ] Review `scripts/lib/system.sh` — `_detect_platform`, `_create_nfs_share_mac`
- [ ] Review `scripts/lib/agent_rigor.sh` — `_agent_lint`, `_agent_audit`
- [ ] Review `scripts/tests/core/install_k3s.bats` — stub alignment
- [ ] Review `scripts/tests/lib/agent_rigor.bats` — new suite
- [ ] Review `scripts/etc/agent/lint-rules.md` — architectural rules
- [ ] Confirm CHANGE.md entry accurate

@codex please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)