### PR TITLE
v0.6.5 — Agent Rigor Coverage + lib-foundation Extraction

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,29 @@
 # Changes - k3d-manager
 
+## v0.6.5 — Agent Rigor Coverage + lib-foundation Extraction — dated 2026-03-07
+
+### Fixed
+- **`_agent_audit` awk portability** (`scripts/lib/agent_rigor.sh`): The if-count-per-function check used a multi-parameter awk user-defined function rejected by macOS BSD awk (20200816), causing a noisy syntax error on every commit. Replaced with a pure bash `while IFS= read -r line` loop — bash 3.0+ compatible, no external tool dependency, identical logic. Issue: `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`.
+- **SC2155 splits in `system.sh`**: `local var=$(...)` declarations in `_add_exit_trap` and `_detect_cluster_name` split into two-line form for shellcheck compliance.
+
+### Added
+- **BATS coverage for `_agent_audit` new checks** (`scripts/tests/lib/agent_rigor.bats`): 4 new tests for the v0.6.4 bare sudo and kubectl exec credential detections. Each test uses a real mini git repo — no git stubs. Suite: 9/9. Full BATS: 158/158.
+  - `_agent_audit: flags bare sudo in unstaged diff`
+  - `_agent_audit: ignores _run_command sudo in diff`
+  - `_agent_audit: flags kubectl exec with credential env var in staged diff`
+  - `_agent_audit: passes clean staged diff`
+
+### Infrastructure
+- **`lib-foundation` repository created**: https://github.com/wilddog64/lib-foundation — shared Bash foundation library. Branch protection, required CI (shellcheck + BATS 1.13.0), linear history enforced.
+- **`core.sh` + `system.sh` extracted**: Copied to `lib-foundation` branch `extract/v0.1.0`. All shellcheck warnings resolved. PR #1 open on lib-foundation, CI green.
+
+### Verification
+- BATS suite: 158/158 passing (clean `env -i` environment, Ubuntu 24.04 VM).
+- shellcheck: PASS on all touched `.sh` files.
+- Pre-commit hook: no awk error on macOS M-series.
+
+---
+
 ## v0.6.4 — Linux k3s Validation + Agent Harness Hardening — dated 2026-03-07
 
 ### Validation

--- a/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
+++ b/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
@@ -52,7 +52,29 @@ this syntax correctly but is not the system default `awk`.
 
 ## Fix Options
 
-**Option A (preferred) — rewrite without user-defined function:**
+**Option A (preferred) — local gawk detection with transparent fallback:**
+
+Detect `gawk` (available via Homebrew on macOS, default on most Linux) and use it
+transparently. The awk script stays unchanged — only the interpreter selection changes.
+Add a local `awk_cmd` variable inside `_agent_audit` before the awk call (line 112):
+
+```bash
+local awk_cmd
+awk_cmd="$(command -v gawk || command -v awk)"
+offenders=$("$awk_cmd" -v max_if="$max_if" '
+   function emit(func,count){
+     if(func != "" && count > max_if){printf "%s:%d\n", func, count}
+   }
+   ...
+' "$file")
+```
+
+- macOS + Homebrew: uses `/opt/homebrew/bin/gawk` → works ✅
+- Linux (Ubuntu): uses system `gawk` or `awk` (GNU awk) → works ✅
+- macOS without Homebrew: falls back to BSD awk → same problem, but this is
+  an unsupported config (Homebrew required for k3d, bats, etc.)
+
+**Option B — rewrite without user-defined function:**
 Replace the `emit()` function with inline awk logic. The function only prints
 when count exceeds threshold — this is expressible without a named function:
 
@@ -78,16 +100,12 @@ offenders=$(awk -v max_if="$max_if" '
 ' "$file")
 ```
 
-**Option B — use `gawk` explicitly:**
-Replace `awk` with `gawk` at line 112. Requires gawk installed
-(`brew install gawk`). Less portable — gawk is not guaranteed present on Linux CI.
-
 **Option C — use `awk` file instead of heredoc:**
 Extract the awk script to `scripts/lib/agent_audit_ifcount.awk` and call
 `awk -v max_if="$max_if" -f scripts/lib/agent_audit_ifcount.awk "$file"`.
 This avoids the heredoc indentation issue but adds a file dependency.
 
-**Recommendation: Option A** — no new dependencies, works on all platforms.
+**Recommendation: Option A** — transparent gawk detection, minimal change, awk script unchanged.
 
 ---
 
@@ -116,6 +134,7 @@ env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test agent_rigor 2>&1 | t
 ## Scope
 
 - Edit only `scripts/lib/agent_rigor.sh` lines 112–132 (the awk block inside `_agent_audit`)
-- Do not change any other logic — only the awk implementation of the if-count check
+- Add `local awk_cmd` + `awk_cmd="$(command -v gawk || command -v awk)"` before the awk call
+- Replace `awk` with `"$awk_cmd"` on the awk invocation line — no other changes
 - Run `shellcheck scripts/lib/agent_rigor.sh` and confirm PASS
 - Verify pre-commit hook no longer prints awk error on a test commit

--- a/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
+++ b/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
@@ -52,33 +52,12 @@ this syntax correctly but is not the system default `awk`.
 
 ## Fix Options
 
-**Option A (preferred) — local gawk detection with transparent fallback:**
+**Option A (preferred) — rewrite without user-defined function (POSIX portable):**
 
-Detect `gawk` (available via Homebrew on macOS, default on most Linux) and use it
-transparently. The awk script stays unchanged — only the interpreter selection changes.
-Add a local `awk_cmd` variable inside `_agent_audit` before the awk call (line 112):
+Inline the `emit()` logic directly. Works on BSD awk, mawk, gawk, and every POSIX awk.
+No dependency on gawk, no Homebrew requirement, no detection logic needed.
 
 ```bash
-local awk_cmd
-awk_cmd="$(command -v gawk || command -v awk)"
-offenders=$("$awk_cmd" -v max_if="$max_if" '
-   function emit(func,count){
-     if(func != "" && count > max_if){printf "%s:%d\n", func, count}
-   }
-   ...
-' "$file")
-```
-
-- macOS + Homebrew: uses `/opt/homebrew/bin/gawk` → works ✅
-- Linux (Ubuntu): uses system `gawk` or `awk` (GNU awk) → works ✅
-- macOS without Homebrew: falls back to BSD awk → same problem, but this is
-  an unsupported config (Homebrew required for k3d, bats, etc.)
-
-**Option B — rewrite without user-defined function:**
-Replace the `emit()` function with inline awk logic. The function only prints
-when count exceeds threshold — this is expressible without a named function:
-
-```awk
 offenders=$(awk -v max_if="$max_if" '
    /^[ \t]*function[ \t]+/ {
      if (current_func != "" && if_count > max_if) {
@@ -100,12 +79,27 @@ offenders=$(awk -v max_if="$max_if" '
 ' "$file")
 ```
 
-**Option C — use `awk` file instead of heredoc:**
-Extract the awk script to `scripts/lib/agent_audit_ifcount.awk` and call
-`awk -v max_if="$max_if" -f scripts/lib/agent_audit_ifcount.awk "$file"`.
-This avoids the heredoc indentation issue but adds a file dependency.
+Works on:
+- macOS BSD awk (no Homebrew) ✅
+- macOS with Homebrew gawk ✅
+- Linux mawk / GNU awk ✅
+- Any POSIX awk ✅
 
-**Recommendation: Option A** — transparent gawk detection, minimal change, awk script unchanged.
+**Option B — gawk detection with fallback:**
+
+```bash
+local awk_cmd
+awk_cmd="$(command -v gawk || command -v awk)"
+offenders=$("$awk_cmd" -v max_if="$max_if" '...' "$file")
+```
+
+Only helps if `gawk` is installed. macOS without Homebrew still fails.
+**Not recommended** — partial fix, hides the real portability gap.
+
+**Option C — extract to `.awk` file:**
+Adds a file dependency. Not recommended for a single-use internal script.
+
+**Recommendation: Option A** — truly portable, no dependencies, minimal code change.
 
 ---
 
@@ -134,7 +128,7 @@ env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test agent_rigor 2>&1 | t
 ## Scope
 
 - Edit only `scripts/lib/agent_rigor.sh` lines 112–132 (the awk block inside `_agent_audit`)
-- Add `local awk_cmd` + `awk_cmd="$(command -v gawk || command -v awk)"` before the awk call
-- Replace `awk` with `"$awk_cmd"` on the awk invocation line — no other changes
+- Replace the entire awk heredoc with the Option A rewrite — no other changes
 - Run `shellcheck scripts/lib/agent_rigor.sh` and confirm PASS
 - Verify pre-commit hook no longer prints awk error on a test commit
+- Verify the if-count check still flags functions with > 8 if blocks

--- a/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
+++ b/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
@@ -1,0 +1,121 @@
+# Issue: _agent_audit awk user-defined function fails on macOS BSD awk
+
+**Date:** 2026-03-07
+**File:** `scripts/lib/agent_rigor.sh` — `_agent_audit` function, lines 112–132
+**Symptom:** Pre-commit hook prints awk syntax error on every commit on macOS
+**Assigned to:** Codex
+
+---
+
+## Symptom
+
+Every commit on macOS M-series triggers this error from the pre-commit hook:
+
+```
+awk: syntax error at source line 2 in function emit
+ context is
+            function >>> emit(func <<< ,count){
+        2 missing )'s
+awk: bailing out at source line 2 in function emit
+```
+
+The commit still succeeds — the hook does not block — but the error is noisy and
+masks real audit warnings.
+
+---
+
+## Root Cause
+
+macOS ships **BSD one-true-awk** (version 20200816). This awk implementation does not
+support multi-parameter user-defined functions in multi-line heredoc format when the
+`function` keyword is indented with leading whitespace.
+
+The failing awk in `_agent_audit` (lines 112–132):
+
+```awk
+offenders=$(awk -v max_if="$max_if" '
+   function emit(func,count){          ← indented, 2 params → BSD awk fails here
+     if(func != "" && count > max_if){ ... }
+   }
+   ...
+' "$file")
+```
+
+**Confirmed behaviors on macOS awk 20200816:**
+- `function f(x){return x}` — single param, inline → **works** ✅
+- `function emit(func,count){...}` — two params, any formatting → **fails** ❌
+
+**gawk** (GNU Awk 5.4.0, available at `/opt/homebrew/bin/gawk`) supports
+this syntax correctly but is not the system default `awk`.
+
+---
+
+## Fix Options
+
+**Option A (preferred) — rewrite without user-defined function:**
+Replace the `emit()` function with inline awk logic. The function only prints
+when count exceeds threshold — this is expressible without a named function:
+
+```awk
+offenders=$(awk -v max_if="$max_if" '
+   /^[ \t]*function[ \t]+/ {
+     if (current_func != "" && if_count > max_if) {
+       printf "%s:%d\n", current_func, if_count
+     }
+     line = $0
+     gsub(/^[ \t]*function[ \t]+/, "", line)
+     current_func = line
+     gsub(/\(.*/, "", current_func)
+     if_count = 0
+     next
+   }
+   /^[[:space:]]*if[[:space:](]/ { if_count++ }
+   END {
+     if (current_func != "" && if_count > max_if) {
+       printf "%s:%d\n", current_func, if_count
+     }
+   }
+' "$file")
+```
+
+**Option B — use `gawk` explicitly:**
+Replace `awk` with `gawk` at line 112. Requires gawk installed
+(`brew install gawk`). Less portable — gawk is not guaranteed present on Linux CI.
+
+**Option C — use `awk` file instead of heredoc:**
+Extract the awk script to `scripts/lib/agent_audit_ifcount.awk` and call
+`awk -v max_if="$max_if" -f scripts/lib/agent_audit_ifcount.awk "$file"`.
+This avoids the heredoc indentation issue but adds a file dependency.
+
+**Recommendation: Option A** — no new dependencies, works on all platforms.
+
+---
+
+## Verification
+
+```bash
+# Before fix — should print awk error
+echo "dummy" | awk -v max_if="8" '
+   function emit(func,count){
+     if(func != "" && count > max_if){printf "%s:%d\n", func, count}
+   }
+   END { emit("test", 10) }
+' /dev/null
+
+# After fix — should print no awk error, and cyclomatic check still works
+# Stage a .sh file with >8 if blocks and confirm audit flags it
+```
+
+Also run the full BATS suite after the fix:
+```bash
+env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test agent_rigor 2>&1 | tail -10
+```
+
+---
+
+## Scope
+
+- Edit only `scripts/lib/agent_rigor.sh` lines 112–132 (the awk block inside `_agent_audit`)
+- Do not change any other logic — only the awk implementation of the if-count check
+- Run `shellcheck scripts/lib/agent_rigor.sh` and confirm PASS
+- Verify pre-commit hook no longer prints awk error on a test commit

--- a/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
+++ b/docs/issues/2026-03-07-agent-audit-awk-macos-compat.md
@@ -99,7 +99,7 @@ Only helps if `gawk` is installed. macOS without Homebrew still fails.
 **Option C — extract to `.awk` file:**
 Adds a file dependency. Not recommended for a single-use internal script.
 
-**Recommendation: Option A** — truly portable, no dependencies, minimal code change.
+**Recommendation: Option A** — truly portable, no external tool dependency, bash 3.2+ compatible, consistent with k3d-manager's bash-native philosophy.
 
 ---
 
@@ -125,10 +125,28 @@ env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test agent_rigor 2>&1 | t
 
 ---
 
+## Bash Version Requirement
+
+The pre-commit hook sources only `system.sh` + `agent_rigor.sh` — core files
+deliberately kept bash 3.2+ compatible. (`declare -A` associative arrays appear
+only in optional lazy-loaded plugins — not in core.) The fix must also be
+bash 3.2+ compatible.
+
+Pure bash solution uses only:
+- `while IFS= read -r line` — bash 2.0+
+- `[[ "$line" =~ pattern ]]` — bash 3.0+
+- `(( if_count++ ))` — bash 2.0+
+- `${var#pattern}`, `${var%%pattern}` — bash 2.0+
+
+All safe for bash 3.2 (macOS `/bin/bash`) and bash 5.x (Homebrew / Ubuntu).
+
+---
+
 ## Scope
 
 - Edit only `scripts/lib/agent_rigor.sh` lines 112–132 (the awk block inside `_agent_audit`)
-- Replace the entire awk heredoc with the Option A rewrite — no other changes
+- Replace the entire awk heredoc with the pure bash `while read` rewrite
+- Do not use `declare -A`, `mapfile`, or any bash 4.0+ feature
 - Run `shellcheck scripts/lib/agent_rigor.sh` and confirm PASS
 - Verify pre-commit hook no longer prints awk error on a test commit
 - Verify the if-count check still flags functions with > 8 if blocks

--- a/docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md
+++ b/docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md
@@ -1,0 +1,81 @@
+# Issue: lib-foundation system.sh shellcheck failures
+
+**Date:** 2026-03-07
+**Repo:** `lib-foundation`, branch `extract/v0.1.0`
+**Reported by:** Claude (review of Codex extraction task)
+**Assigned to:** Codex
+
+---
+
+## Summary
+
+Codex's extraction of `core.sh` and `system.sh` into lib-foundation is incomplete.
+`core.sh` passes shellcheck. `system.sh` fails shellcheck with exit code 1, blocking CI.
+
+---
+
+## Findings
+
+### core.sh — PASS ✅
+
+Codex applied two correct fixes to make shellcheck pass:
+- Added `# shellcheck shell=bash` directive (line 1)
+- `pushd /tmp` → `pushd /tmp >/dev/null || return 1` (SC2164)
+- `popd` → `popd >/dev/null || return 1` (SC2164)
+
+These changes deviated from the "verbatim copy" instruction but were necessary to satisfy
+the shellcheck requirement. Accepted.
+
+### system.sh — FAIL ❌
+
+`shellcheck scripts/lib/system.sh` exits 1. Findings:
+
+| Code | Severity | Count | Lines | Pattern |
+|---|---|---|---|---|
+| SC2016 | info | 14 | 383,384,394,396,436,438,464,466,488,489,502,503,524,526,543,548 | `bash -c '..."\$1"...'` — intentional arg-passing pattern |
+| SC2046 | warning | 1 | 837 | Unquoted `$(lsb_release -is)` in curl URL |
+| SC2086 | info | 2 | 857,944 | Unquoted `$USER`, `$HELM_GLOBAL_ARGS` |
+| SC2155 | warning | 3 | 1635,1669,1670 | `local var=$(...)` — declare and assign separately |
+
+---
+
+## Required Fix
+
+Codex must resolve shellcheck exit 1 on `system.sh`. Two acceptable approaches:
+
+**Option A (preferred) — targeted `# shellcheck disable` directives:**
+Add per-line or per-block disable comments for the SC2016 false positives
+(intentional `bash -c` arg-passing). Fix the genuine SC2046, SC2086, SC2155 findings.
+
+```bash
+# Example for SC2016 false positives:
+# shellcheck disable=SC2016
+_no_trace bash -c 'security delete-generic-password -s "$1" ...' _ "$service"
+```
+
+**Option B — fix all findings:**
+Fix the SC2046, SC2086, SC2155 warnings (genuine issues). For SC2016, add
+`# shellcheck disable=SC2016` block-level around the intentional patterns.
+
+**Option C (not acceptable):**
+~~Setting `--severity=error` in CI to suppress info/warning findings.~~
+This hides real issues and weakens the CI gate.
+
+---
+
+## Verification
+
+```bash
+shellcheck scripts/lib/system.sh
+# Expected: exit 0, no output
+```
+
+CI must pass on `extract/v0.1.0` before PR can be opened.
+
+---
+
+## Additional Protocol Violations (note only — no fix required)
+
+- Branch was not pushed before reporting completion — CI was never run
+- Memory-bank marked task `[x]` complete without CI confirmation
+- Future: do not mark complete until `gh run list` shows green CI

--- a/docs/plans/task-spec-template.md
+++ b/docs/plans/task-spec-template.md
@@ -20,8 +20,9 @@ Any change not on the checklist is forbidden, even if it seems like an improveme
 2. Do not modify test files unless explicitly listed.
 3. Run `shellcheck` on every touched `.sh` file and report output.
 4. Commit your own work — self-commit is your sign-off.
-5. Update memory-bank to report completion.
-6. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+5. **Push your branch and confirm CI is green before updating memory-bank.** Use `gh run list --repo <owner>/<repo> --limit 3` to verify. Never report COMPLETE without a green CI run URL.
+6. Update memory-bank to report completion — include the CI run URL.
+7. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
 
 ---
 
@@ -78,6 +79,9 @@ Task: [title]
 Status: COMPLETE / BLOCKED
 Files changed: [list]
 Shellcheck: PASS / [issues found]
+CI run: [URL from gh run list] — PASS / FAIL / not applicable
 Verification: [output]
 Unexpected findings: [anything outside task scope — report, do not fix]
 ```
+
+**Do not set Status: COMPLETE without a green CI run URL. No CI URL = not done.**

--- a/docs/plans/v0.6.5-codex-awk-bash-rewrite.md
+++ b/docs/plans/v0.6.5-codex-awk-bash-rewrite.md
@@ -1,0 +1,128 @@
+# v0.6.5 — Codex Task: Replace awk if-count check with pure bash
+
+## Context
+
+`_agent_audit` in `scripts/lib/agent_rigor.sh` uses an awk user-defined function
+to count `if` blocks per shell function. macOS BSD awk (version 20200816) rejects
+multi-parameter user-defined functions, causing a noisy syntax error on every commit
+via the pre-commit hook. The commit still succeeds but the error masks real audit warnings.
+
+Background: `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`
+
+**Branch:** `k3d-manager-v0.6.5`
+
+---
+
+## Critical Rules
+
+1. **Edit only `scripts/lib/agent_rigor.sh` lines 112–132. Nothing else.**
+2. Replace the `awk` block with a pure bash `while read` loop — same logic, no external tool.
+3. **Do not use bash 4.0+ features** — core must stay bash 3.2+ compatible:
+   - Forbidden: `declare -A`, `mapfile`, `readarray`
+   - Allowed: `[[ =~ ]]` (bash 3.0+), `(( expr ))`, `${var#pat}`, `${var%%pat}`
+4. Run `shellcheck scripts/lib/agent_rigor.sh` and confirm PASS.
+5. Commit your own work — self-commit is your sign-off.
+6. Update memory-bank to report completion. Local commit is sufficient — Claude pushes.
+7. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+
+---
+
+## Change Checklist
+
+Tick each item as you complete it. Do not add items.
+
+- [ ] `scripts/lib/agent_rigor.sh` lines 112–132 — replace the `awk` heredoc block with a pure bash `while IFS= read -r line` loop implementing identical if-count-per-function logic
+
+**Forbidden:** Any change outside lines 112–132. Do not touch other checks, other files, or the surrounding `if [[ -n "$changed_sh" ]]` block.
+
+---
+
+## Expected Result
+
+### Before (lines 112–132):
+
+```bash
+         offenders=$(awk -v max_if="$max_if" '
+            function emit(func,count){
+              if(func != "" && count > max_if){printf "%s:%d\n", func, count}
+            }
+            /^[ \t]*function[ \t]+/ {
+              line=$0
+              gsub(/^[ \t]*function[ \t]+/, "", line)
+              func=line
+              gsub(/\(.*/, "", func)
+              emit(current_func, if_count)
+              current_func=func
+              if_count=0
+              next
+            }
+            /^[[:space:]]*if[[:space:](]/ {
+              if_count++
+            }
+            END {
+              emit(current_func, if_count)
+            }
+         ' "$file")
+```
+
+### After — pure bash equivalent:
+
+```bash
+         local current_func="" if_count=0 offenders=""
+         while IFS= read -r line; do
+            if [[ "$line" =~ ^[[:space:]]*function[[:space:]]+ ]]; then
+               if [[ -n "$current_func" && "$if_count" -gt "$max_if" ]]; then
+                  offenders+="${current_func}:${if_count}"$'\n'
+               fi
+               current_func="${line#*function }"
+               current_func="${current_func%%(*}"
+               current_func="${current_func//[[:space:]]/}"
+               if_count=0
+            elif [[ "$line" =~ ^[[:space:]]*if[[:space:|(] ]]; then
+               (( if_count++ )) || true
+            fi
+         done < "$file"
+         if [[ -n "$current_func" && "$if_count" -gt "$max_if" ]]; then
+            offenders+="${current_func}:${if_count}"$'\n'
+         fi
+         offenders="${offenders%$'\n'}"
+```
+
+---
+
+## Verification
+
+```bash
+# 1. shellcheck must pass
+shellcheck scripts/lib/agent_rigor.sh
+echo "exit: $?"
+
+# 2. Pre-commit hook must not print awk error
+# Stage any file and commit — no awk error should appear
+git add memory-bank/activeContext.md
+git commit -m "test: verify no awk error"
+# Expected: no awk syntax error output
+
+# 3. Full BATS suite — must not regress
+env -i HOME="$HOME" PATH="$PATH" \
+  ./scripts/k3d-manager test agent_rigor 2>&1 | tail -10
+# Expected: all existing tests pass (5/5 or more)
+```
+
+---
+
+## Completion Report (required)
+
+Update `memory-bank/activeContext.md` on `k3d-manager-v0.6.5` with:
+
+```
+Task: awk → pure bash rewrite in _agent_audit
+Status: COMPLETE / BLOCKED
+Files changed: scripts/lib/agent_rigor.sh
+Shellcheck: PASS / [issues]
+Pre-commit: no awk error on test commit — PASS / FAIL
+BATS agent_rigor: N/N passing
+Unexpected findings: [anything outside scope — report, do not fix]
+```
+
+Note: local commit is sufficient — Claude handles push.

--- a/docs/plans/v0.6.5-codex-lib-foundation-extraction.md
+++ b/docs/plans/v0.6.5-codex-lib-foundation-extraction.md
@@ -1,0 +1,121 @@
+# v0.6.5 — Codex Task: Extract core.sh + system.sh into lib-foundation
+
+## Context
+
+`lib-foundation` is a new standalone repository for shared Bash foundation code.
+It is scaffolded and has CI + branch protection in place.
+The `extract/v0.1.0` branch is cut from `main` and ready for this work.
+This task populates the repo with `core.sh` and `system.sh` copied from k3d-manager.
+
+**Target repo:** `https://github.com/wilddog64/lib-foundation`
+**Target branch:** `extract/v0.1.0`
+**k3d-manager source branch:** `k3d-manager-v0.6.5` (read-only reference — do not modify k3d-manager files in this task)
+
+---
+
+## Critical Rules
+
+1. **Edit only the files and lines listed in the Change Checklist below. Nothing else.**
+2. Do not modify any files in k3d-manager — this task is in lib-foundation only.
+3. Do not modify `system.sh` or `core.sh` content — copy them verbatim.
+4. Run `shellcheck` on both `.sh` files and report output.
+5. Commit your own work — self-commit is your sign-off.
+6. Update memory-bank to report completion.
+7. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+
+---
+
+## Change Checklist
+
+Tick each item as you complete it. Do not add items.
+
+- [ ] `scripts/lib/core.sh` — new file, copy verbatim from k3d-manager `scripts/lib/core.sh`
+- [ ] `scripts/lib/system.sh` — new file, copy verbatim from k3d-manager `scripts/lib/system.sh`
+- [ ] `scripts/lib/.gitkeep` — delete this stub file
+- [ ] `scripts/tests/lib/.gitkeep` — delete this stub file
+
+**Forbidden:** Any change not listed above. Do not modify file content, do not touch k3d-manager, do not add new files.
+
+---
+
+## Setup
+
+```bash
+# Clone lib-foundation and switch to the extraction branch
+git clone https://github.com/wilddog64/lib-foundation.git
+cd lib-foundation
+git checkout extract/v0.1.0
+
+# Also have k3d-manager available to copy from
+git clone https://github.com/wilddog64/k3d-manager.git
+git -C k3d-manager checkout k3d-manager-v0.6.5
+```
+
+---
+
+## Expected Result
+
+After the task:
+
+```
+lib-foundation/
+  scripts/lib/
+    core.sh       ← copied verbatim from k3d-manager/scripts/lib/core.sh  (~806 lines)
+    system.sh     ← copied verbatim from k3d-manager/scripts/lib/system.sh (~1690 lines)
+  scripts/tests/lib/
+    (empty — .gitkeep removed, no .bats files yet)
+```
+
+No `.gitkeep` stubs remain.
+
+---
+
+## Known Dependency (do not fix in this task)
+
+`system.sh` sources `agent_rigor.sh` at load time:
+```bash
+if [[ "${K3DM_AGENT_RIGOR_LIB_SOURCED}" != "1" ]]; then
+   agent_rigor_lib_path="${SCRIPT_DIR}/lib/agent_rigor.sh"
+   if [[ -r "$agent_rigor_lib_path" ]]; then
+      source "$agent_rigor_lib_path"
+   fi
+fi
+```
+
+`agent_rigor.sh` does not exist in lib-foundation. This is **safe** — the `if [[ -r ... ]]`
+guard means the source is silently skipped when the file is absent.
+**Do not attempt to fix, remove, or work around this.** Report it in your completion report.
+
+---
+
+## Verification
+
+```bash
+# shellcheck — must pass with no errors
+shellcheck scripts/lib/core.sh scripts/lib/system.sh
+
+# Confirm file sizes are reasonable (not empty, not truncated)
+wc -l scripts/lib/core.sh scripts/lib/system.sh
+# Expected: core.sh ~806 lines, system.sh ~1690 lines
+
+# CI runs automatically on push — shellcheck job must pass
+# bats job will skip gracefully (no .bats files yet) — this is expected and correct
+git push origin extract/v0.1.0
+# Watch: https://github.com/wilddog64/lib-foundation/actions
+```
+
+---
+
+## Completion Report (required)
+
+Update `memory-bank/activeContext.md` in lib-foundation on `extract/v0.1.0` with:
+
+```
+Task: lib-foundation extraction — core.sh + system.sh
+Status: COMPLETE / BLOCKED
+Files changed: scripts/lib/core.sh (new), scripts/lib/system.sh (new), removed .gitkeep stubs
+Line counts: core.sh NNN lines, system.sh NNN lines
+Shellcheck: PASS / [issues found]
+CI: PASS / [URL to run]
+Unexpected findings: [anything outside task scope — report, do not fix]
+```

--- a/docs/plans/v0.6.5-codex-system-sh-shellcheck.md
+++ b/docs/plans/v0.6.5-codex-system-sh-shellcheck.md
@@ -1,0 +1,127 @@
+# v0.6.5 — Codex Task: Fix system.sh shellcheck failures in lib-foundation
+
+## Context
+
+`scripts/lib/system.sh` was imported into lib-foundation but fails `shellcheck` with exit 1.
+CI blocks on shellcheck — PR `extract/v0.1.0 → main` cannot merge until this is green.
+`core.sh` already passes. Only `system.sh` needs fixing.
+
+Background: `docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md`
+
+**Repo:** `https://github.com/wilddog64/lib-foundation`
+**Branch:** `extract/v0.1.0`
+
+---
+
+## Critical Rules
+
+1. **Edit only `scripts/lib/system.sh`. Nothing else.**
+2. Do not change logic — only add `# shellcheck disable` directives or fix quoting as listed.
+3. Run `shellcheck scripts/lib/system.sh` and confirm exit 0 before committing.
+4. Commit your own work — self-commit is your sign-off.
+5. Update `memory-bank/activeContext.md` in lib-foundation on `extract/v0.1.0`.
+6. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+
+---
+
+## Change Checklist
+
+Tick each item as you complete it. Do not add items.
+
+- [ ] `scripts/lib/system.sh` lines 383,384,394,396,436,438,464,466,488,489,502,503,524,526,543,548 — add `# shellcheck disable=SC2016` above each affected `bash -c '...'` block (14 occurrences, intentional arg-passing pattern — do not change the code)
+- [ ] `scripts/lib/system.sh` line 837 — quote `$(lsb_release -is)` → `"$(lsb_release -is)"`
+- [ ] `scripts/lib/system.sh` line 857 — quote `$USER` → `"$USER"`
+- [ ] `scripts/lib/system.sh` line 944 — quote `$HELM_GLOBAL_ARGS` → `"${HELM_GLOBAL_ARGS}"`
+- [ ] `scripts/lib/system.sh` line 1635 — split `local cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"` into two lines: `local cur` then `cur="$(...)"`
+- [ ] `scripts/lib/system.sh` line 1669 — split `local cluster_ready=$(...)` into two lines
+- [ ] `scripts/lib/system.sh` line 1670 — split `local cluster_name=$(...)` into two lines
+
+**Forbidden:** Any change not listed above. Do not touch `core.sh`, CI, memory-bank in k3d-manager, or any other file.
+
+---
+
+## Expected Result
+
+### SC2016 — disable directive pattern (do not change the code itself)
+
+```bash
+# Before:
+_no_trace bash -c 'security delete-generic-password -s "$1" ...' _ "$service"
+
+# After:
+# shellcheck disable=SC2016
+_no_trace bash -c 'security delete-generic-password -s "$1" ...' _ "$service"
+```
+
+### SC2046 — line 837
+
+```bash
+# Before:
+_curl -fsSL https://download.docker.com/linux/$(lsb_release -is \
+
+# After:
+_curl -fsSL https://download.docker.com/linux/"$(lsb_release -is \
+```
+
+### SC2086 — line 857
+
+```bash
+# Before:
+_run_command -- sudo usermod -aG docker $USER
+
+# After:
+_run_command -- sudo usermod -aG docker "$USER"
+```
+
+### SC2086 — line 944
+
+```bash
+# Before:
+_run_command "${pre[@]}" --probe 'version --short' -- helm ${HELM_GLOBAL_ARGS} "$@"
+
+# After:
+_run_command "${pre[@]}" --probe 'version --short' -- helm "${HELM_GLOBAL_ARGS}" "$@"
+```
+
+### SC2155 — lines 1635, 1669, 1670
+
+```bash
+# Before:
+local cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"
+
+# After:
+local cur
+cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"
+```
+
+---
+
+## Verification
+
+```bash
+# Must exit 0 with no output
+shellcheck scripts/lib/system.sh
+echo "exit: $?"
+
+# Also verify core.sh still passes
+shellcheck scripts/lib/core.sh
+echo "exit: $?"
+```
+
+Push to `extract/v0.1.0`. CI runs on PR only — do not expect CI to run on push.
+Claude will open the PR once memory-bank reports completion.
+
+---
+
+## Completion Report (required)
+
+Update `memory-bank/activeContext.md` in lib-foundation on `extract/v0.1.0` with:
+
+```
+Task: system.sh shellcheck fix
+Status: COMPLETE / BLOCKED
+Files changed: scripts/lib/system.sh
+Shellcheck core.sh: PASS
+Shellcheck system.sh: PASS / [issues remaining]
+Unexpected findings: [anything outside task scope — report, do not fix]
+```

--- a/docs/plans/v0.6.5-gemini-agent-audit-bats.md
+++ b/docs/plans/v0.6.5-gemini-agent-audit-bats.md
@@ -1,0 +1,113 @@
+# v0.6.5 — Gemini Task: BATS tests for _agent_audit new checks
+
+## Context
+
+v0.6.4 hardened `_agent_audit` with two new mechanical checks (Codex):
+1. **Bare sudo detection** — flags `sudo` calls in diff that bypass `_run_command`
+2. **kubectl exec credential scan** — flags staged diffs with credential env vars in `kubectl exec` args
+
+The existing test at `agent_rigor.bats` line 89 only verifies exit 0 with no changes.
+These two new checks have no test coverage. A regex change could silently break detection.
+
+**Branch:** `k3d-manager-v0.6.5`
+**File to add tests to:** `scripts/tests/lib/agent_rigor.bats`
+
+---
+
+## Critical Rules
+
+1. **Add only new `@test` blocks after line 97. Do not modify any existing tests.**
+2. Do not modify `scripts/lib/agent_rigor.sh` or any other file.
+3. Each test must use a real mini git repo in `$BATS_TEST_TMPDIR` — do not stub `git diff`.
+4. Run all tests in a clean environment and report output.
+5. Commit your own work — self-commit is your sign-off.
+6. Update memory-bank to report completion (local commit is sufficient — Claude pushes).
+7. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+
+---
+
+## Change Checklist
+
+Tick each item as you complete it. Do not add items.
+
+- [ ] `scripts/tests/lib/agent_rigor.bats` after line 97 — add `@test "_agent_audit: flags bare sudo in unstaged diff"`
+- [ ] `scripts/tests/lib/agent_rigor.bats` after previous test — add `@test "_agent_audit: ignores _run_command sudo in diff"`
+- [ ] `scripts/tests/lib/agent_rigor.bats` after previous test — add `@test "_agent_audit: flags kubectl exec with credential env var in staged diff"`
+- [ ] `scripts/tests/lib/agent_rigor.bats` after previous test — add `@test "_agent_audit: passes clean staged diff"`
+
+**Forbidden:** Modifying existing tests, touching any `.sh` file, adding more than 4 `@test` blocks.
+
+---
+
+## Test Requirements
+
+### Git repo setup (required for all 4 tests)
+
+Each test must create a real git repo in `$BATS_TEST_TMPDIR`, commit a baseline `.sh` file,
+then apply changes to trigger (or not trigger) the audit check. The `_agent_audit` function
+calls `git diff` and `git diff --cached` directly — do not stub `git`.
+
+```bash
+# Pattern to use inside each @test:
+local repo="$BATS_TEST_TMPDIR/repo"
+git init "$repo"
+git -C "$repo" config user.email "test@test.com"
+git -C "$repo" config user.name "test"
+# create baseline file, commit it, then apply the test-specific change
+cd "$repo"
+```
+
+### Test 1 — bare sudo in unstaged diff (expect FAIL)
+
+The bare sudo check reads `git diff -- "$file"` (unstaged changes).
+Setup: commit a baseline `test.sh`, then append `sudo apt-get install -y curl` to it (do NOT stage).
+The `changed_sh` list comes from `git diff --name-only -- '*.sh'` — the file must be modified but unstaged.
+Expected: `_agent_audit` exits non-zero, output contains `"bare sudo call"`.
+
+### Test 2 — `_run_command` sudo ignored (expect PASS)
+
+Same setup but append `_run_command --prefer-sudo -- apt-get install -y curl` instead.
+Expected: `_agent_audit` exits 0 (no bare sudo detected).
+
+### Test 3 — kubectl exec with credential in staged diff (expect FAIL)
+
+The credential check reads `git diff --cached -- '*.sh'` (staged changes).
+Setup: commit a baseline `test.sh`, append `kubectl exec pod -- -e TOKEN=abc123 env`, then `git add` it (stage it).
+Expected: `_agent_audit` exits non-zero, output contains `"credential pattern detected"`.
+
+### Test 4 — clean staged diff (expect PASS)
+
+Setup: commit a baseline `test.sh`, append a harmless line `echo hello`, then `git add` it.
+Expected: `_agent_audit` exits 0.
+
+---
+
+## Verification
+
+```bash
+# Must run in clean environment
+env -i HOME="$HOME" PATH="$PATH" \
+  ./scripts/k3d-manager test agent_rigor 2>&1 | tail -15
+```
+
+Expected output: all tests pass including the 4 new ones.
+Total test count must increase from 5 to 9.
+
+**Also verify the existing 5 tests still pass — do not regress them.**
+
+---
+
+## Completion Report (required)
+
+Update `memory-bank/activeContext.md` on `k3d-manager-v0.6.5` with:
+
+```
+Task: BATS tests for _agent_audit bare sudo + kubectl exec checks
+Status: COMPLETE / BLOCKED
+Files changed: scripts/tests/lib/agent_rigor.bats
+Tests added: 4 (total suite: 9)
+Verification: [paste tail output of test run]
+Unexpected findings: [anything outside task scope — report, do not fix]
+```
+
+Note: local commit is sufficient. Claude handles push to remote.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -60,6 +60,10 @@ Owner
 - **NEVER run `git rebase`, `git reset --hard`, or `git push --force` on shared branches.**
 - Stay within task spec scope — do not add changes beyond what was specified, even if they seem like improvements. Unsanctioned scope expansion gets reverted.
 
+**Push rules by agent location:**
+- **Codex (M4 Air, same machine as Claude):** Commit locally + update memory-bank. Claude reviews local commit and handles push + PR.
+- **Gemini (Ubuntu VM):** Must push to remote — Claude cannot see Ubuntu-local commits. Always push before updating memory-bank.
+
 **Claude awareness — Gemini works on Ubuntu VM:**
 - Gemini commits directly to the active branch from the Ubuntu VM repo clone.
 - Always `git pull origin <branch>` before reading or editing any file Gemini may have touched.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,7 +16,7 @@
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
 | 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ✅ done — shellcheck fixed, PR #1 open on lib-foundation, CI green |
-| 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | **active** — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
+| 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | ✅ done — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
 
 ---
 
@@ -88,6 +88,18 @@ Agent  → memory-bank   (report: task complete, what changed, what was unexpect
 Claude reads           (review: detect gaps, inaccuracies, overclaiming)
 Claude → memory-bank   (instruct: corrections + next task spec)
 Agent reads + acts
+```
+
+### Completion Report — Codex (2026-03-07)
+
+```
+Task: awk → pure bash rewrite in _agent_audit
+Status: COMPLETE
+Files changed: scripts/lib/agent_rigor.sh
+Shellcheck: PASS
+Pre-commit: PASS (no awk error)
+BATS agent_rigor: 5/5 passing
+Unexpected findings: none
 ```
 
 **Lessons learned:**

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -139,7 +139,7 @@ Agent reads + acts
 
 ## Codex Backlog (needs task spec)
 
-- [ ] Fix `_agent_audit` awk user-defined function — fails on macOS BSD awk, noisy on every commit. See `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Recommended fix: rewrite without user-defined function (Option A).
+- [ ] Fix `_agent_audit` awk user-defined function — fails on macOS BSD awk, noisy on every commit. See `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Recommended fix: pure bash `while read` rewrite — no external tool, bash 3.2+ compatible (core must not use bash 4.0+ features).
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
+| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | **active** — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
 | 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ✅ done — shellcheck fixed, PR #1 open on lib-foundation, CI green |
 | 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | ✅ done — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
@@ -90,17 +90,40 @@ Claude → memory-bank   (instruct: corrections + next task spec)
 Agent reads + acts
 ```
 
-### Completion Report — Codex (2026-03-07)
+### Completion Report — Codex Task 4 (2026-03-07)
 
 ```
 Task: awk → pure bash rewrite in _agent_audit
-Status: COMPLETE
-Files changed: scripts/lib/agent_rigor.sh
-Shellcheck: PASS
+Status: COMPLETE — commit 6b14539
+Files changed: scripts/lib/agent_rigor.sh (lines 112–132 only)
+Shellcheck: PASS (Claude verified)
 Pre-commit: PASS (no awk error)
-BATS agent_rigor: 5/5 passing
+BATS agent_rigor: 5/5 passing (Codex reported — Gemini to re-verify)
 Unexpected findings: none
 ```
+
+---
+
+## Gemini — Active Task
+
+**Task 1: Add BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan**
+
+Spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md`
+
+Summary:
+- Add 4 new `@test` blocks to `scripts/tests/lib/agent_rigor.bats` after line 97
+- Do NOT modify any existing tests or any `.sh` file
+- Each test uses a real mini git repo in `$BATS_TEST_TMPDIR` — no stubbing `git diff`
+- Tests: bare sudo positive, `_run_command` negative, kubectl exec credential positive, clean diff negative
+- Expected total: 5 existing + 4 new = **9 tests passing**
+
+Verify with clean environment (required before reporting complete):
+```bash
+env -i HOME="$HOME" PATH="$PATH" \
+  ./scripts/k3d-manager test agent_rigor 2>&1 | tail -15
+```
+
+**Push to `origin/k3d-manager-v0.6.5` before updating memory-bank.**
 
 **Lessons learned:**
 - Gemini may write stale memory-bank content — Claude reviews every update before writing next task.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,43 +1,21 @@
 # Active Context – k3d-manager
 
-## Current Branch: `k3d-manager-v0.6.4` (as of 2026-03-07)
+## Current Branch: `k3d-manager-v0.6.5` (as of 2026-03-07)
 
-**v0.6.3 SHIPPED** — tag `v0.6.3` pushed, PR #21 merged. See CHANGE.md.
-**v0.6.4 active** — branch cut from `main`.
+**v0.6.4 SHIPPED** — tag `v0.6.4` pushed, PR #22 merged. See CHANGE.md.
+**v0.6.5 active** — branch cut from `main`.
 
 ---
 
 ## Current Focus
 
-**v0.6.4: Linux k3s Validation + lib-foundation Extraction**
+**v0.6.5: BATS audit test coverage + lib-foundation extraction**
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | Linux k3s validation — 5-phase teardown/rebuild on Ubuntu VM (`CLUSTER_PROVIDER=k3s`) | Gemini | ✅ done |
-| 1a | Fix `_install_bats_from_source` default `1.10.0` → `1.11.0` + re-run Phase 5 | Gemini | ✅ done |
-| 2 | `_agent_audit` hardening — bare sudo detection + credential pattern check | Codex | ✅ done |
-| 3 | Pre-commit hook — wire `_agent_audit` to run on every commit | Codex | ✅ done |
-| 4 | Contract BATS tests — provider interface enforcement | Gemini | ✅ done |
-| 5 | Create `lib-foundation` repository | Owner | pending |
-| 6 | Extract `core.sh` + `system.sh` via git subtree | Codex | pending |
-
-## All Agent Tasks Complete — Pending Owner Action
-
-**Claude review of Codex provider_contract fix — PASS:**
-- `provider_contract.bats` setup(): `SCRIPT_DIR` export added — correct fix ✅
-- `orbstack.sh`: added `_provider_orbstack_expose_ingress` — scope expansion accepted.
-  Contract test revealed genuinely missing function. Codex fixed inline rather than
-  filing another task. Implementation follows correct delegate pattern. ✅
-- Verified: 30/30 in clean `env -i` environment. Full suite 154/154 in normal env.
-
-**v0.6.4 agent tasks — all complete:**
-- Task 1+1a: Linux k3s validation + BATS fix (Gemini) ✅
-- Task 2+3: `_agent_audit` hardening + pre-commit hook (Codex) ✅
-- Task 4: Contract BATS tests 30/30 (Gemini + Codex fix) ✅
-
-**Remaining — owner actions only:**
-- Task 5: Create `lib-foundation` repository
-- Task 6: Extract `core.sh` + `system.sh` via git subtree (Codex — blocked on task 5)
+| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
+| 2 | Create `lib-foundation` repository | Owner | pending |
+| 3 | Extract `core.sh` + `system.sh` via git subtree | Codex | blocked on task 2 |
 
 ---
 
@@ -47,7 +25,7 @@
 2. **Checkpointing**: Git commit before every surgical operation.
 3. **Audit Phase**: Verify no tests weakened after every fix cycle.
 4. **Simplification**: Refactor for minimal logic before final verification.
-5. **Memory-bank compression**: Compress memory-bank at the *start* of the new branch, before the first agent task. Completed release details → single line in "Released" section + CHANGE.md. Reason: end of release the context is still live and needed; start of new branch it is history — compress before any agent loads stale data.
+5. **Memory-bank compression**: Compress memory-bank at the *start* of the new branch, before the first agent task.
 
 ---
 
@@ -79,12 +57,12 @@ Owner
 - Update memory-bank to report completion — this is how you communicate back to Claude.
 - No credentials in task specs or reports — reference env var names only (`$VAULT_ADDR`).
 - Run `shellcheck` on every touched `.sh` file and report output.
-- **NEVER run `git rebase`, `git reset --hard`, or `git push --force` on shared branches.** These rewrite history and break other agents' local copies. Commit forward only.
+- **NEVER run `git rebase`, `git reset --hard`, or `git push --force` on shared branches.**
 - Stay within task spec scope — do not add changes beyond what was specified, even if they seem like improvements. Unsanctioned scope expansion gets reverted.
 
 **Claude awareness — Gemini works on Ubuntu VM:**
-- Gemini commits directly to `k3d-manager-v0.6.4` from the Ubuntu VM repo clone.
-- Always `git pull origin k3d-manager-v0.6.4` before reading or editing any file Gemini may have touched.
+- Gemini commits directly to the active branch from the Ubuntu VM repo clone.
+- Always `git pull origin <branch>` before reading or editing any file Gemini may have touched.
 - Conflicts are possible if Claude and Gemini both push to the same branch concurrently.
 
 **Red Team scope (Gemini):**
@@ -93,12 +71,10 @@ Owner
 - Do NOT modify production code.
 
 **Gemini BATS verification rule:**
-- Always run tests in a clean environment — never in an interactive shell with residual state:
+- Always run tests in a clean environment:
   ```bash
   env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test <suite> 2>&1 | tail -10
   ```
-- `SCRIPT_DIR`, `CLUSTER_PROVIDER`, and other k3d-manager vars set in your shell make tests
-  pass that would fail in CI or on another machine. Clean env catches this.
 - Never report a test as passing unless it passed in a clean environment.
 
 **Memory-bank flow:**
@@ -111,11 +87,10 @@ Agent reads + acts
 
 **Lessons learned:**
 - Gemini may write stale memory-bank content — Claude reviews every update before writing next task.
-- Gemini expands scope beyond task spec — spec must explicitly state what is forbidden, not just what is required.
-- Gemini ran `git rebase -i` on a shared branch and left it in a conflicted state — destructive git ops now explicitly forbidden in agent rules.
-- Gemini pushed scope-expanded URL change despite "two lines only" spec — accepted this time (tested, 124/124 BATS pass on Ubuntu). Future violations get reverted regardless of outcome.
-- Gemini over-reports test success when shell has residual env vars (`SCRIPT_DIR` etc.) — always verify with `env -i` clean environment. Contract BATS tests reported 30/30 on Ubuntu; actual result 10/30 in clean env.
-- PR sub-branches from Copilot agent (e.g. `copilot/sub-pr-*`) may conflict — evaluate and close if our implementation is superior.
+- Gemini expands scope beyond task spec — spec must explicitly state what is forbidden.
+- Gemini ran `git rebase -i` on a shared branch — destructive git ops explicitly forbidden.
+- Gemini over-reports test success with ambient env vars — always verify with `env -i` clean environment.
+- PR sub-branches from Copilot agent may conflict — evaluate and close if our implementation is superior.
 
 ---
 
@@ -123,25 +98,24 @@ Agent reads + acts
 
 ### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-cluster`)
 
-| Component | Status | Notes |
-|---|---|---|
-| Vault | Running | `secrets` ns, initialized + unsealed |
-| ESO | Running | `secrets` ns |
-| OpenLDAP | Running | `identity` ns |
-| Istio | Running | `istio-system` |
-| Jenkins | Running | `cicd` ns |
-| ArgoCD | Running | `cicd` ns |
-| Keycloak | Running | `identity` ns |
+| Component | Status |
+|---|---|
+| Vault | Running — `secrets` ns, initialized + unsealed |
+| ESO | Running — `secrets` ns |
+| OpenLDAP | Running — `identity` ns |
+| Istio | Running — `istio-system` |
+| Jenkins | Running — `cicd` ns |
+| ArgoCD | Running — `cicd` ns |
+| Keycloak | Running — `identity` ns |
 
 ### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`)
 
-| Component | Status | Notes |
-|---|---|---|
-| k3s node | Ready | v1.34.4+k3s1 |
-| Istio | Running | IngressGateway + istiod |
-| ESO | Pending | Deploy after infra work stabilizes |
-| shopping-cart-data | Pending | PostgreSQL, Redis, RabbitMQ |
-| shopping-cart-apps | Pending | basket, order, payment, catalog, frontend |
+| Component | Status |
+|---|---|
+| k3s node | Ready — v1.34.4+k3s1 |
+| Istio | Running |
+| ESO | Pending |
+| shopping-cart-data / apps | Pending |
 
 **SSH note:** `ForwardAgent yes` in `~/.ssh/config`. Stale socket fix: `ssh -O exit ubuntu`.
 
@@ -151,8 +125,8 @@ Agent reads + acts
 
 | Version | Status | Notes |
 |---|---|---|
-| v0.1.0–v0.6.3 | released | See CHANGE.md |
-| v0.6.4 | **active** | Linux k3s validation gate + lib-foundation extraction |
+| v0.1.0–v0.6.4 | released | See CHANGE.md |
+| v0.6.5 | **active** | BATS audit coverage + lib-foundation extraction |
 | v0.7.0 | planned | Keycloak provider + App Cluster deployment |
 | v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
 | v1.0.0 | vision | Reassess after v0.7.0 |
@@ -161,11 +135,13 @@ Agent reads + acts
 
 ## Open Items
 
+- [ ] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini)
+- [ ] Create `lib-foundation` repository (owner)
+- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex — blocked on above)
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
-- [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner action)
-- [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster` — see `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`
-- [ ] `scripts/tests/plugins/jenkins.bats` — backlog
+- [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)
+- [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster`
 - [ ] v0.7.0: Keycloak provider interface + App Cluster deployment
 - [ ] v0.8.0: `k3dm-mcp` lean MCP server
 
@@ -175,13 +151,12 @@ Agent reads + acts
 
 - **Always run `reunseal_vault`** after any cluster restart before other deployments
 - **ESO SecretStore**: `mountPath` must be `kubernetes` (not `auth/kubernetes`)
-- **New namespace defaults**: `secrets`, `identity`, `cicd`
 - **Branch protection**: `enforce_admins` permanently disabled — owner can self-merge
 - **Istio + Jobs**: `sidecar.istio.io/inject: "false"` required on Helm pre-install job pods
 - **Bitnami images**: use `docker.io/bitnamilegacy/*` for ARM64
 
 ### Keycloak Known Failure Patterns
 
-1. **Istio sidecar blocks `keycloak-config-cli` job** — mitigated via `sidecar.istio.io/inject: "false"` in `values.yaml.tmpl`.
+1. **Istio sidecar blocks `keycloak-config-cli` job** — mitigated via `sidecar.istio.io/inject: "false"`.
 2. **ARM64 image pull failures** — use `docker.io/bitnamilegacy/*`.
 3. **Stale PVCs block retry** — delete `data-keycloak-postgresql-0` PVC in `identity` ns before retrying.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -137,9 +137,9 @@ Agent reads + acts
 
 ---
 
-## Codex Backlog (needs task spec)
+## Codex Backlog
 
-- [ ] Fix `_agent_audit` awk user-defined function — fails on macOS BSD awk, noisy on every commit. See `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Recommended fix: pure bash `while read` rewrite — no external tool, bash 3.2+ compatible (core must not use bash 4.0+ features).
+- [ ] Fix `_agent_audit` awk → pure bash rewrite — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md`, issue: `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Edit only `agent_rigor.sh` lines 112–132. Must be bash 3.2+ compatible — no `declare -A`, no `mapfile`.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -15,7 +15,7 @@
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
-| 3 | Extract `core.sh` + `system.sh` via git subtree | Codex | pending |
+| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | pending — target branch `extract/v0.1.0` on lib-foundation |
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -14,8 +14,8 @@
 | # | Task | Who | Status |
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
-| 2 | Create `lib-foundation` repository | Owner | pending |
-| 3 | Extract `core.sh` + `system.sh` via git subtree | Codex | blocked on task 2 |
+| 2 | Create `lib-foundation` repository | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
+| 3 | Extract `core.sh` + `system.sh` via git subtree | Codex | pending |
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -137,6 +137,12 @@ Agent reads + acts
 
 ---
 
+## Codex Backlog (needs task spec)
+
+- [ ] Fix `_agent_audit` awk user-defined function — fails on macOS BSD awk, noisy on every commit. See `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Recommended fix: rewrite without user-defined function (Option A).
+
+---
+
 ## Open Items
 
 - [ ] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -15,7 +15,8 @@
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
-| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ⚠️ blocked — `core.sh` ✅, `system.sh` shellcheck fails (SC2016×14, SC2046, SC2086×2, SC2155×3). See `docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md` |
+| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ✅ done — shellcheck fixed, PR #1 open on lib-foundation, CI green |
+| 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | **active** — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
 
 ---
 
@@ -137,17 +138,11 @@ Agent reads + acts
 
 ---
 
-## Codex Backlog
-
-- [ ] Fix `_agent_audit` awk → pure bash rewrite — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md`, issue: `docs/issues/2026-03-07-agent-audit-awk-macos-compat.md`. Edit only `agent_rigor.sh` lines 112–132. Must be bash 3.2+ compatible — no `declare -A`, no `mapfile`.
-
----
-
 ## Open Items
 
 - [ ] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini)
-- [ ] Create `lib-foundation` repository (owner)
-- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex — blocked on above)
+- [x] Create `lib-foundation` repository (owner) — ✅ done
+- [x] Extract `core.sh` + `system.sh` via git subtree (Codex) — ✅ done, PR #1 open on lib-foundation
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -15,7 +15,7 @@
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
-| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | pending — target branch `extract/v0.1.0` on lib-foundation |
+| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | pending — spec: `docs/plans/v0.6.5-codex-lib-foundation-extraction.md`, target branch `extract/v0.1.0` on lib-foundation |
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
+| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
 | 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ⚠️ blocked — `core.sh` ✅, `system.sh` shellcheck fails (SC2016×14, SC2046, SC2086×2, SC2155×3). See `docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md` |
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -152,7 +152,7 @@ Agent reads + acts
 
 ## Open Items
 
-- [ ] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini)
+- [x] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini) — ✅ done
 - [x] Create `lib-foundation` repository (owner) — ✅ done
 - [x] Extract `core.sh` + `system.sh` via git subtree (Codex) — ✅ done, PR #1 open on lib-foundation
 - [ ] ESO deploy on Ubuntu app cluster

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -14,7 +14,7 @@
 | # | Task | Who | Status |
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
-| 2 | Create `lib-foundation` repository | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
+| 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
 | 3 | Extract `core.sh` + `system.sh` via git subtree | Codex | pending |
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | **active** — spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md` |
+| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | ✅ done — 4 tests, suite 9/9, total 158/158 |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
 | 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ✅ done — shellcheck fixed, PR #1 open on lib-foundation, CI green |
 | 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | ✅ done — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
@@ -90,40 +90,17 @@ Claude → memory-bank   (instruct: corrections + next task spec)
 Agent reads + acts
 ```
 
-### Completion Report — Codex Task 4 (2026-03-07)
+### Completion Reports (2026-03-07)
 
-```
-Task: awk → pure bash rewrite in _agent_audit
-Status: COMPLETE — commit 6b14539
-Files changed: scripts/lib/agent_rigor.sh (lines 112–132 only)
-Shellcheck: PASS (Claude verified)
-Pre-commit: PASS (no awk error)
-BATS agent_rigor: 5/5 passing (Codex reported — Gemini to re-verify)
-Unexpected findings: none
-```
+**Codex Task 4 — awk → pure bash rewrite in `_agent_audit`:**
+- commit `6b14539` — `agent_rigor.sh` lines 112–132 only
+- shellcheck PASS (Claude verified), no bash 4.0+ features
+- BATS agent_rigor: 5/5 (Codex) → re-verified 9/9 by Gemini
 
----
-
-## Gemini — Active Task
-
-**Task 1: Add BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan**
-
-Spec: `docs/plans/v0.6.5-gemini-agent-audit-bats.md`
-
-Summary:
-- Add 4 new `@test` blocks to `scripts/tests/lib/agent_rigor.bats` after line 97
-- Do NOT modify any existing tests or any `.sh` file
-- Each test uses a real mini git repo in `$BATS_TEST_TMPDIR` — no stubbing `git diff`
-- Tests: bare sudo positive, `_run_command` negative, kubectl exec credential positive, clean diff negative
-- Expected total: 5 existing + 4 new = **9 tests passing**
-
-Verify with clean environment (required before reporting complete):
-```bash
-env -i HOME="$HOME" PATH="$PATH" \
-  ./scripts/k3d-manager test agent_rigor 2>&1 | tail -15
-```
-
-**Push to `origin/k3d-manager-v0.6.5` before updating memory-bank.**
+**Gemini Task 1 — BATS tests for bare sudo + kubectl exec credential scan:**
+- commit `5f04814` — `scripts/tests/lib/agent_rigor.bats` only
+- 4 tests added (ok 6–9), real git repo per test, no git stubs
+- Total suite: 9/9 agent_rigor, 158/158 full BATS (clean env, Ubuntu VM)
 
 **Lessons learned:**
 - Gemini may write stale memory-bank content — Claude reviews every update before writing next task.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -15,7 +15,7 @@
 |---|---|---|---|
 | 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | pending |
 | 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
-| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | pending — spec: `docs/plans/v0.6.5-codex-lib-foundation-extraction.md`, target branch `extract/v0.1.0` on lib-foundation |
+| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ⚠️ blocked — `core.sh` ✅, `system.sh` shellcheck fails (SC2016×14, SC2046, SC2086×2, SC2155×3). See `docs/issues/2026-03-07-lib-foundation-shellcheck-failures.md` |
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -40,8 +40,8 @@
 ### Priority 1 — v0.6.5 (active)
 
 - [ ] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini)
-- [ ] Create `lib-foundation` repository (owner)
-- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex — blocked on above)
+- [x] Create `lib-foundation` repository (owner) — https://github.com/wilddog64/lib-foundation
+- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex)
 
 ### Priority 2 — v0.7.0
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -31,7 +31,9 @@
 - [x] Provider contract BATS suite — 30 tests (3 providers × 10 functions)
 - [x] `_provider_orbstack_expose_ingress` missing function added
 - [x] Copilot P1/P2 fixes — `git diff --cached`, diff-based sudo scan, `\b` pattern
-- [x] BATS suite: 154/154 passing
+- [x] BATS suite: 154/154 passing (v0.6.4)
+- [x] `_agent_audit` awk → pure bash rewrite (bash 3.2+, no macOS BSD awk dependency)
+- [x] BATS tests for `_agent_audit` bare sudo + kubectl exec — 4 new tests, suite 9/9, total 158/158
 
 ---
 
@@ -39,9 +41,9 @@
 
 ### Priority 1 — v0.6.5 (active)
 
-- [ ] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini)
-- [x] Create `lib-foundation` repository + branch protection + CI (owner) — https://github.com/wilddog64/lib-foundation
-- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex)
+- [x] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini) ✅
+- [x] Create `lib-foundation` repository + branch protection + CI (owner) ✅
+- [x] Extract `core.sh` + `system.sh` into lib-foundation (Codex) — PR #1 open, CI green
 
 ### Priority 2 — v0.7.0
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,14 +2,14 @@
 
 ## Overall Status
 
-**v0.6.3 SHIPPED** — tag `v0.6.3` pushed, PR #21 merged 2026-03-07.
-**v0.6.4 ACTIVE** — branch `k3d-manager-v0.6.4` cut from main 2026-03-07.
+**v0.6.4 SHIPPED** — tag `v0.6.4` pushed, PR #22 merged 2026-03-07.
+**v0.6.5 ACTIVE** — branch `k3d-manager-v0.6.5` cut from main 2026-03-07.
 
 ---
 
 ## What Is Complete
 
-### Released (v0.1.0 – v0.6.3)
+### Released (v0.1.0 – v0.6.4)
 
 - [x] k3d/OrbStack/k3s cluster provider abstraction
 - [x] Vault PKI, ESO, Istio, Jenkins, OpenLDAP, ArgoCD, Keycloak (infra cluster)
@@ -21,33 +21,34 @@
 - [x] `_k3d_manager_copilot` scoped wrapper (8-fragment deny list, `K3DM_ENABLE_AI` gate)
 - [x] `_safe_path` / `_is_world_writable_dir` PATH poisoning defense
 - [x] VAULT_TOKEN stdin injection in `ldap-password-rotator.sh`
-- [x] Permission cascade elimination in `core.sh` — single `_run_command --prefer-sudo`
-- [x] `_detect_platform` — single source of truth for OS detection in `system.sh`
-- [x] `_run_command` TTY flakiness fix — `auto_interactive` block removed
-- [x] `.github/copilot-instructions.md` — shaped Copilot PR reviews
-- [x] BATS suites: 124/124 passing
+- [x] Permission cascade elimination in `core.sh`
+- [x] `_detect_platform` — single source of truth for OS detection
+- [x] `_run_command` TTY flakiness fix
+- [x] Linux k3s gate — 5-phase teardown/rebuild on Ubuntu 24.04 VM
+- [x] BATS source install 404 fix — 1.10.0 → 1.13.0, archive URL
+- [x] `_agent_audit` hardening — bare sudo detection + kubectl exec credential scan
+- [x] Pre-commit hook — `_agent_audit` wired to every commit
+- [x] Provider contract BATS suite — 30 tests (3 providers × 10 functions)
+- [x] `_provider_orbstack_expose_ingress` missing function added
+- [x] Copilot P1/P2 fixes — `git diff --cached`, diff-based sudo scan, `\b` pattern
+- [x] BATS suite: 154/154 passing
 
 ---
 
 ## What Is Pending
 
-### Priority 1 — v0.6.4 (active)
+### Priority 1 — v0.6.5 (active)
 
-- [x] Linux k3s validation gate — Gemini full 5-phase teardown/rebuild on Ubuntu VM (124/124 BATS pass, Smoke tests PASS)
-- [x] Fix `_install_bats_from_source` default `1.10.0` → `1.11.0` + robust URL (Gemini)
-- [x] `_agent_audit` hardening — bare sudo detection + credential pattern check in `kubectl exec` args (Codex)
-- [x] Pre-commit hook — wire `_agent_audit` to `.git/hooks/pre-commit` (Codex)
-- [x] Contract BATS tests — provider interface enforcement (Gemini) (154/154 pass)
-- [x] Provider contract regression fix — export `SCRIPT_DIR` in BATS `setup()` and add `_provider_orbstack_expose_ingress` delegate (Codex, 30/30 provider_contract)
-- [ ] Create `lib-foundation` repository (owner action)
-- [ ] Extract `core.sh` and `system.sh` via git subtree (Codex)
+- [ ] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini)
+- [ ] Create `lib-foundation` repository (owner)
+- [ ] Extract `core.sh` + `system.sh` via git subtree (Codex — blocked on above)
 
 ### Priority 2 — v0.7.0
 
-- [ ] ESO deploy on Ubuntu app cluster (SSH)
+- [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) on Ubuntu
 - [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) on Ubuntu
-- [ ] Rename infra cluster to `infra`; fix `CLUSTER_NAME` env var
+- [ ] `CLUSTER_NAME` env var respected during `deploy_cluster`
 - [ ] Keycloak provider interface
 
 ### Priority 3 — v0.8.0
@@ -62,7 +63,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | False positive — IPs in docs. Mark in dashboard. |
+| GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | False positive — mark in dashboard. |
 | `CLUSTER_NAME` env var ignored during `deploy_cluster` | OPEN | See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
 | `deploy_jenkins` (no flags) broken | OPEN | Use `--enable-vault` as workaround. |
 | No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | Future work. |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -40,7 +40,7 @@
 ### Priority 1 — v0.6.5 (active)
 
 - [ ] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini)
-- [x] Create `lib-foundation` repository (owner) — https://github.com/wilddog64/lib-foundation
+- [x] Create `lib-foundation` repository + branch protection + CI (owner) — https://github.com/wilddog64/lib-foundation
 - [ ] Extract `core.sh` + `system.sh` via git subtree (Codex)
 
 ### Priority 2 — v0.7.0

--- a/scripts/lib/agent_rigor.sh
+++ b/scripts/lib/agent_rigor.sh
@@ -109,27 +109,25 @@ function _agent_audit() {
       for file in $changed_sh; do
          [[ -f "$file" ]] || continue
          local offenders
-         offenders=$(awk -v max_if="$max_if" '
-            function emit(func,count){
-              if(func != "" && count > max_if){printf "%s:%d\n", func, count}
-            }
-            /^[ \t]*function[ \t]+/ {
-              line=$0
-              gsub(/^[ \t]*function[ \t]+/, "", line)
-              func=line
-              gsub(/\(.*/, "", func)
-              emit(current_func, if_count)
-              current_func=func
-              if_count=0
-              next
-            }
-            /^[[:space:]]*if[[:space:](]/ {
-              if_count++
-            }
-            END {
-              emit(current_func, if_count)
-            }
-         ' "$file")
+         local current_func="" if_count=0 line
+         local offenders_lines=""
+         while IFS= read -r line; do
+            if [[ $line =~ ^[[:space:]]*function[[:space:]]+([A-Za-z0-9_]+) ]]; then
+               if [[ -n "$current_func" && $if_count -gt $max_if ]]; then
+                  offenders_lines+="${current_func}:${if_count}"$'\n'
+               fi
+               current_func="${BASH_REMATCH[1]}"
+               if_count=0
+            elif [[ $line =~ ^[[:space:]]*if[[:space:]\(] ]]; then
+               ((if_count++))
+            fi
+         done < "$file"
+
+         if [[ -n "$current_func" && $if_count -gt $max_if ]]; then
+            offenders_lines+="${current_func}:${if_count}"$'\n'
+         fi
+
+         offenders="${offenders_lines%$'\n'}"
 
          if [[ -n "$offenders" ]]; then
             _warn "Agent audit: $file exceeds if-count threshold in: $offenders"

--- a/scripts/lib/agent_rigor.sh
+++ b/scripts/lib/agent_rigor.sh
@@ -112,14 +112,16 @@ function _agent_audit() {
          local current_func="" if_count=0 line
          local offenders_lines=""
          while IFS= read -r line; do
-            if [[ $line =~ ^[[:space:]]*function[[:space:]]+([A-Za-z0-9_]+) ]]; then
+            if [[ $line =~ ^[[:space:]]*function[[:space:]]+ ]]; then
                if [[ -n "$current_func" && $if_count -gt $max_if ]]; then
                   offenders_lines+="${current_func}:${if_count}"$'\n'
                fi
-               current_func="${BASH_REMATCH[1]}"
+               current_func="${line#*function }"
+               current_func="${current_func%%(*}"
+               current_func="${current_func//[[:space:]]/}"
                if_count=0
             elif [[ $line =~ ^[[:space:]]*if[[:space:]\(] ]]; then
-               ((if_count++))
+               ((++if_count))
             fi
          done < "$file"
 
@@ -157,7 +159,7 @@ function _agent_audit() {
    local diff_sh
    diff_sh="$(git diff --cached -- '*.sh' 2>/dev/null || true)"
    if [[ -n "$diff_sh" ]]; then
-      if grep -qE '^\+.*kubectl exec.*(-e |--env).*(TOKEN|PASSWORD|SECRET|KEY)' <<<"$diff_sh"; then
+      if grep -qE '^\+.*kubectl exec.*(TOKEN|PASSWORD|SECRET|KEY)=' <<<"$diff_sh"; then
          _warn "Agent audit: credential pattern detected in kubectl exec args — use Vault/ESO instead"
          status=1
       fi

--- a/scripts/lib/system.sh
+++ b/scripts/lib/system.sh
@@ -1628,7 +1628,8 @@ function _ensure_cargo() {
 
 function _add_exit_trap() {
    local handler="$1"
-   local cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"
+   local cur
+   cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"
 
    if [[ -n "$cur" ]]; then
       trap '"$cur"; "$handler"' EXIT
@@ -1656,14 +1657,16 @@ function _failfast_off() {
 }
 
 function _detect_cluster_name() {
-   # shellcheck disable=SC2155
-   local cluster_info="$(_kubectl --quiet -- get nodes | tail -1)"
+   local cluster_info
+   cluster_info="$(_kubectl --quiet -- get nodes | tail -1)"
 
    if [[ -z "$cluster_info" ]]; then
       _err "Cannot detect cluster name: no nodes found"
    fi
-   local cluster_ready=$(echo "$cluster_info" | awk '{print $2}')
-   local cluster_name=$(echo "$cluster_info" | awk '{print $1}')
+   local cluster_ready
+   cluster_ready=$(echo "$cluster_info" | awk '{print $2}')
+   local cluster_name
+   cluster_name=$(echo "$cluster_info" | awk '{print $1}')
 
    if [[ "$cluster_ready" != "Ready" ]]; then
       _err "Cluster node is not ready: $cluster_info"

--- a/scripts/tests/lib/agent_rigor.bats
+++ b/scripts/tests/lib/agent_rigor.bats
@@ -95,3 +95,88 @@ setup() {
   run _agent_audit
   [ "$status" -eq 0 ]
 }
+
+@test "_agent_audit: flags bare sudo in unstaged diff" {
+  local repo="$BATS_TEST_TMPDIR/repo_sudo"
+  git init "$repo"
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "test"
+  
+  cd "$repo"
+  echo "#!/bin/bash" > test.sh
+  git add test.sh
+  git commit -m "initial"
+  
+  echo "sudo apt-get install -y curl" >> test.sh
+  
+  # Stub _k3dm_repo_root to point to our test repo
+  _k3dm_repo_root() { echo "$repo"; }
+  export -f _k3dm_repo_root
+  
+  run _agent_audit
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"bare sudo call"* ]]
+}
+
+@test "_agent_audit: ignores _run_command sudo in diff" {
+  local repo="$BATS_TEST_TMPDIR/repo_run_cmd"
+  git init "$repo"
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "test"
+  
+  cd "$repo"
+  echo "#!/bin/bash" > test.sh
+  git add test.sh
+  git commit -m "initial"
+  
+  echo "_run_command --prefer-sudo -- apt-get install -y curl" >> test.sh
+  
+  _k3dm_repo_root() { echo "$repo"; }
+  export -f _k3dm_repo_root
+  
+  run _agent_audit
+  [ "$status" -eq 0 ]
+}
+
+@test "_agent_audit: flags kubectl exec with credential env var in staged diff" {
+  local repo="$BATS_TEST_TMPDIR/repo_cred"
+  git init "$repo"
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "test"
+  
+  cd "$repo"
+  echo "#!/bin/bash" > test.sh
+  git add test.sh
+  git commit -m "initial"
+  
+  echo "kubectl exec pod -- -e TOKEN=abc123 env" >> test.sh
+  git add test.sh
+  
+  _k3dm_repo_root() { echo "$repo"; }
+  export -f _k3dm_repo_root
+  
+  run _agent_audit
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"credential pattern detected"* ]]
+}
+
+@test "_agent_audit: passes clean staged diff" {
+  local repo="$BATS_TEST_TMPDIR/repo_clean"
+  git init "$repo"
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "test"
+  
+  cd "$repo"
+  echo "#!/bin/bash" > test.sh
+  git add test.sh
+  git commit -m "initial"
+  
+  echo "echo hello" >> test.sh
+  git add test.sh
+  
+  _k3dm_repo_root() { echo "$repo"; }
+  export -f _k3dm_repo_root
+  
+  run _agent_audit
+  [ "$status" -eq 0 ]
+}

--- a/scripts/tests/lib/agent_rigor.bats
+++ b/scripts/tests/lib/agent_rigor.bats
@@ -108,11 +108,7 @@ setup() {
   git commit -m "initial"
   
   echo "sudo apt-get install -y curl" >> test.sh
-  
-  # Stub _k3dm_repo_root to point to our test repo
-  _k3dm_repo_root() { echo "$repo"; }
-  export -f _k3dm_repo_root
-  
+
   run _agent_audit
   [ "$status" -ne 0 ]
   [[ "$output" == *"bare sudo call"* ]]
@@ -130,10 +126,7 @@ setup() {
   git commit -m "initial"
   
   echo "_run_command --prefer-sudo -- apt-get install -y curl" >> test.sh
-  
-  _k3dm_repo_root() { echo "$repo"; }
-  export -f _k3dm_repo_root
-  
+
   run _agent_audit
   [ "$status" -eq 0 ]
 }
@@ -149,12 +142,9 @@ setup() {
   git add test.sh
   git commit -m "initial"
   
-  echo "kubectl exec pod -- -e TOKEN=abc123 env" >> test.sh
+  echo "kubectl exec pod -- env TOKEN=abc123 sh" >> test.sh
   git add test.sh
-  
-  _k3dm_repo_root() { echo "$repo"; }
-  export -f _k3dm_repo_root
-  
+
   run _agent_audit
   [ "$status" -ne 0 ]
   [[ "$output" == *"credential pattern detected"* ]]
@@ -173,10 +163,7 @@ setup() {
   
   echo "echo hello" >> test.sh
   git add test.sh
-  
-  _k3dm_repo_root() { echo "$repo"; }
-  export -f _k3dm_repo_root
-  
+
   run _agent_audit
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

- **Fix**: `_agent_audit` awk portability — replace BSD-awk-incompatible user-defined function with pure bash `while read` loop (bash 3.0+, no external dependency)
- **Add**: 4 new BATS tests for `_agent_audit` bare sudo + kubectl exec credential checks — real git repos, no stubs. Suite: 9/9. Full BATS: 158/158
- **Infra**: `lib-foundation` repo created (https://github.com/wilddog64/lib-foundation) with CI + branch protection. `core.sh` + `system.sh` extracted, PR #1 open, CI green

## Test plan

- [x] shellcheck PASS on all touched `.sh` files
- [x] BATS suite 158/158 passing — clean `env -i` environment, Ubuntu 24.04 VM
- [x] Pre-commit hook: no awk error on macOS M-series (BSD awk 20200816)
- [x] `_agent_audit` if-count check still flags functions exceeding threshold
- [x] New BATS tests (ok 6–9) cover both positive and negative cases

## Agent breakdown

| Task | Agent | Commit |
|---|---|---|
| awk → pure bash rewrite | Codex | `6b14539` |
| BATS tests for new audit checks | Gemini | `5f04814` |
| lib-foundation repo + CI | Owner | — |
| `core.sh` + `system.sh` extraction | Codex | lib-foundation PR #1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)