### PR TITLE
v0.7.0: lib-foundation subtree integration + deploy_cluster hardening

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,55 @@
+# .clinerules — lib-foundation
+
+Shared Bash foundation library consumed by k3d-manager, rigor-cli, and shopping-carts via git subtree.
+
+## Layout
+
+```
+scripts/lib/core.sh       — cluster lifecycle, provider abstraction
+scripts/lib/system.sh     — _run_command, _detect_platform, package helpers, BATS install
+scripts/tests/lib/        — BATS unit tests
+memory-bank/              — persistent agent context (read before any task)
+```
+
+## Before Any Task
+
+1. Read `memory-bank/activeContext.md` — branch, focus, open tasks
+2. Read `memory-bank/progress.md` — what is done, what is pending
+3. `git pull origin <current-branch>` — another agent may have pushed
+
+## Critical Rules
+
+- **No bare `sudo`** — always `_run_command --prefer-sudo` or `_run_command --require-sudo`
+- **Double-quote all variable expansions** — `"$var"`, never bare `$var` in command args
+- **`set -euo pipefail`** on all new scripts
+- **No eval with external input**
+- **Pin all versions** — no `latest` tags in images or Helm charts
+- **NEVER run `git rebase -i`, `git reset --hard`, or `git push --force`**
+
+## Key Contracts — Do Not Break
+
+`_run_command` mode flags: `--prefer-sudo`, `--require-sudo`, `--probe '<subcmd>'`, `--quiet`
+`_detect_platform` returns: `debian | rhel | arch | darwin | unknown`
+`_cluster_provider` reads: `CLUSTER_PROVIDER` / `K3D_MANAGER_PROVIDER` / `K3DMGR_PROVIDER`
+
+Changing these signatures requires coordination with all consumers (k3d-manager, rigor-cli, shopping-carts).
+
+## Testing
+
+```bash
+# Always run BATS in a clean environment
+env -i HOME="$HOME" PATH="$PATH" bats scripts/tests/lib/
+
+# shellcheck every touched .sh file
+shellcheck scripts/lib/core.sh scripts/lib/system.sh
+```
+
+Never report a test as passing if it was only run in an interactive shell where
+SCRIPT_DIR or CLUSTER_PROVIDER may already be set.
+
+## Commit Protocol
+
+- Self-commit your own work — your commit is your sign-off
+- Update `memory-bank/` to report task completion
+- Run shellcheck on every `.sh` file you touch and include the result in your report
+- Stay within the task spec — no unsanctioned changes, even improvements

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck
+        run: |
+          shfiles=$(find scripts/lib -name '*.sh' 2>/dev/null || true)
+          if [[ -z "$shfiles" ]]; then
+            echo "No .sh files found — skipping (pre-extraction)"
+            exit 0
+          fi
+          echo "$shfiles" | xargs shellcheck
+
+  bats:
+    name: bats
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install BATS 1.13.0
+        run: |
+          curl -fsSL \
+            https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz \
+            | tar -xz -C /tmp
+          sudo /tmp/bats-core-1.13.0/install.sh /usr/local
+
+      - name: Run BATS tests
+        run: |
+          testfiles=$(find scripts/tests/lib -name '*.bats' 2>/dev/null || true)
+          if [[ -z "$testfiles" ]]; then
+            echo "No .bats files found — skipping (pre-extraction)"
+            exit 0
+          fi
+          env -i HOME="$HOME" PATH="$PATH" bats scripts/tests/lib/

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,29 @@
 # Changes - k3d-manager
 
+## v0.7.0 — lib-foundation Subtree + deploy_cluster Hardening — dated 2026-03-07
+
+### Added
+- **lib-foundation git subtree** (`scripts/lib/foundation/`): Pulls `lib-foundation` main into the repo via `git subtree add --squash`. Dispatcher sources subtree copies of `core.sh` and `system.sh` first, falling back to local copies during transition.
+- **`_deploy_cluster_prompt_provider`** (`scripts/lib/core.sh`): Extracted helper — prompts user to select a cluster provider interactively.
+- **`_deploy_cluster_resolve_provider`** (`scripts/lib/core.sh`): Extracted helper — resolves provider from env var, positional arg, or interactive prompt.
+
+### Fixed
+- **`deploy_cluster` if-count violation** (`scripts/lib/core.sh`): Refactored from 12 to 5 `if` blocks after extracting provider helpers. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`.
+- **`CLUSTER_NAME` env var ignored** (`scripts/lib/core.sh`): When no positional cluster name is supplied, `deploy_cluster` now reads `$CLUSTER_NAME` from the environment and exports it before calling the provider. Verified via `_cluster_provider_call` stub test.
+- **ESO SecretStore `identity/vault-kv-store` unauthorized** (`scripts/plugins/vault.sh`): `_vault_configure_secret_reader_role` now binds `eso-ldap-directory` to both `directory` and `identity` namespaces. Previously only `directory` was bound, causing `InvalidProviderConfig` within minutes of deploy. Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`.
+- **`pushd`/`popd` unguarded in `_install_istioctl`** (`scripts/lib/core.sh`): Added `|| return` guards to both calls.
+
+### Validation
+- OrbStack macOS ARM64: 158/158 BATS, all services Running (Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak).
+- Ubuntu k3s Linux: 158/158 BATS, all services Ready.
+
+### Known Issues (deferred to v0.7.x backlog)
+- BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test, can block port 8000/8443 on next `deploy_cluster`. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`.
+- colima VM inotify limit not persistent across restarts. Manual fix: `colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=512`.
+- ESO + shopping-cart deployment on Ubuntu app cluster deferred to next milestone.
+
+---
+
 ## v0.6.5 — Agent Rigor Coverage + lib-foundation Extraction — dated 2026-03-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md — lib-foundation
+
+Shared Bash foundation library. Consumed by `k3d-manager`, `rigor-cli`, and `shopping-carts` via git subtree.
+
+## Layout
+
+```
+scripts/lib/
+  core.sh       # Cluster lifecycle: create/destroy/deploy, provider abstraction
+  system.sh     # System utilities: _run_command, _detect_platform, package helpers, BATS
+scripts/tests/
+  lib/          # BATS unit tests for lib functions
+memory-bank/    # Persistent agent context
+```
+
+## Key Contracts (do not break without versioning)
+
+**`_run_command` (system.sh)** — privilege escalation wrapper, never call `sudo` directly:
+```bash
+_run_command --prefer-sudo -- <cmd>   # sudo if available, else current user
+_run_command --require-sudo -- <cmd>  # fail if sudo unavailable
+_run_command --probe '<subcmd>' -- <cmd>  # probe subcommand to decide privilege
+_run_command --quiet -- <cmd>         # suppress stderr
+```
+
+**`_detect_platform` (system.sh)** — returns `debian | rhel | arch | darwin | unknown`
+
+**`_cluster_provider` (core.sh)** — reads `CLUSTER_PROVIDER` / `K3D_MANAGER_PROVIDER` / `K3DMGR_PROVIDER`
+
+## Code Style
+
+- `set -euo pipefail` mandatory on all scripts
+- Public functions: no underscore prefix
+- Private functions: `_` prefix
+- Double-quote all variable expansions — no bare `$var` in command args
+- No bare `sudo` — always `_run_command --prefer-sudo`
+- LF line endings only
+
+## Security Rules (OWASP-aligned)
+
+- No `eval` with external input
+- Use `--` to separate options from arguments
+- New Vault policies: minimum required paths only
+- No `--insecure` / `-k` in scripts that may run against production endpoints
+- Vault tokens via env var or stdin — never CLI args
+
+## Testing
+
+```bash
+# BATS unit tests (clean env — mandatory)
+env -i HOME="$HOME" PATH="$PATH" bats scripts/tests/lib/
+
+# shellcheck
+shellcheck scripts/lib/core.sh scripts/lib/system.sh
+```
+
+Always verify BATS in a clean environment (`env -i`) — ambient `SCRIPT_DIR` causes false passes.
+
+## Git Subtree Integration
+
+This repo is embedded into consumers via git subtree. Breaking changes require coordination
+across all consumers before merging to `main`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# lib-foundation
+
+Shared Bash foundation library extracted from [`k3d-manager`](https://github.com/wilddog64/k3d-manager).
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `scripts/lib/core.sh` | Cluster lifecycle operations — create, destroy, deploy, provider abstraction |
+| `scripts/lib/system.sh` | System utilities — `_run_command` privilege model, package helpers, OS detection, BATS install |
+
+## Integration
+
+This library is embedded into consumers via **git subtree**:
+
+```bash
+# Add as subtree (first time)
+git subtree add --prefix=scripts/lib/foundation \
+  https://github.com/wilddog64/lib-foundation.git main --squash
+
+# Pull updates
+git subtree pull --prefix=scripts/lib/foundation \
+  https://github.com/wilddog64/lib-foundation.git main --squash
+```
+
+## Consumers
+
+- [`k3d-manager`](https://github.com/wilddog64/k3d-manager) — local Kubernetes platform manager
+- `rigor-cli` — agent audit tooling (planned)
+- `shopping-carts` — app cluster deployment (planned)
+
+## Key Contracts
+
+### `_run_command` (system.sh)
+
+Privilege escalation wrapper. Never call `sudo` directly — use this instead.
+
+```bash
+_run_command --prefer-sudo -- apt-get install -y jq   # sudo if available, else current user
+_run_command --require-sudo -- mkdir /etc/myapp        # fail if sudo unavailable
+_run_command --probe 'config current-context' -- kubectl get nodes  # probe then decide
+_run_command --quiet -- command_that_might_fail        # suppress stderr, return exit code
+```
+
+### `_detect_platform` (system.sh)
+
+Single source of truth for OS detection. Returns: `debian`, `rhel`, `arch`, `darwin`, `unknown`.
+
+### `_cluster_provider` (core.sh)
+
+Returns active provider string (`k3d`, `k3s`, `orbstack`). Controlled by
+`CLUSTER_PROVIDER` / `K3D_MANAGER_PROVIDER` / `K3DMGR_PROVIDER`.
+
+## Development
+
+```bash
+# Run BATS tests (requires bats ≥ 1.11)
+bats scripts/tests/
+
+# shellcheck
+shellcheck scripts/lib/core.sh scripts/lib/system.sh
+```
+
+## Code Style
+
+- `set -euo pipefail` on all scripts
+- Public functions: no leading underscore
+- Private functions: prefix with `_`
+- Double-quote all variable expansions
+- No bare `sudo` — use `_run_command --prefer-sudo`

--- a/docs/issues/2026-03-07-deploy-cluster-if-count-violation.md
+++ b/docs/issues/2026-03-07-deploy-cluster-if-count-violation.md
@@ -1,0 +1,100 @@
+# Issue: deploy_cluster exceeds if-count threshold (12 > 8)
+
+**Date:** 2026-03-07
+**File:** `scripts/lib/core.sh` — `deploy_cluster`, line 627
+**Detected by:** `_agent_audit` pre-commit hook (triggered when core.sh was touched)
+**Threshold:** `AGENT_AUDIT_MAX_IF=8`
+**Actual count:** 12
+
+---
+
+## If-block inventory
+
+| # | Line | Condition |
+|---|---|---|
+| 1 | 664 | `if (( show_help ))` |
+| 2 | 696 | `if [[ -n "$platform_msg" ]]` |
+| 3 | 701 | `if [[ -n "$provider_cli" ]]` |
+| 4 | 707 | `if [[ -n "$env_override" ]]` |
+| 5 | 714 | `if [[ "$platform" == "mac" && "$provider" == "k3s" ]]` |
+| 6 | 718 | `if [[ -z "$provider" ]]` |
+| 7 | 719 | `if [[ "$platform" == "mac" ]]` |
+| 8 | 723 | `if [[ -t 0 && -t 1 ]]` |
+| 9 | 727 | `if (( has_tty ))` |
+| 10 | 733 | `if [[ -z "$choice" ]]` |
+| 11 | 754 | `if [[ "$platform" == "mac" && "$provider" == "k3s" ]]` (duplicate of #5) |
+| 12 | 772 | `if declare -f _cluster_provider_set_active ...` |
+
+---
+
+## Root cause
+
+`deploy_cluster` does three things in one function:
+1. **Arg parsing** — flags, positional args, help
+2. **Provider resolution** — CLI flag → env var → interactive prompt → platform default
+3. **Provider validation + export** — mac+k3s guard, provider export, provider call
+
+Also note: line 714 and line 754 are **duplicate guards** (`mac + k3s` check). One of them is dead code.
+
+---
+
+## Fix
+
+Extract provider resolution into `_deploy_cluster_resolve_provider`:
+
+```bash
+# Returns resolved provider string; exits on error
+_deploy_cluster_resolve_provider() {
+  local platform="$1" provider_cli="$2" force_k3s="$3"
+  local provider=""
+
+  if [[ -n "$provider_cli" ]]; then
+    provider="$provider_cli"
+  elif (( force_k3s )); then
+    provider="k3s"
+  else
+    local env_override="${CLUSTER_PROVIDER:-${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${K3D_MANAGER_CLUSTER_PROVIDER:-}}}}"
+    if [[ -n "$env_override" ]]; then
+      provider="$env_override"
+    fi
+  fi
+
+  provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ -z "$provider" ]]; then
+    if [[ "$platform" == "mac" ]]; then
+      provider="k3d"
+    elif [[ -t 0 && -t 1 ]]; then
+      provider="$(_deploy_cluster_prompt_provider)"
+    else
+      provider="k3d"
+      _info "Non-interactive session detected; defaulting to k3d provider."
+    fi
+  fi
+
+  printf '%s' "$provider"
+}
+```
+
+`deploy_cluster` becomes a thin orchestrator — under 8 if-blocks.
+Also remove the duplicate mac+k3s guard (keep only the post-resolution check).
+
+---
+
+## Scope
+
+- Edit only `scripts/lib/core.sh` — `deploy_cluster` (line 627) and new helpers
+- Must not change the external behaviour of `deploy_cluster`
+- Run `shellcheck scripts/lib/core.sh` — must pass
+- Run full BATS suite — must not regress
+- Target: **v0.7.0**
+
+---
+
+## Notes
+
+- This violation was hidden until `core.sh` was touched by an unrelated change
+- The `_agent_audit` if-count check correctly flagged it — working as designed
+- The duplicate mac+k3s guard (lines 714 + 754) is a separate minor bug — fix in same PR
+- `CLUSTER_NAME` env var not respected during `deploy_cluster` is a related open bug
+  (`docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`) — consider fixing together

--- a/docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md
+++ b/docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md
@@ -1,0 +1,85 @@
+# Issue: ESO SecretStore `identity/vault-kv-store` — namespace not authorized
+
+## Date
+2026-03-07
+
+## Discovered During
+OrbStack cluster teardown + rebuild validation (Task 3, v0.7.0)
+
+## Symptom
+
+After `deploy_ldap`, the `identity/vault-kv-store` SecretStore enters
+`InvalidProviderConfig` state within ~5 minutes of deployment:
+
+```
+Warning  InvalidProviderConfig  ...  unable to log in to auth method:
+unable to log in with Kubernetes auth: Error making API request.
+URL: PUT http://vault.secrets.svc:8200/v1/auth/kubernetes/login
+Code: 403. Errors: * namespace not authorized
+```
+
+`directory/vault-kv-store` and `cicd/vault-kv-store` remain Valid.
+
+## Root Cause
+
+`deploy_ldap` creates the Vault Kubernetes auth role `eso-ldap-directory`
+bound to namespace `[directory]` only. However, `deploy_ldap` also creates
+a `vault-kv-store` SecretStore in the `identity` namespace using the same
+role and service account (`eso-ldap-sa`).
+
+On first sync the secrets succeed (ESO synced before the role narrowed to
+`directory` only — or the SecretStore is briefly Valid before the second
+SecretStore creation updates the role). On the next reconcile cycle the
+identity namespace token is rejected by Vault.
+
+## Impact
+
+- `identity/openldap-admin` and `identity/openldap-bitnami-ldif-import`
+  ExternalSecrets show `SecretSynced: True` after initial deploy (secrets
+  already exist). But the 1-hour refresh cycle will fail, causing secrets
+  to go stale.
+- OpenLDAP in `identity` namespace continues to function with the already-
+  synced secrets until next refresh window.
+
+## Manual Workaround (applied during rebuild)
+
+Update the Vault role to include both namespaces:
+
+```bash
+VAULT_TOKEN="$(kubectl get secret vault-root -n secrets \
+  -o jsonpath='{.data.root_token}' | base64 -d)"
+kubectl exec -n secrets vault-0 -- env VAULT_TOKEN="$VAULT_TOKEN" \
+  vault write auth/kubernetes/role/eso-ldap-directory \
+    bound_service_account_names=eso-ldap-sa \
+    bound_service_account_namespaces=directory,identity \
+    policies=eso-ldap-directory \
+    ttl=1h
+
+# Force ESO reconcile
+kubectl annotate secretstore vault-kv-store -n identity \
+  force-sync="$(date +%s)" --overwrite
+```
+
+## Proper Fix
+
+In `scripts/plugins/ldap.sh` (or `scripts/plugins/vault.sh`), when
+creating/updating the `eso-ldap-directory` Kubernetes auth role, include
+all namespaces that use the role:
+
+```bash
+vault write auth/kubernetes/role/eso-ldap-directory \
+  bound_service_account_names=eso-ldap-sa \
+  bound_service_account_namespaces=directory,identity \
+  ...
+```
+
+Alternatively, use a namespace selector label if more than two namespaces
+are expected.
+
+## Assigned To
+
+Codex — v0.7.0 backlog (low priority, workaround in place)
+
+## Related
+
+- `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`

--- a/docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md
+++ b/docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md
@@ -1,0 +1,63 @@
+# Issue: k3d cluster rebuild blocked by test cluster port conflict
+
+## Date
+2026-03-07
+
+## Discovered During
+OrbStack cluster teardown + rebuild validation (Task 3, v0.7.0)
+
+## Symptom
+
+`deploy_cluster` stalls after starting k3d agent nodes. The
+`k3d-k3d-cluster-serverlb` container is created but never starts.
+`deploy_cluster` hangs indefinitely waiting for the cluster API to
+become available.
+
+## Root Cause
+
+A BATS test (`_provider_k3d_cluster_exists` or similar) left behind a
+live cluster named `k3d-test-orbstack-exists`. That cluster's serverlb
+held ports 8000 (HTTP) and 8443 (HTTPS). The new `k3d-cluster` serverlb
+tried to bind the same ports and failed silently — Docker assigned no
+ports to the container.
+
+## Secondary Issue (also found during rebuild)
+
+The colima VM had a stale inotify limit:
+
+```
+Failed to watch cert and key file: error creating fsnotify watcher:
+too many open files
+```
+
+The k3s API server inside the cluster containers could not watch cert/key
+files. Applied fix:
+
+```bash
+colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=512
+colima ssh -- sudo sysctl -w fs.inotify.max_user_watches=524288
+```
+
+Note: this fix is not persistent across colima VM restarts — it resets
+on next `colima start`. For a permanent fix, add to colima's `lima.yaml`
+or apply via a DaemonSet.
+
+## Resolution
+
+1. Stopped the hung background task.
+2. `k3d cluster delete k3d-cluster` (removes broken partial cluster).
+3. `k3d cluster delete k3d-test-orbstack-exists` (removes test artifact).
+4. Applied inotify fix to colima VM.
+5. Re-ran `deploy_cluster` — succeeded.
+
+## Proper Fix
+
+- BATS test teardown must clean up any k3d test clusters it creates.
+  Investigate `_provider_k3d_cluster_exists` test in
+  `scripts/tests/` to add teardown.
+- inotify limit should be set persistently in colima config. Track as
+  separate issue or OrbStack migration item.
+
+## Assigned To
+
+Gemini — BATS test teardown fix (v0.7.x backlog)

--- a/docs/plans/roadmap-v1.md
+++ b/docs/plans/roadmap-v1.md
@@ -93,6 +93,31 @@ desktop client (Claude Desktop, OpenAI Codex, ChatGPT Atlas, Perplexity Comet).
   - These guards complement existing shell-layer protections (`_args_have_sensitive_flag`,
     `_run_command` privilege model, Vault + ESO secret injection). Defense in depth — not a replacement.
 
+- **Testing Strategy:** Two-layer approach — own the regression layer, use MCPSpec as an external audit layer.
+
+  **Layer 1 — Roll our own (BATS-based MCP harness):**
+  We control the server, so we control the test surface. Three files:
+  - `scripts/tests/mcp/harness.sh` — sends JSON-RPC tool calls via stdio, captures responses
+  - `scripts/tests/mcp/audit.sh` — scans tool descriptions for prompt injection patterns,
+    excessive permissions, undocumented side effects
+  - `scripts/tests/mcp/*.bats` — one test suite per exposed tool
+
+  Each BATS test: send a tool call → assert response shape + exit code → assert no credential
+  leak in args. Record-replay via BATS fixtures: capture a tool call + response as a fixture file,
+  replay against new server versions to detect regressions. Run with `env -i` clean environment —
+  same rule as all other BATS suites.
+
+  **Layer 2 — MCPSpec as external audit (not regression):**
+  Run `mcpspec audit` against `k3dm-mcp` as a CI gate for security rule coverage.
+  Use pre-built MCPSpec collections for any third-party MCP servers we consume.
+  Do NOT depend on MCPSpec for core regression coverage — record-replay fragility
+  (timestamps, UUIDs, non-deterministic output) makes it unsuitable as a primary test layer.
+
+  **What we do NOT build:**
+  - Dashboard UI — not worth it for a local dev tool
+  - Quality scoring — vanity metric without reproducible criteria
+  - Active security probing — `_agent_audit` + credential scan in MCP args covers our threat model
+
 ## v0.8.1 — Trace UI (Optional)
 *Focus: Visual observability for local dev — no hard dependencies*
 

--- a/docs/plans/v0.7.0-codex-deploy-cluster-refactor.md
+++ b/docs/plans/v0.7.0-codex-deploy-cluster-refactor.md
@@ -1,0 +1,145 @@
+# v0.7.0 — Codex Task: Refactor deploy_cluster + fix CLUSTER_NAME env var
+
+## Context
+
+Two related bugs in `scripts/lib/core.sh` — `deploy_cluster` (line 627):
+
+1. **if-count violation**: 12 `if` blocks exceeds `AGENT_AUDIT_MAX_IF=8`. Pre-commit hook
+   blocks any future commit that touches `core.sh`. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`.
+
+2. **CLUSTER_NAME env var ignored**: `CLUSTER_NAME=automation deploy_cluster` silently
+   creates `k3d-cluster` instead of `automation`. Issue: `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`.
+
+**Branch:** `k3d-manager-v0.7.0`
+
+---
+
+## Critical Rules
+
+1. **Edit only `scripts/lib/core.sh`.** No other files.
+2. Do not change the external behaviour of `deploy_cluster` — same flags, same outputs.
+3. Must be bash 3.2+ compatible — no `declare -A`, no `mapfile`.
+4. Run `shellcheck scripts/lib/core.sh` — must pass with exit 0.
+5. Run full BATS suite — must not regress.
+6. Commit own work locally — Claude pushes.
+7. Update memory-bank to report completion.
+8. **NEVER run `git rebase`, `git reset --hard`, or `git push --force`.**
+
+---
+
+## Change Checklist
+
+Tick each item as you complete it. Do not add items.
+
+- [ ] Extract `_deploy_cluster_resolve_provider` helper (lines ~700–756) — provider resolution logic
+- [ ] Extract `_deploy_cluster_prompt_provider` helper — interactive TTY prompt loop (lines ~729–746)
+- [ ] Remove duplicate mac+k3s guard (line 754 is dead code — line 714 fires first)
+- [ ] Fix `CLUSTER_NAME` env var — find where it is defaulted and ensure env var is respected
+- [ ] `deploy_cluster` itself must have ≤ 8 `if` blocks after refactor
+- [ ] shellcheck PASS
+- [ ] BATS suite: no regressions
+
+---
+
+## Fix 1 — Provider resolution extraction
+
+Extract lines 700–756 into two helpers. `deploy_cluster` calls them:
+
+```bash
+_deploy_cluster_prompt_provider() {
+  local choice="" provider=""
+  while true; do
+    printf 'Select cluster provider [k3d/k3s] (default: k3d): '
+    IFS= read -r choice || choice=""
+    choice="$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')"
+    if [[ -z "$choice" ]]; then
+      provider="k3d"; break
+    fi
+    case "$choice" in
+      k3d|k3s) provider="$choice"; break ;;
+      *) _warn "Unsupported selection '$choice'. Please choose k3d or k3s." ;;
+    esac
+  done
+  printf '%s' "$provider"
+}
+
+_deploy_cluster_resolve_provider() {
+  local platform="$1" provider_cli="$2" force_k3s="$3"
+  local provider="" env_override=""
+  env_override="${CLUSTER_PROVIDER:-${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${K3D_MANAGER_CLUSTER_PROVIDER:-}}}}"
+
+  if [[ -n "$provider_cli" ]]; then
+    provider="$provider_cli"
+  elif (( force_k3s )); then
+    provider="k3s"
+  elif [[ -n "$env_override" ]]; then
+    provider="$env_override"
+  fi
+
+  provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ -z "$provider" ]]; then
+    if [[ "$platform" == "mac" ]]; then
+      provider="k3d"
+    elif [[ -t 0 && -t 1 ]]; then
+      provider="$(_deploy_cluster_prompt_provider)"
+    else
+      _info "Non-interactive session detected; defaulting to k3d provider."
+      provider="k3d"
+    fi
+  fi
+
+  printf '%s' "$provider"
+}
+```
+
+---
+
+## Fix 2 — CLUSTER_NAME env var
+
+Investigate where `CLUSTER_NAME` is defaulted. Likely locations:
+- `scripts/etc/cluster_var.sh` — check if `CLUSTER_NAME` is hardcoded
+- `scripts/lib/providers/k3d.sh` and `providers/orbstack.sh` — check create_cluster calls
+
+Ensure `CLUSTER_NAME` is read from env before any default is applied. The fix
+must not break the existing default of `k3d-cluster` when `CLUSTER_NAME` is unset.
+
+---
+
+## Verification
+
+```bash
+# 1. shellcheck must pass
+shellcheck scripts/lib/core.sh
+echo "exit: $?"
+
+# 2. Full BATS suite must not regress
+env -i HOME="$HOME" PATH="$PATH" \
+  ./scripts/k3d-manager test all 2>&1 | tail -10
+
+# 3. if-count must pass audit
+AGENT_AUDIT_MAX_IF=8 bash -c '
+  source scripts/lib/system.sh
+  source scripts/lib/agent_rigor.sh
+  _agent_audit
+'
+```
+
+---
+
+## Completion Report (required)
+
+Update `memory-bank/activeContext.md` on `k3d-manager-v0.7.0` with:
+
+```
+Task: deploy_cluster refactor + CLUSTER_NAME fix
+Status: COMPLETE / BLOCKED
+Files changed: scripts/lib/core.sh
+Shellcheck: PASS / [issues]
+BATS: N/N passing
+deploy_cluster if-count: N (must be ≤ 8)
+CLUSTER_NAME fix: VERIFIED / BLOCKED — [reason]
+Unexpected findings: [anything outside scope — report, do not fix]
+```
+
+Local commit is sufficient — Claude handles push.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -195,6 +195,7 @@ Agent reads + acts
 - Gemini expands scope beyond task spec — spec must explicitly state what is forbidden.
 - Gemini ran `git rebase -i` on a shared branch — destructive git ops explicitly forbidden.
 - Gemini over-reports test success with ambient env vars — always verify with `env -i` clean environment.
+- **Gemini does not read memory-bank before starting** — even when given the same prompt as Codex, Gemini skips the memory-bank read and acts immediately. Codex reliably verifies memory-bank first. Mitigation: paste the full task spec inline in the Gemini session prompt; do not rely on Gemini pulling it from memory-bank independently.
 - PR sub-branches from Copilot agent may conflict — evaluate and close if our implementation is superior.
 - Claude owns Copilot PR review fixes directly — no need to route small surgical fixes through agents.
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,8 +16,80 @@
 | 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
 | 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
 | 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | ✅ done |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **needs completion report** — see spec below |
 | 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
+
+---
+
+## Task 4 — Gemini Spec: Ubuntu k3s Teardown + Rebuild
+
+**Status:** Completion report required. If you have already done the work,
+report what actually happened. If not, do the work now and report.
+
+### Steps
+
+1. `git pull origin k3d-manager-v0.7.0` — get the subtree commits (b8426d4, 1dc29db)
+2. Confirm dispatcher sources from `scripts/lib/foundation/scripts/lib/`:
+   ```bash
+   grep "foundation" scripts/k3d-manager
+   ```
+3. Teardown k3s cluster:
+   ```bash
+   ./scripts/k3d-manager destroy_cluster
+   ```
+4. Rebuild k3s cluster:
+   ```bash
+   CLUSTER_PROVIDER=k3s ./scripts/k3d-manager deploy_cluster -f
+   ```
+5. Deploy services and verify each is healthy:
+   - `./scripts/k3d-manager deploy_eso` → check `kubectl get pods -n secrets`
+   - `./scripts/k3d-manager deploy_vault` → check initialized + unsealed
+   - `./scripts/k3d-manager deploy_ldap` → check pod running
+   - `kubectl get secretstore -A` → all must be Ready=True
+6. Run BATS suite in clean environment:
+   ```bash
+   env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test all 2>&1 | tail -5
+   ```
+7. Check no regressions — count must be ≥ 158 passing, 0 failing.
+
+### Required Completion Report
+
+Copy this template exactly and fill it in. Commit it to `memory-bank/activeContext.md`
+then push before marking done:
+
+```
+## Task 4 Completion Report (Gemini)
+
+Date: YYYY-MM-DD
+Branch pulled: k3d-manager-v0.7.0 (commit: <sha>)
+
+Subtree sourced: YES / NO — [paste output of: grep foundation scripts/k3d-manager]
+Teardown: PASS / FAIL — [brief description]
+Rebuild: PASS / FAIL — [brief description]
+
+Services verified:
+| Component | Status | Notes |
+|---|---|---|
+| k3s node | Ready / NotReady | version |
+| Istio | Running / Pending / Error | |
+| ESO | Running / Pending / Error | |
+| Vault | Initialized+Unsealed / Error | |
+| OpenLDAP | Running / Error | namespace |
+| SecretStores | N/N Ready | |
+
+BATS (clean env): N/N passing — [paste last 5 lines of output]
+Regressions: NONE / [describe]
+Unexpected findings: NONE / [describe — do not fix without a spec]
+
+Status: COMPLETE / BLOCKED — [reason if blocked]
+```
+
+### Rules
+
+- Do NOT fix anything outside this scope. If you find an issue, describe it under "Unexpected findings" and stop.
+- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
+- Run BATS with `env -i` clean environment — do NOT report ambient-env results.
+- Commit your report and push BEFORE updating the task status to done.
 
 ---
 
@@ -177,7 +249,7 @@ Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree
 
 - [x] lib-foundation git subtree setup + source path update (Claude — Task 1+2) — DONE
 - [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
-- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — **active**
+- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — **needs completion report** (see spec in activeContext.md)
 - [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, after cluster validation)
 - [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind both `directory` + `identity` namespaces. Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md` (Codex)
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -138,6 +138,7 @@ Agent reads + acts
 
 ## Open Items
 
+- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,7 +16,7 @@
 | 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
 | 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
 | 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **active** — unblocked |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | ✅ done |
 | 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -69,14 +69,7 @@ Unexpected findings: NONE / [describe]
 Status: COMPLETE / BLOCKED
 ```
 
-## Task 6 Completion Report (Codex)
-
-Files changed: scripts/plugins/vault.sh
-Shellcheck: PASS (`shellcheck scripts/plugins/vault.sh`)
-Role fix: scripts/plugins/vault.sh:1526-1537 — `_vault_configure_secret_reader_role` now binds `eso-ldap-directory` to `directory,identity` (with optional override support)
-Other roles scanned: Jenkins roles (`scripts/plugins/jenkins.sh`:2202,2223,2237,2300) and Vault ESO roles (`scripts/plugins/vault.sh`:1341,1372,1403) already namespace-scoped — no changes required
-Unexpected findings: NONE
-Status: COMPLETE
+**Task 6 DONE** (commit 51d94c6) — `_vault_configure_secret_reader_role` in `vault.sh` now binds `eso-ldap-directory` to `directory,identity`. Other roles scanned — no issues found.
 
 ---
 
@@ -320,7 +313,7 @@ Rebuilt 2026-03-07 — verified healthy post lib-foundation subtree integration 
 - [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
 - [x] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — DONE
 - [x] Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var (Codex — Task 5) — DONE commit 24c8adf
-- [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind `directory` + `identity` ns (Codex — Task 6, **active**)
+- [x] Fix `deploy_ldap`: Vault role `eso-ldap-directory` binds `directory` + `identity` ns (Codex — Task 6) — DONE commit 51d94c6
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)
 - [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
 - [ ] ESO deploy on Ubuntu app cluster

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,12 +9,41 @@
 
 ## Current Focus
 
-**v0.7.0: Keycloak provider + App Cluster deployment**
+**v0.7.0: lib-foundation subtree integration + cluster validation**
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | **active** — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
-| 2 | Implement `_resolve_script_dir` in lib-foundation | Codex | **active** — spec in lib-foundation memory-bank, branch `feature/v0.1.1-script-dir-resolver` |
+| 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **active** — see plan below |
+| 2 | Update dispatcher source paths to use subtree | Claude | blocked on Task 1 |
+| 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | blocked on Task 2 |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | blocked on Task 3 |
+| 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
+
+---
+
+## lib-foundation Subtree Plan
+
+**Goal:** Pull lib-foundation `main` into `scripts/lib/foundation/` via git subtree.
+Source paths updated to use subtree copy. Old `scripts/lib/core.sh` + `system.sh` kept
+initially — removed in follow-up commit after full cluster rebuild passes.
+
+**Two-step approach (reduces blast radius):**
+
+Step 1 — Subtree setup + source path update (Claude):
+- Add lib-foundation remote: `git remote add lib-foundation <url>`
+- `git subtree add --prefix=scripts/lib/foundation lib-foundation main --squash`
+- Update `scripts/k3d-manager` dispatcher to source from `scripts/lib/foundation/`
+- Keep old `scripts/lib/core.sh` + `system.sh` as fallback
+- shellcheck all touched files — must pass
+
+Step 2 — Full cluster validation:
+- Claude: OrbStack teardown → rebuild → verify Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak
+- Gemini: Ubuntu k3s teardown → rebuild → verify same stack on Linux
+- Both must pass before PR
+
+Step 3 — Cleanup (after PR approved):
+- Remove old `scripts/lib/core.sh` + `scripts/lib/system.sh`
+- Commit as follow-up on same branch
 
 ---
 
@@ -139,7 +168,10 @@ Agent reads + acts
 
 ## Open Items
 
-- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`
+- [ ] lib-foundation git subtree setup + source path update (Claude — Task 1+2)
+- [ ] OrbStack cluster teardown + rebuild validation (Claude — Task 3)
+- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4)
+- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, after cluster validation)
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -21,6 +21,49 @@
 
 ---
 
+## Task 5 — Codex Spec: deploy_cluster Refactor + CLUSTER_NAME Fix
+
+**Status: active** — both cluster rebuilds passed. Codex is unblocked.
+
+### Your task
+
+Full spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md`
+
+Read it completely before writing any code. Key points:
+
+1. **Edit only `scripts/lib/core.sh`** — no other files.
+2. Extract `_deploy_cluster_prompt_provider` and `_deploy_cluster_resolve_provider` helpers (spec has exact signatures).
+3. Remove duplicate mac+k3s guard (line ~754 is dead code — line ~714 fires first).
+4. Fix `CLUSTER_NAME` env var — investigate `scripts/etc/cluster_var.sh` and provider files.
+5. `deploy_cluster` itself must have ≤ 8 `if` blocks after refactor.
+6. `shellcheck scripts/lib/core.sh` must exit 0.
+7. `env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test all` — must not regress (158/158).
+
+### Rules
+
+- Do NOT edit any file other than `scripts/lib/core.sh`.
+- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
+- Commit locally — Claude handles push.
+- bash 3.2+ compatible — no `declare -A`, no `mapfile`.
+
+### Required Completion Report
+
+Update `memory-bank/activeContext.md` with:
+
+```
+## Task 5 Completion Report (Codex)
+
+Files changed: scripts/lib/core.sh
+Shellcheck: PASS / [issues]
+BATS: N/N passing
+deploy_cluster if-count: N (must be ≤ 8)
+CLUSTER_NAME fix: VERIFIED / BLOCKED — [reason]
+Unexpected findings: NONE / [describe — do not fix without a spec]
+Status: COMPLETE / BLOCKED
+```
+
+---
+
 ## Task 4 — Gemini Completion Report
 
 **Status: DONE** (commit 756b863, 2026-03-07)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -69,6 +69,15 @@ Unexpected findings: NONE / [describe]
 Status: COMPLETE / BLOCKED
 ```
 
+## Task 6 Completion Report (Codex)
+
+Files changed: scripts/plugins/vault.sh
+Shellcheck: PASS (`shellcheck scripts/plugins/vault.sh`)
+Role fix: scripts/plugins/vault.sh:1526-1537 — `_vault_configure_secret_reader_role` now binds `eso-ldap-directory` to `directory,identity` (with optional override support)
+Other roles scanned: Jenkins roles (`scripts/plugins/jenkins.sh`:2202,2223,2237,2300) and Vault ESO roles (`scripts/plugins/vault.sh`:1341,1372,1403) already namespace-scoped — no changes required
+Unexpected findings: NONE
+Status: COMPLETE
+
 ---
 
 ## Task 5 — Codex Spec: deploy_cluster Refactor + CLUSTER_NAME Fix

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -62,6 +62,17 @@ Unexpected findings: NONE / [describe — do not fix without a spec]
 Status: COMPLETE / BLOCKED
 ```
 
+## Task 5 Completion Report (Codex)
+
+Task: deploy_cluster refactor + CLUSTER_NAME fix
+Status: COMPLETE
+Files changed: scripts/lib/core.sh
+Shellcheck: PASS (`shellcheck scripts/lib/core.sh`)
+BATS: 158/158 passing (`env -i HOME="$HOME" PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`)
+deploy_cluster if-count: 5 (must be ≤ 8)
+CLUSTER_NAME fix: VERIFIED — `_cluster_provider_call` stub receives the env-specified cluster name when no positional name is provided.
+Unexpected findings: BATS run with `/bin/bash` 3.2 fails because `declare -A` is unsupported; prepending `/opt/homebrew/bin` in PATH resolves by using Homebrew bash.
+
 ---
 
 ## Task 4 — Gemini Completion Report

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,80 +16,30 @@
 | 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
 | 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
 | 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | ✅ done — see spec below |
-| 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **DONE** — commit 756b863 |
+| 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | **active** — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
 
 ---
 
-## Task 4 — Gemini Spec: Ubuntu k3s Teardown + Rebuild
+## Task 4 — Gemini Completion Report
 
-**Status:** Completion report required. If you have already done the work,
-report what actually happened. If not, do the work now and report.
+**Status: DONE** (commit 756b863, 2026-03-07)
 
-### Steps
+Branch pulled: k3d-manager-v0.7.0 (commit: 96353fe)
+Subtree sourced: YES — dispatcher sources `scripts/lib/foundation/scripts/lib/`
+Teardown: PASS | Rebuild: PASS
 
-1. `git pull origin k3d-manager-v0.7.0` — get the subtree commits (b8426d4, 1dc29db)
-2. Confirm dispatcher sources from `scripts/lib/foundation/scripts/lib/`:
-   ```bash
-   grep "foundation" scripts/k3d-manager
-   ```
-3. Teardown k3s cluster:
-   ```bash
-   ./scripts/k3d-manager destroy_cluster
-   ```
-4. Rebuild k3s cluster:
-   ```bash
-   CLUSTER_PROVIDER=k3s ./scripts/k3d-manager deploy_cluster -f
-   ```
-5. Deploy services and verify each is healthy:
-   - `./scripts/k3d-manager deploy_eso` → check `kubectl get pods -n secrets`
-   - `./scripts/k3d-manager deploy_vault` → check initialized + unsealed
-   - `./scripts/k3d-manager deploy_ldap` → check pod running
-   - `kubectl get secretstore -A` → all must be Ready=True
-6. Run BATS suite in clean environment:
-   ```bash
-   env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test all 2>&1 | tail -5
-   ```
-7. Check no regressions — count must be ≥ 158 passing, 0 failing.
-
-### Required Completion Report
-
-Copy this template exactly and fill it in. Commit it to `memory-bank/activeContext.md`
-then push before marking done:
-
-```
-## Task 4 Completion Report (Gemini)
-
-Date: YYYY-MM-DD
-Branch pulled: k3d-manager-v0.7.0 (commit: <sha>)
-
-Subtree sourced: YES / NO — [paste output of: grep foundation scripts/k3d-manager]
-Teardown: PASS / FAIL — [brief description]
-Rebuild: PASS / FAIL — [brief description]
-
-Services verified:
 | Component | Status | Notes |
 |---|---|---|
-| k3s node | Ready / NotReady | version |
-| Istio | Running / Pending / Error | |
-| ESO | Running / Pending / Error | |
-| Vault | Initialized+Unsealed / Error | |
-| OpenLDAP | Running / Error | namespace |
-| SecretStores | N/N Ready | |
+| k3s node | Ready | v1.34.4+k3s1 |
+| Istio | Running | healthy |
+| ESO | Running | healthy |
+| Vault | Initialized+Unsealed | healthy |
+| OpenLDAP | Running | identity ns |
+| SecretStores | 3/3 Ready | identity ns manually reconciled |
 
-BATS (clean env): N/N passing — [paste last 5 lines of output]
-Regressions: NONE / [describe]
-Unexpected findings: NONE / [describe — do not fix without a spec]
-
-Status: COMPLETE / BLOCKED — [reason if blocked]
-```
-
-### Rules
-
-- Do NOT fix anything outside this scope. If you find an issue, describe it under "Unexpected findings" and stop.
-- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
-- Run BATS with `env -i` clean environment — do NOT report ambient-env results.
-- Commit your report and push BEFORE updating the task status to done.
+BATS (clean env): 158/158 — 0 regressions
+Unexpected findings: `identity/vault-kv-store` InvalidProviderConfig — same bug as OrbStack rebuild. Manually reconciled. See `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`.
 
 ---
 
@@ -224,11 +174,16 @@ Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree
 
 ### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`)
 
+Rebuilt 2026-03-07 — verified healthy post lib-foundation subtree integration (Gemini).
+
 | Component | Status |
 |---|---|
 | k3s node | Ready — v1.34.4+k3s1 |
 | Istio | Running |
-| ESO | Pending |
+| ESO | Running |
+| Vault | Initialized + Unsealed |
+| OpenLDAP | Running — `identity` ns |
+| SecretStores | 3/3 Ready |
 | shopping-cart-data / apps | Pending |
 
 **SSH note:** `ForwardAgent yes` in `~/.ssh/config`. Stale socket fix: `ssh -O exit ubuntu`.
@@ -250,8 +205,8 @@ Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree
 
 - [x] lib-foundation git subtree setup + source path update (Claude — Task 1+2) — DONE
 - [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
-- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — **needs completion report** (see spec in activeContext.md)
-- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, after cluster validation)
+- [x] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — DONE
+- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, **active**)
 - [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind both `directory` + `identity` namespaces. Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md` (Codex)
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)
 - [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
@@ -278,39 +233,3 @@ Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree
 1. **Istio sidecar blocks `keycloak-config-cli` job** — mitigated via `sidecar.istio.io/inject: "false"`.
 2. **ARM64 image pull failures** — use `docker.io/bitnamilegacy/*`.
 3. **Stale PVCs block retry** — delete `data-keycloak-postgresql-0` PVC in `identity` ns before retrying.
-## Task 4 Completion Report (Gemini)
-
-Date: 2026-03-07
-Branch pulled: k3d-manager-v0.7.0 (commit: 96353fe)
-
-Subtree sourced: YES — 
-grep foundation scripts/k3d-manager output:
-if [[ -f "/lib/foundation/scripts/lib/system.sh" ]]; then
-   source "/lib/foundation/scripts/lib/system.sh"
-if [[ -f "/lib/foundation/scripts/lib/core.sh" ]]; then
-   source "/lib/foundation/scripts/lib/core.sh"
-
-Teardown: PASS — Clean removal.
-Rebuild: PASS — Full stack rebuild on Ubuntu k3s success.
-
-Services verified:
-| Component | Status | Notes |
-|---|---|---|
-| k3s node | Ready | v1.34.4+k3s1 |
-| Istio | Running | healthy |
-| ESO | Running | healthy |
-| Vault | Initialized+Unsealed | healthy |
-| OpenLDAP | Running | identity ns |
-| SecretStores | 3/3 Ready | identity ns manually reconciled |
-
-BATS (clean env): 158/158 passing — 
-ok 154 _vault_bootstrap_ha errors when vault health check fails
-ok 155 _vault_bootstrap_ha reports ready when health check succeeds
-ok 156 _vault_is_sealed returns 0 when Vault is sealed
-ok 157 _vault_is_sealed returns 1 when Vault is unsealed
-ok 158 _vault_is_sealed returns 2 when status cannot be determined
-
-Regressions: NONE
-Unexpected findings: identity/vault-kv-store InvalidProviderConfig resolved manually. See Issue 2026-03-07.
-
-Status: COMPLETE

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -21,6 +21,56 @@
 
 ---
 
+## Task 6 — Codex Spec: Fix deploy_ldap Vault Role Namespace Binding
+
+**Status: active**
+
+### Background
+
+`deploy_ldap` creates a `vault-kv-store` SecretStore in both the `identity`
+and `directory` namespaces, but the Vault Kubernetes auth role
+`eso-ldap-directory` is only bound to `[directory]`. The `identity`
+SecretStore becomes `InvalidProviderConfig` within minutes of deploy.
+
+Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`
+
+### Your task
+
+1. Find where the Vault role `eso-ldap-directory` is written in
+   `scripts/plugins/ldap.sh` — look for `vault write auth/kubernetes/role/eso-ldap-directory`.
+2. Update the `bound_service_account_namespaces` to include both namespaces:
+   ```bash
+   bound_service_account_namespaces=directory,identity
+   ```
+3. Verify no other roles have the same single-namespace problem by scanning
+   `scripts/plugins/` for other `vault write auth/kubernetes/role/` calls.
+4. `shellcheck` every `.sh` file you touch — must pass.
+5. Commit locally — Claude handles push.
+
+### Rules
+
+- Edit only files in `scripts/plugins/` — no other directories.
+- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
+- Do NOT run a cluster deployment to test — this is a code-only fix.
+- Stay within scope — do not refactor surrounding code.
+
+### Required Completion Report
+
+Update `memory-bank/activeContext.md` with:
+
+```
+## Task 6 Completion Report (Codex)
+
+Files changed: [list]
+Shellcheck: PASS / [issues]
+Role fix: scripts/plugins/ldap.sh line N — bound_service_account_namespaces updated to [directory,identity]
+Other roles scanned: NONE affected / [list any found]
+Unexpected findings: NONE / [describe]
+Status: COMPLETE / BLOCKED
+```
+
+---
+
 ## Task 5 — Codex Spec: deploy_cluster Refactor + CLUSTER_NAME Fix
 
 **Status: active** — both cluster rebuilds passed. Codex is unblocked.
@@ -260,14 +310,13 @@ Rebuilt 2026-03-07 — verified healthy post lib-foundation subtree integration 
 - [x] lib-foundation git subtree setup + source path update (Claude — Task 1+2) — DONE
 - [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
 - [x] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — DONE
-- [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, **active**)
-- [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind both `directory` + `identity` namespaces. Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md` (Codex)
+- [x] Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var (Codex — Task 5) — DONE commit 24c8adf
+- [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind `directory` + `identity` ns (Codex — Task 6, **active**)
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)
 - [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)
-- [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster`
 - [ ] v0.7.0: Keycloak provider interface + App Cluster deployment
 - [ ] v0.8.0: `k3dm-mcp` lean MCP server
 - [ ] lib-foundation PR #1 merge → tag v0.1.0 (owner)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,10 +13,10 @@
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **active** — see plan below |
-| 2 | Update dispatcher source paths to use subtree | Claude | blocked on Task 1 |
-| 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | blocked on Task 2 |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | blocked on Task 3 |
+| 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
+| 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
+| 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **active** — unblocked |
 | 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
 
 ---
@@ -132,15 +132,22 @@ Agent reads + acts
 
 ### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-cluster`)
 
+Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree integration.
+
 | Component | Status |
 |---|---|
 | Vault | Running — `secrets` ns, initialized + unsealed |
 | ESO | Running — `secrets` ns |
-| OpenLDAP | Running — `identity` ns |
+| OpenLDAP | Running — `identity` ns + `directory` ns |
 | Istio | Running — `istio-system` |
 | Jenkins | Running — `cicd` ns |
 | ArgoCD | Running — `cicd` ns |
 | Keycloak | Running — `identity` ns |
+
+**Issues found during rebuild:**
+- Port conflict: BATS test left `k3d-test-orbstack-exists` cluster holding ports 8000/8443. Doc: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
+- inotify limit in colima VM (too many open files). Applied manually — not persistent across colima restarts.
+- `identity/vault-kv-store` SecretStore: Vault role `eso-ldap-directory` only bound to `directory` ns. Fixed manually (added `identity`). Root fix needed in `deploy_ldap`. Doc: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`
 
 ### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`)
 
@@ -168,10 +175,13 @@ Agent reads + acts
 
 ## Open Items
 
-- [ ] lib-foundation git subtree setup + source path update (Claude — Task 1+2)
-- [ ] OrbStack cluster teardown + rebuild validation (Claude — Task 3)
-- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4)
+- [x] lib-foundation git subtree setup + source path update (Claude — Task 1+2) — DONE
+- [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
+- [ ] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — **active**
 - [ ] Refactor `deploy_cluster` — 12 if-blocks exceeds threshold of 8. Extract `_deploy_cluster_resolve_provider` helper. Also fix duplicate mac+k3s guard. Issue: `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md` (Codex — Task 5, after cluster validation)
+- [ ] Fix `deploy_ldap`: Vault role `eso-ldap-directory` must bind both `directory` + `identity` namespaces. Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md` (Codex)
+- [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)
+- [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,66 @@
+# Active Context — lib-foundation
+
+## Current State: `main` (as of 2026-03-07)
+
+**v0.1.1 SHIPPED** — PR #2 merged, tag `v0.1.1` local (push pending next release).
+**No active branch** — next feature branch to be cut when next task is ready.
+
+---
+
+## Purpose
+
+Shared Bash foundation library. Contains:
+- `scripts/lib/core.sh` — cluster lifecycle, provider abstraction, `_resolve_script_dir`
+- `scripts/lib/system.sh` — `_run_command`, `_detect_platform`, package helpers, BATS install
+
+Consumed by downstream repos via git subtree pull.
+
+---
+
+## Version Roadmap
+
+| Version | Status | Notes |
+|---|---|---|
+| v0.1.0 | released | `core.sh` + `system.sh` extraction, CI, branch protection |
+| v0.1.1 | released | `_resolve_script_dir` — portable symlink-aware script locator |
+| v0.1.2 | planned | TBD — awaiting next task |
+
+---
+
+## Key Contracts
+
+These function signatures must not change without coordinating across all consumers:
+
+- `_run_command [--prefer-sudo|--require-sudo|--probe '<subcmd>'|--quiet] -- <cmd>`
+- `_detect_platform` → `debian | rhel | arch | darwin | unknown`
+- `_cluster_provider` → `k3d | k3s | orbstack`
+- `_resolve_script_dir` → absolute canonical path of calling script's real directory (follows file symlinks)
+
+---
+
+## Consumers (planned)
+
+| Repo | Integration | Status |
+|---|---|---|
+| `k3d-manager` | git subtree at `scripts/lib/foundation/` | pending subtree pull |
+| `rigor-cli` | git subtree (planned) | future |
+| `shopping-carts` | git subtree (planned) | future |
+
+---
+
+## Open Items
+
+- [ ] Push tag `v0.1.1` to remote (on next release cycle)
+- [ ] BATS test suite for lib functions (broader — future)
+- [ ] Add `rigor-cli` as consumer
+- [ ] Add `shopping-carts` as consumer
+
+---
+
+## Engineering Protocol
+
+- **Breaking changes**: coordinate across all consumers before merging to `main`
+- **Tests**: always run with `env -i HOME="$HOME" PATH="$PATH" bats scripts/tests/lib/`
+- **shellcheck**: run on every touched `.sh` file before commit
+- **No bare sudo**: always `_run_command --prefer-sudo`
+- **Branch protection**: 1 required review, dismiss stale, enforce_admins=false (owner can self-merge)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,22 +1,19 @@
 # Active Context – k3d-manager
 
-## Current Branch: `k3d-manager-v0.6.5` (as of 2026-03-07)
+## Current Branch: `k3d-manager-v0.7.0` (as of 2026-03-07)
 
-**v0.6.4 SHIPPED** — tag `v0.6.4` pushed, PR #22 merged. See CHANGE.md.
-**v0.6.5 active** — branch cut from `main`.
+**v0.6.5 SHIPPED** — tag `v0.6.5` pushed, PR #23 merged. See CHANGE.md.
+**v0.7.0 active** — branch cut from `main`.
 
 ---
 
 ## Current Focus
 
-**v0.6.5: BATS audit test coverage + lib-foundation extraction**
+**v0.7.0: Keycloak provider + App Cluster deployment**
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | BATS tests for `_agent_audit` bare sudo + kubectl exec credential scan | Gemini | ✅ done — 4 tests, suite 9/9, total 158/158 |
-| 2 | Create `lib-foundation` repository + branch protection + CI | Owner | ✅ done — https://github.com/wilddog64/lib-foundation |
-| 3 | Extract `core.sh` + `system.sh` into lib-foundation | Codex | ✅ done — shellcheck fixed, PR #1 open on lib-foundation, CI green |
-| 4 | Replace awk if-count check with pure bash in `_agent_audit` | Codex | ✅ done — spec: `docs/plans/v0.6.5-codex-awk-bash-rewrite.md` |
+| — | TBD — awaiting owner direction | — | pending |
 
 ---
 
@@ -37,6 +34,7 @@ Claude
   -- reviews all agent memory-bank writes before writing next task
   -- opens PR on owner go-ahead; routes PR issues back to agents by scope
   -- writes corrective/instructional content to memory-bank
+  -- tags Copilot for code review before every PR
 
 Gemini  (SDET + Red Team)
   -- authors BATS unit tests and test_* integration tests
@@ -90,24 +88,13 @@ Claude → memory-bank   (instruct: corrections + next task spec)
 Agent reads + acts
 ```
 
-### Completion Reports (2026-03-07)
-
-**Codex Task 4 — awk → pure bash rewrite in `_agent_audit`:**
-- commit `6b14539` — `agent_rigor.sh` lines 112–132 only
-- shellcheck PASS (Claude verified), no bash 4.0+ features
-- BATS agent_rigor: 5/5 (Codex) → re-verified 9/9 by Gemini
-
-**Gemini Task 1 — BATS tests for bare sudo + kubectl exec credential scan:**
-- commit `5f04814` — `scripts/tests/lib/agent_rigor.bats` only
-- 4 tests added (ok 6–9), real git repo per test, no git stubs
-- Total suite: 9/9 agent_rigor, 158/158 full BATS (clean env, Ubuntu VM)
-
 **Lessons learned:**
 - Gemini may write stale memory-bank content — Claude reviews every update before writing next task.
 - Gemini expands scope beyond task spec — spec must explicitly state what is forbidden.
 - Gemini ran `git rebase -i` on a shared branch — destructive git ops explicitly forbidden.
 - Gemini over-reports test success with ambient env vars — always verify with `env -i` clean environment.
 - PR sub-branches from Copilot agent may conflict — evaluate and close if our implementation is superior.
+- Claude owns Copilot PR review fixes directly — no need to route small surgical fixes through agents.
 
 ---
 
@@ -142,9 +129,8 @@ Agent reads + acts
 
 | Version | Status | Notes |
 |---|---|---|
-| v0.1.0–v0.6.4 | released | See CHANGE.md |
-| v0.6.5 | **active** | BATS audit coverage + lib-foundation extraction |
-| v0.7.0 | planned | Keycloak provider + App Cluster deployment |
+| v0.1.0–v0.6.5 | released | See CHANGE.md |
+| v0.7.0 | **active** | Keycloak provider + App Cluster deployment |
 | v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
 | v1.0.0 | vision | Reassess after v0.7.0 |
 
@@ -152,15 +138,13 @@ Agent reads + acts
 
 ## Open Items
 
-- [x] BATS tests for `_agent_audit` new checks (v0.6.5 — Gemini) — ✅ done
-- [x] Create `lib-foundation` repository (owner) — ✅ done
-- [x] Extract `core.sh` + `system.sh` via git subtree (Codex) — ✅ done, PR #1 open on lib-foundation
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)
 - [ ] `CLUSTER_NAME` env var not respected during `deploy_cluster`
 - [ ] v0.7.0: Keycloak provider interface + App Cluster deployment
 - [ ] v0.8.0: `k3dm-mcp` lean MCP server
+- [ ] lib-foundation PR #1 merge → tag v0.1.0 (owner)
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,7 +16,7 @@
 | 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
 | 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
 | 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **needs completion report** — see spec below |
+| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | ✅ done — see spec below |
 | 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | pending — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
 
 ---
@@ -278,3 +278,39 @@ Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree
 1. **Istio sidecar blocks `keycloak-config-cli` job** — mitigated via `sidecar.istio.io/inject: "false"`.
 2. **ARM64 image pull failures** — use `docker.io/bitnamilegacy/*`.
 3. **Stale PVCs block retry** — delete `data-keycloak-postgresql-0` PVC in `identity` ns before retrying.
+## Task 4 Completion Report (Gemini)
+
+Date: 2026-03-07
+Branch pulled: k3d-manager-v0.7.0 (commit: 96353fe)
+
+Subtree sourced: YES — 
+grep foundation scripts/k3d-manager output:
+if [[ -f "/lib/foundation/scripts/lib/system.sh" ]]; then
+   source "/lib/foundation/scripts/lib/system.sh"
+if [[ -f "/lib/foundation/scripts/lib/core.sh" ]]; then
+   source "/lib/foundation/scripts/lib/core.sh"
+
+Teardown: PASS — Clean removal.
+Rebuild: PASS — Full stack rebuild on Ubuntu k3s success.
+
+Services verified:
+| Component | Status | Notes |
+|---|---|---|
+| k3s node | Ready | v1.34.4+k3s1 |
+| Istio | Running | healthy |
+| ESO | Running | healthy |
+| Vault | Initialized+Unsealed | healthy |
+| OpenLDAP | Running | identity ns |
+| SecretStores | 3/3 Ready | identity ns manually reconciled |
+
+BATS (clean env): 158/158 passing — 
+ok 154 _vault_bootstrap_ha errors when vault health check fails
+ok 155 _vault_bootstrap_ha reports ready when health check succeeds
+ok 156 _vault_is_sealed returns 0 when Vault is sealed
+ok 157 _vault_is_sealed returns 1 when Vault is unsealed
+ok 158 _vault_is_sealed returns 2 when status cannot be determined
+
+Regressions: NONE
+Unexpected findings: identity/vault-kv-store InvalidProviderConfig resolved manually. See Issue 2026-03-07.
+
+Status: COMPLETE

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,8 @@
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| — | TBD — awaiting owner direction | — | pending |
+| 1 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | **active** — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
+| 2 | Implement `_resolve_script_dir` in lib-foundation | Codex | **active** — spec in lib-foundation memory-bank, branch `feature/v0.1.1-script-dir-resolver` |
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,40 @@
+# Progress — lib-foundation
+
+## Overall Status
+
+**Active** — v0.1.0 shipped; v0.1.1 adds `_resolve_script_dir` helper.
+
+---
+
+## What Is Complete
+
+- [x] GitHub repo created: `wilddog64/lib-foundation`
+- [x] Directory structure: `scripts/lib/`, `scripts/tests/lib/`, `memory-bank/`
+- [x] `CLAUDE.md` — navigation + key contracts + testing rules
+- [x] `.clinerules` — Cline-compatible agent instructions
+- [x] `memory-bank/` — context carried over from k3d-manager v0.6.5
+- [x] Branch protection — `required_linear_history`, no force push, required status checks (`shellcheck`, `bats`)
+- [x] CI — `.github/workflows/ci.yaml` — shellcheck + BATS 1.13.0, pre-extraction graceful skip, `env -i` clean env. ✅ green
+- [x] `scripts/lib/core.sh` + `scripts/lib/system.sh` imported from k3d-manager (Codex) — shellcheck run; BATS suite empty (1..0)
+- [x] `system.sh` shellcheck cleanup — SC2016 annotations, quoting fixes, and `_detect_cluster_name` locals (Codex)
+- [x] `_resolve_script_dir` helper added to `core.sh` with BATS coverage (Codex, v0.1.1)
+
+---
+
+## What Is Pending
+
+- [ ] Wire lib-foundation subtree back into k3d-manager (`git subtree pull/push`, Codex follow-up)
+- [ ] Integrate lib-foundation as subtree remote back into k3d-manager
+- [ ] Broader BATS coverage for remaining lib functions
+- [ ] Consumer integration: `rigor-cli`
+- [ ] Consumer integration: `shopping-carts`
+
+---
+
+## Known Constraints
+
+| Item | Notes |
+|---|---|
+| `SCRIPT_DIR` dependency | `system.sh` sources `agent_rigor.sh` via `$SCRIPT_DIR` at load time — must resolve correctly in subtree layout |
+| Contract stability | `_run_command`, `_detect_platform`, `_cluster_provider` — signature changes require all-consumer coordination |
+| Clean env testing | BATS must run with `env -i` — ambient `SCRIPT_DIR` causes false passes |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -32,6 +32,7 @@
 - [x] BATS tests for `_agent_audit` bare sudo + kubectl exec — suite 9/9, total 158/158
 - [x] `lib-foundation` repo created — https://github.com/wilddog64/lib-foundation
 - [x] `core.sh` + `system.sh` extracted to lib-foundation (PR #1 open, CI green)
+- [x] Ubuntu k3s validation gate — full 5-phase teardown/rebuild verified (158/158 BATS pass)
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -58,6 +58,7 @@
 | Item | Status | Notes |
 |---|---|---|
 | GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | False positive — mark in dashboard. |
+| `deploy_cluster` if-count violation (12 > 8) | OPEN | Extract `_deploy_cluster_resolve_provider`. Fix duplicate mac+k3s guard. See `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`. Target: v0.7.0. |
 | `CLUSTER_NAME` env var ignored during `deploy_cluster` | OPEN | See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
 | `deploy_jenkins` (no flags) broken | OPEN | Use `--enable-vault` as workaround. |
 | No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | Future work. |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,14 +2,14 @@
 
 ## Overall Status
 
-**v0.6.4 SHIPPED** — tag `v0.6.4` pushed, PR #22 merged 2026-03-07.
-**v0.6.5 ACTIVE** — branch `k3d-manager-v0.6.5` cut from main 2026-03-07.
+**v0.6.5 SHIPPED** — tag `v0.6.5` pushed, PR #23 merged 2026-03-07.
+**v0.7.0 ACTIVE** — branch `k3d-manager-v0.7.0` cut from main 2026-03-07.
 
 ---
 
 ## What Is Complete
 
-### Released (v0.1.0 – v0.6.4)
+### Released (v0.1.0 – v0.6.5)
 
 - [x] k3d/OrbStack/k3s cluster provider abstraction
 - [x] Vault PKI, ESO, Istio, Jenkins, OpenLDAP, ArgoCD, Keycloak (infra cluster)
@@ -25,35 +25,27 @@
 - [x] `_detect_platform` — single source of truth for OS detection
 - [x] `_run_command` TTY flakiness fix
 - [x] Linux k3s gate — 5-phase teardown/rebuild on Ubuntu 24.04 VM
-- [x] BATS source install 404 fix — 1.10.0 → 1.13.0, archive URL
 - [x] `_agent_audit` hardening — bare sudo detection + kubectl exec credential scan
 - [x] Pre-commit hook — `_agent_audit` wired to every commit
 - [x] Provider contract BATS suite — 30 tests (3 providers × 10 functions)
-- [x] `_provider_orbstack_expose_ingress` missing function added
-- [x] Copilot P1/P2 fixes — `git diff --cached`, diff-based sudo scan, `\b` pattern
-- [x] BATS suite: 154/154 passing (v0.6.4)
-- [x] `_agent_audit` awk → pure bash rewrite (bash 3.2+, no macOS BSD awk dependency)
-- [x] BATS tests for `_agent_audit` bare sudo + kubectl exec — 4 new tests, suite 9/9, total 158/158
+- [x] `_agent_audit` awk → pure bash rewrite (bash 3.2+, macOS BSD awk compatible)
+- [x] BATS tests for `_agent_audit` bare sudo + kubectl exec — suite 9/9, total 158/158
+- [x] `lib-foundation` repo created — https://github.com/wilddog64/lib-foundation
+- [x] `core.sh` + `system.sh` extracted to lib-foundation (PR #1 open, CI green)
 
 ---
 
 ## What Is Pending
 
-### Priority 1 — v0.6.5 (active)
+### Priority 1 — v0.7.0 (active)
 
-- [x] BATS tests for `_agent_audit` new checks — bare sudo + kubectl exec (Gemini) ✅
-- [x] Create `lib-foundation` repository + branch protection + CI (owner) ✅
-- [x] Extract `core.sh` + `system.sh` into lib-foundation (Codex) — PR #1 open, CI green
-
-### Priority 2 — v0.7.0
-
+- [ ] Keycloak provider interface
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) on Ubuntu
 - [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) on Ubuntu
 - [ ] `CLUSTER_NAME` env var respected during `deploy_cluster`
-- [ ] Keycloak provider interface
 
-### Priority 3 — v0.8.0
+### Priority 2 — v0.8.0
 
 - [ ] `k3dm-mcp` — lean MCP server wrapping k3d-manager CLI
 - [ ] Target clients: Claude Desktop, Codex, Atlas, Comet

--- a/scripts/k3d-manager
+++ b/scripts/k3d-manager
@@ -50,9 +50,10 @@ source "${SCRIPT_DIR}/lib/cluster_provider.sh"
 source "${SCRIPT_DIR}/lib/test.sh"
 if [[ -f "${SCRIPT_DIR}/lib/foundation/scripts/lib/core.sh" ]]; then
    source "${SCRIPT_DIR}/lib/foundation/scripts/lib/core.sh"
-else
-   source "${SCRIPT_DIR}/lib/core.sh"
 fi
+# Always source local core.sh — its deploy_cluster and CLUSTER_NAME fixes
+# override any older definitions from the lib-foundation subtree during transition.
+source "${SCRIPT_DIR}/lib/core.sh"
 source "${SCRIPT_DIR}/lib/help/utils.sh"
 
 CLUSTER_ROLE="${CLUSTER_ROLE:-infra}"

--- a/scripts/k3d-manager
+++ b/scripts/k3d-manager
@@ -40,10 +40,19 @@ PLUGINS_DIR="${SCRIPT_DIR}/plugins"
 
 # load our library functions
 source "${SCRIPT_DIR}/lib/provider.sh"
-source "${SCRIPT_DIR}/lib/system.sh"
+# lib-foundation subtree — prefer subtree copy; fall back to local for transition
+if [[ -f "${SCRIPT_DIR}/lib/foundation/scripts/lib/system.sh" ]]; then
+   source "${SCRIPT_DIR}/lib/foundation/scripts/lib/system.sh"
+else
+   source "${SCRIPT_DIR}/lib/system.sh"
+fi
 source "${SCRIPT_DIR}/lib/cluster_provider.sh"
 source "${SCRIPT_DIR}/lib/test.sh"
-source "${SCRIPT_DIR}/lib/core.sh"
+if [[ -f "${SCRIPT_DIR}/lib/foundation/scripts/lib/core.sh" ]]; then
+   source "${SCRIPT_DIR}/lib/foundation/scripts/lib/core.sh"
+else
+   source "${SCRIPT_DIR}/lib/core.sh"
+fi
 source "${SCRIPT_DIR}/lib/help/utils.sh"
 
 CLUSTER_ROLE="${CLUSTER_ROLE:-infra}"

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -1,0 +1,820 @@
+# shellcheck shell=bash
+function _cluster_provider() {
+   local provider="${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${CLUSTER_PROVIDER:-}}}"
+
+   # If no provider set, auto-detect based on available binaries
+   if [[ -z "$provider" ]]; then
+      if command -v k3d >/dev/null 2>&1; then
+         provider="k3d"
+      elif command -v k3s >/dev/null 2>&1; then
+         provider="k3s"
+      else
+         provider="k3d"  # Default fallback
+      fi
+   fi
+
+   provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+
+   case "$provider" in
+      k3d|orbstack|k3s)
+         printf '%s' "$provider"
+         ;;
+      *)
+         _err "Unsupported cluster provider: $provider"
+         ;;
+   esac
+}
+
+function _ensure_path_exists() {
+   local dir="$1"
+   [[ -z "$dir" ]] && return 0
+
+   if [[ -d "$dir" ]]; then
+      return 0
+   fi
+
+   if _run_command --prefer-sudo -- mkdir -p "$dir"; then
+      return 0
+   fi
+
+   _err "Cannot create directory '$dir'. Create it manually, configure sudo, or set K3S_CONFIG_DIR to a writable path."
+}
+
+function _ensure_port_available() {
+   local port="$1"
+   [[ -z "$port" ]] && return 0
+
+   if ! _command_exist python3; then
+      _warn "python3 is not available; skipping port availability check for $port"
+      return 0
+   fi
+
+   local script
+   script=$(cat <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+s = socket.socket()
+try:
+    s.bind(("0.0.0.0", port))
+except OSError as exc:
+    print(f"Port {port} unavailable: {exc}", file=sys.stderr)
+    sys.exit(1)
+finally:
+    try:
+        s.close()
+    except Exception:
+        pass
+PY
+)
+
+   if ! _run_command --prefer-sudo -- python3 - "$port" <<<"$script"; then
+      _err "Port $port is already in use"
+   fi
+}
+
+function _resolve_script_dir() {
+   local src="${BASH_SOURCE[1]}"
+   local dir
+   while [[ -h "$src" ]]; do
+      dir="$(cd -P "$(dirname "$src")" && pwd)"
+      src="$(readlink "$src")"
+      if [[ "$src" != /* ]]; then
+         src="$dir/$src"
+      fi
+   done
+   dir="$(cd -P "$(dirname "$src")" && pwd)"
+   printf '%s\n' "$dir"
+}
+
+function _k3s_asset_dir() {
+   printf '%s/etc/k3s' "$(dirname "$SOURCE")"
+}
+
+function _k3s_template_path() {
+   local name="${1:-}"
+   printf '%s/%s' "$(_k3s_asset_dir)" "$name"
+}
+
+function _k3s_detect_ip() {
+   local override="${K3S_NODE_IP:-${NODE_IP:-}}"
+   if [[ -n "$override" ]]; then
+      printf '%s\n' "$override"
+      return 0
+   fi
+
+   if declare -f _ip >/dev/null 2>&1; then
+      local detected
+      detected=$(_ip 2>/dev/null || true)
+      detected="${detected//$'\r'/}"
+      detected="${detected//$'\n'/}"
+      detected="${detected## }"
+      detected="${detected%% }"
+      if [[ -n "$detected" ]]; then
+         printf '%s\n' "$detected"
+         return 0
+      fi
+   fi
+
+   printf '127.0.0.1\n'
+}
+
+function _k3s_stage_file() {
+   local src="$1"
+   local dest="$2"
+   local mode="${3:-0644}"
+
+   if [[ -z "$src" || -z "$dest" ]]; then
+      [[ -n "$src" ]] && rm -f "$src"
+      return 1
+   fi
+
+   local dir
+   dir="$(dirname "$dest")"
+   _ensure_path_exists "$dir"
+
+   if [[ -f "$dest" ]] && cmp -s "$src" "$dest" 2>/dev/null; then
+      rm -f "$src"
+      return 0
+   fi
+
+   if command -v install >/dev/null 2>&1; then
+      _run_command --prefer-sudo -- install -m "$mode" "$src" "$dest"
+      rm -f "$src"
+      return 0
+   fi
+
+   _run_command --prefer-sudo -- cp "$src" "$dest"
+   _run_command --prefer-sudo -- chmod "$mode" "$dest"
+   rm -f "$src"
+}
+
+function _k3s_render_template() {
+   local template="$1"
+   local destination="$2"
+   local mode="${3:-0644}"
+
+   if [[ ! -r "$template" ]]; then
+      return 0
+   fi
+
+   local tmp
+   tmp="$(mktemp -t k3s-istio-template.XXXXXX)"
+   envsubst <"$template" >"$tmp"
+   _k3s_stage_file "$tmp" "$destination" "$mode"
+}
+
+function _k3s_prepare_assets() {
+   _ensure_path_exists "$K3S_CONFIG_DIR"
+   _ensure_path_exists "$K3S_MANIFEST_DIR"
+   _ensure_path_exists "$K3S_LOCAL_STORAGE"
+
+   local ip saved_ip
+   ip="$(_k3s_detect_ip)"
+   saved_ip="${IP:-}"
+   export IP="$ip"
+
+   _k3s_render_template "$(_k3s_template_path config.yaml.tmpl)" "$K3S_CONFIG_FILE"
+   _k3s_render_template "$(_k3s_template_path local-path-storage.yaml.tmpl)" \
+      "${K3S_MANIFEST_DIR}/local-path-storage.yaml"
+
+   if [[ -n "$saved_ip" ]]; then
+      export IP="$saved_ip"
+   else
+      unset IP
+   fi
+}
+
+function _k3s_cluster_exists() {
+   [[ -f "$K3S_SERVICE_FILE" ]] && return 0 || return 1
+}
+
+function _install_k3s() {
+   local cluster_name="${1:-${CLUSTER_NAME:-k3s-cluster}}"
+
+   export CLUSTER_NAME="$cluster_name"
+
+   if _is_mac ; then
+      if _command_exist k3s ; then
+         _info "k3s already installed, skipping"
+         return 0
+      fi
+
+      local arch asset tmpfile dest
+      arch="$(uname -m)"
+      case "$arch" in
+         arm64|aarch64)
+            asset="k3s-darwin-arm64"
+            ;;
+         x86_64|amd64)
+            asset="k3s-darwin-amd64"
+            ;;
+         *)
+            _err "Unsupported macOS architecture for k3s: $arch"
+            ;;
+      esac
+
+      tmpfile="$(mktemp -t k3s-download.XXXXXX)"
+      dest="${K3S_INSTALL_DIR}/k3s"
+
+      _info "Downloading k3s binary for macOS ($arch)"
+      _curl -fsSL "https://github.com/k3s-io/k3s/releases/latest/download/${asset}" -o "$tmpfile"
+
+      _ensure_path_exists "$K3S_INSTALL_DIR"
+
+      _run_command --prefer-sudo -- mv "$tmpfile" "$dest"
+      _run_command --prefer-sudo -- chmod 0755 "$dest"
+
+      _info "Installed k3s binary at $dest"
+      return 0
+   fi
+
+   if ! _is_debian_family && ! _is_redhat_family && ! _is_wsl ; then
+      if _command_exist k3s ; then
+         _info "k3s already installed, skipping installer"
+         return 0
+      fi
+
+      _err "Unsupported platform for k3s installation"
+   fi
+
+   _k3s_prepare_assets
+
+   if _command_exist k3s ; then
+      _info "k3s already installed, skipping installer"
+      return 0
+   fi
+
+   local installer
+   installer="$(mktemp -t k3s-installer.XXXXXX)"
+   _info "Fetching k3s installer script"
+   _curl -fsSL https://get.k3s.io -o "$installer"
+
+   local install_exec
+   if [[ -n "${INSTALL_K3S_EXEC:-}" ]]; then
+      install_exec="${INSTALL_K3S_EXEC}"
+   else
+      install_exec="server --write-kubeconfig-mode 0644"
+      if [[ -f "$K3S_CONFIG_FILE" ]]; then
+         install_exec+=" --config ${K3S_CONFIG_FILE}"
+      fi
+      export INSTALL_K3S_EXEC="$install_exec"
+   fi
+
+   _info "Running k3s installer"
+   _run_command --prefer-sudo -- env INSTALL_K3S_EXEC="$install_exec" \
+      sh "$installer"
+
+   rm -f "$installer"
+
+   if _systemd_available ; then
+      _run_command --prefer-sudo -- systemctl enable "$K3S_SERVICE_NAME"
+   else
+      _warn "systemd not available; skipping enable for $K3S_SERVICE_NAME"
+   fi
+}
+
+function _teardown_k3s_cluster() {
+   if _is_mac ; then
+      local dest="${K3S_INSTALL_DIR}/k3s"
+      if [[ -f "$dest" ]]; then
+         if [[ -w "$dest" ]]; then
+            rm -f "$dest"
+         else
+            _run_command --prefer-sudo -- rm -f "$dest"
+         fi
+         _info "Removed k3s binary at $dest"
+      fi
+      return 0
+   fi
+
+   if [[ -x "/usr/local/bin/k3s-uninstall.sh" ]]; then
+      _run_command --prefer-sudo -- /usr/local/bin/k3s-uninstall.sh
+      return 0
+   fi
+
+   if [[ -x "/usr/local/bin/k3s-killall.sh" ]]; then
+      _run_command --prefer-sudo -- /usr/local/bin/k3s-killall.sh
+      return 0
+   fi
+
+   if _k3s_cluster_exists; then
+      if _systemd_available ; then
+         _run_command --prefer-sudo -- systemctl stop "$K3S_SERVICE_NAME"
+         _run_command --prefer-sudo -- systemctl disable "$K3S_SERVICE_NAME"
+      else
+         _warn "systemd not available; skipping service shutdown for $K3S_SERVICE_NAME"
+      fi
+   fi
+}
+
+function _start_k3s_service() {
+   local -a server_args
+
+   if [[ -n "${INSTALL_K3S_EXEC:-}" ]]; then
+      read -r -a server_args <<<"${INSTALL_K3S_EXEC}"
+   else
+      server_args=(server --write-kubeconfig-mode 0644)
+      if [[ -f "$K3S_CONFIG_FILE" ]]; then
+         server_args+=(--config "$K3S_CONFIG_FILE")
+      fi
+   fi
+
+   if _systemd_available ; then
+      _run_command --prefer-sudo -- systemctl start "$K3S_SERVICE_NAME"
+      return 0
+   fi
+
+   _warn "systemd not available; starting k3s server in background"
+
+   if command -v pgrep >/dev/null 2>&1; then
+      if pgrep -x k3s >/dev/null 2>&1; then
+         _info "k3s already running; skipping manual start"
+         return 0
+      fi
+   fi
+
+   local manual_cmd
+   manual_cmd="$(printf '%q ' k3s "${server_args[@]}")"
+   manual_cmd="${manual_cmd% }"
+
+   local log_file="${K3S_DATA_DIR}/k3s-no-systemd.log"
+   export K3S_NO_SYSTEMD_LOG="$log_file"
+
+   _ensure_path_exists "$(dirname "$log_file")"
+
+   local log_escaped
+   log_escaped="$(printf '%q' "$log_file")"
+
+   local start_cmd
+   start_cmd="nohup ${manual_cmd} >> ${log_escaped} 2>&1 &"
+
+   if (( EUID == 0 )); then
+      _run_command -- sh -c "$start_cmd"
+      return 0
+   fi
+
+   if _run_command --require-sudo -- sh -c "$start_cmd"; then
+      return 0
+   fi
+
+   local instruction
+   instruction="nohup ${manual_cmd} >> ${log_file} 2>&1 &"
+   _err "systemd not available and sudo access is required to start k3s automatically. Run manually as root: ${instruction}"
+}
+
+function _deploy_k3s_cluster() {
+   if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+      echo "Usage: deploy_k3s_cluster [cluster_name=k3s-cluster]"
+      return 0
+   fi
+
+   local cluster_name="${1:-k3s-cluster}"
+   export CLUSTER_NAME="$cluster_name"
+
+   if _is_mac ; then
+      _warn "k3s server deployment is not supported natively on macOS. Installed binaries only."
+      return 0
+   fi
+
+   _install_k3s "$cluster_name"
+
+   _start_k3s_service
+
+   local kubeconfig_src="$K3S_KUBECONFIG_PATH"
+   local timeout=60
+   local kubeconfig_ready=1
+   while (( timeout > 0 )); do
+      if _run_command --soft --quiet --prefer-sudo -- test -r "$kubeconfig_src"; then
+         kubeconfig_ready=0
+         break
+      fi
+      sleep 2
+      timeout=$((timeout - 2))
+   done
+
+   if (( kubeconfig_ready != 0 )); then
+      if [[ -n "${K3S_NO_SYSTEMD_LOG:-}" ]]; then
+         local log_output=""
+         if [[ -r "$K3S_NO_SYSTEMD_LOG" ]]; then
+            log_output="$(tail -n 20 "$K3S_NO_SYSTEMD_LOG" 2>/dev/null || true)"
+         else
+            log_output="$(_run_command --soft --quiet --prefer-sudo -- tail -n 20 "$K3S_NO_SYSTEMD_LOG" 2>/dev/null || true)"
+         fi
+
+         if [[ -n "$log_output" ]]; then
+            _warn "Recent k3s log output:"
+            while IFS= read -r line; do
+               [[ -n "$line" ]] && _warn "  $line"
+            done <<< "$log_output"
+         fi
+      fi
+
+      _err "Timed out waiting for k3s kubeconfig at $kubeconfig_src"
+   fi
+
+   unset K3S_NO_SYSTEMD_LOG
+
+   local dest_kubeconfig="${KUBECONFIG:-$HOME/.kube/config}"
+   _ensure_path_exists "$(dirname "$dest_kubeconfig")"
+
+   _run_command --prefer-sudo -- cp "$kubeconfig_src" "$dest_kubeconfig"
+   _run_command --prefer-sudo -- chown "$(id -u):$(id -g)" "$dest_kubeconfig" 2>/dev/null || true
+   _run_command --prefer-sudo -- chmod 0600 "$dest_kubeconfig" 2>/dev/null || true
+
+   export KUBECONFIG="$dest_kubeconfig"
+
+   _info "k3s cluster '$CLUSTER_NAME' is ready"
+}
+function _install_docker() {
+   local platform
+   platform="$(_detect_platform)"
+
+   case "$platform" in
+      mac)
+         _install_mac_docker
+         ;;
+      debian|wsl)
+         _install_debian_docker
+         ;;
+      redhat)
+         _install_redhat_docker
+         ;;
+      *)
+         _err "Unsupported platform for Docker installation: $platform"
+         ;;
+   esac
+}
+
+function _install_istioctl() {
+   install_dir="${1:-/usr/local/bin}"
+
+   if _command_exist istioctl ; then
+      echo "istioctl already exists, skip installation"
+      return 0
+   fi
+
+   echo "install dir: ${install_dir}"
+   if [[ ! -e "$install_dir" && ! -d "$install_dir" ]]; then
+      if mkdir -p "${install_dir}" 2>/dev/null; then
+         :
+      else
+         _run_command --prefer-sudo -- mkdir -p "${install_dir}"
+      fi
+   fi
+
+   if  ! _command_exist istioctl ; then
+      echo installing istioctl
+      tmp_script=$(mktemp -t istioctl-fetch.XXXXXX)
+      trap 'rm -rf /tmp/istio-*' EXIT TERM
+      pushd /tmp >/dev/null || return 1
+      curl -f -s https://raw.githubusercontent.com/istio/istio/master/release/downloadIstioCandidate.sh -o "$tmp_script"
+      istio_bin=$(bash "$tmp_script" | perl -nle 'print $1 if /add the (.*) directory/')
+      if [[ -z "$istio_bin" ]]; then
+         echo "Failed to download istioctl"
+         exit 1
+      fi
+      if [[ -w "${install_dir}" ]]; then
+         _run_command -- cp -v "$istio_bin/istioctl" "${install_dir}/"
+      else
+         _run_command --prefer-sudo -- cp -v "$istio_bin/istioctl" "${install_dir}/"
+      fi
+      popd >/dev/null || return 1
+   fi
+
+}
+
+function _cleanup_on_success() {
+   local file_to_cleanup=$1
+   local logger="_info"
+   if ! declare -f _info >/dev/null 2>&1; then
+      logger=""
+   fi
+
+   if [[ -n "$file_to_cleanup" ]]; then
+      if [[ -n "$logger" ]]; then
+         "$logger" "Cleaning up temporary files... : $file_to_cleanup :"
+      else
+         printf 'INFO: Cleaning up temporary files... : %s :\n' "$file_to_cleanup" >&2
+      fi
+      rm -rf "$file_to_cleanup"
+   fi
+   local path
+   for path in "$@"; do
+      [[ -n "$path" ]] || continue
+      if [[ -n "$logger" ]]; then
+         "$logger" "Cleaning up temporary files... : $path :"
+      else
+         printf 'INFO: Cleaning up temporary files... : %s :\n' "$path" >&2
+      fi
+      rm -rf -- "$path"
+   done
+}
+
+function _cleanup_trap_command() {
+   local cmd="_cleanup_on_success" path
+
+   for path in "$@"; do
+      [[ -n "$path" ]] || continue
+      printf -v cmd '%s %q' "$cmd" "$path"
+   done
+
+   printf '%s' "$cmd"
+}
+function _install_smb_csi_driver() {
+   if _is_mac ; then
+      _warn "[smb-csi] SMB CSI driver is not supported on macOS; skipping. Use Linux/k3s to validate."
+      return 0
+   fi
+
+   local release="${SMB_CSI_RELEASE:-smb-csi-driver}"
+   local namespace="${SMB_CSI_NAMESPACE:-kube-system}"
+   local chart_repo="https://kubernetes-sigs.github.io/smb-csi-driver"
+
+   _install_helm
+   _helm repo add smb-csi-driver "$chart_repo"
+   _helm repo update
+   _helm upgrade --install "$release" smb-csi-driver/smb-csi-driver \
+      --namespace "$namespace" --create-namespace
+}
+
+function _create_nfs_share() {
+   if _is_mac; then
+      _create_nfs_share_mac "$HOME/k3d-nfs"
+   fi
+}
+
+function _install_k3d() {
+   _cluster_provider_call install "$@"
+}
+
+function destroy_cluster() {
+   _cluster_provider_call destroy_cluster "$@"
+}
+
+function destroy_k3d_cluster() {
+   destroy_cluster "$@"
+}
+
+function destroy_k3s_cluster() {
+   destroy_cluster "$@"
+}
+
+function _create_cluster() {
+   _cluster_provider_call create_cluster "$@"
+}
+
+function create_cluster() {
+   local dry_run=0 show_help=0
+   local -a positional=()
+
+   while [[ $# -gt 0 ]]; do
+      case "$1" in
+         --dry-run|-n)
+            dry_run=1
+            shift
+            ;;
+         -h|--help)
+            show_help=1
+            shift
+            ;;
+         --)
+            shift
+            while [[ $# -gt 0 ]]; do
+               positional+=("$1")
+               shift
+            done
+            break
+            ;;
+         *)
+            positional+=("$1")
+            shift
+            ;;
+      esac
+   done
+
+   if (( show_help )); then
+      cat <<'EOF'
+Usage: create_cluster [cluster_name] [http_port=8000] [https_port=8443]
+
+Options:
+  --dry-run            Resolve provider, print intent, and exit.
+  -h, --help           Show this help message.
+EOF
+      return 0
+   fi
+
+   if (( dry_run )); then
+      local provider args_desc="defaults"
+      if ! provider=$(_cluster_provider_get_active); then
+         _err "Failed to resolve cluster provider for create_cluster dry-run."
+      fi
+
+      if (( ${#positional[@]} )); then
+         args_desc="${positional[*]}"
+      fi
+
+      _info "create_cluster dry-run: provider=${provider}; args=${args_desc}"
+      return 0
+   fi
+
+   _create_cluster "${positional[@]}"
+}
+
+function _create_k3d_cluster() {
+   _create_cluster "$@"
+}
+
+function create_k3d_cluster() {
+   create_cluster "$@"
+}
+
+function _create_k3s_cluster() {
+   _create_cluster "$@"
+}
+
+function create_k3s_cluster() {
+   create_cluster "$@"
+}
+
+function deploy_cluster() {
+   local force_k3s=0 provider_cli="" show_help=0
+   local -a positional=()
+
+   while [[ $# -gt 0 ]]; do
+      case "$1" in
+         -f|--force-k3s)
+            force_k3s=1
+            shift
+            ;;
+         --provider)
+            provider_cli="${2:-}"
+            shift 2
+            ;;
+         --provider=*)
+            provider_cli="${1#*=}"
+            shift
+            ;;
+         -h|--help)
+            show_help=1
+            shift
+            ;;
+         --)
+            shift
+            while [[ $# -gt 0 ]]; do
+               positional+=("$1")
+               shift
+            done
+            break
+            ;;
+         *)
+            positional+=("$1")
+            shift
+            ;;
+      esac
+   done
+
+   if (( show_help )); then
+      cat <<'EOF'
+Usage: deploy_cluster [options] [cluster_name]
+
+Options:
+  -f, --force-k3s     Skip the provider prompt and deploy using k3s.
+  --provider <name>   Explicitly set the provider (k3d or k3s).
+  -h, --help          Show this help message.
+EOF
+      return 0
+   fi
+
+   local platform="" platform_msg=""
+   platform="$(_detect_platform)"
+   case "$platform" in
+      mac)
+         platform_msg="Detected macOS environment."
+         ;;
+      wsl)
+         platform_msg="Detected Windows Subsystem for Linux environment."
+         ;;
+      debian)
+         platform_msg="Detected Debian-based Linux environment."
+         ;;
+      redhat)
+         platform_msg="Detected Red Hat-based Linux environment."
+         ;;
+      linux)
+         platform_msg="Detected generic Linux environment."
+         ;;
+   esac
+
+   if [[ -n "$platform_msg" ]]; then
+      _info "$platform_msg"
+   fi
+
+   local provider=""
+   if [[ -n "$provider_cli" ]]; then
+      provider="$provider_cli"
+   elif (( force_k3s )); then
+      provider="k3s"
+   else
+      local env_override="${CLUSTER_PROVIDER:-${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${K3D_MANAGER_CLUSTER_PROVIDER:-}}}}"
+      if [[ -n "$env_override" ]]; then
+         provider="$env_override"
+      fi
+   fi
+
+   provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+
+   if [[ "$platform" == "mac" && "$provider" == "k3s" ]]; then
+      _err "k3s is not supported on macOS; please use k3d instead."
+   fi
+
+   if [[ -z "$provider" ]]; then
+      if [[ "$platform" == "mac" ]]; then
+         provider="k3d"
+      else
+         local has_tty=0
+         if [[ -t 0 && -t 1 ]]; then
+            has_tty=1
+         fi
+
+         if (( has_tty )); then
+            local choice=""
+            while true; do
+               printf 'Select cluster provider [k3d/k3s] (default: k3d): '
+               IFS= read -r choice || choice=""
+               choice="$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')"
+               if [[ -z "$choice" ]]; then
+                  provider="k3d"
+                  break
+               fi
+               case "$choice" in
+                  k3d|k3s)
+                     provider="$choice"
+                     break
+                     ;;
+                  *)
+                     _warn "Unsupported selection '$choice'. Please choose k3d or k3s."
+                     ;;
+               esac
+            done
+         else
+            provider="k3d"
+            _info "Non-interactive session detected; defaulting to k3d provider."
+         fi
+      fi
+   fi
+
+   if [[ "$platform" == "mac" && "$provider" == "k3s" ]]; then
+      _err "k3s is not supported on macOS; please use k3d instead."
+   fi
+
+   case "$provider" in
+      k3d|orbstack|k3s)
+         ;;
+      "")
+         _err "Failed to determine cluster provider."
+         ;;
+      *)
+         _err "Unsupported cluster provider: $provider"
+         ;;
+   esac
+
+   export CLUSTER_PROVIDER="$provider"
+   export K3D_MANAGER_PROVIDER="$provider"
+   export K3D_MANAGER_CLUSTER_PROVIDER="$provider"
+   if declare -f _cluster_provider_set_active >/dev/null 2>&1; then
+      _cluster_provider_set_active "$provider"
+   fi
+
+   _info "Using cluster provider: $provider"
+   _cluster_provider_call deploy_cluster "${positional[@]}"
+}
+
+function deploy_k3d_cluster() {
+   deploy_cluster "$@"
+}
+
+function deploy_k3s_cluster() {
+   deploy_cluster "$@"
+}
+
+function deploy_ldap() {
+   _try_load_plugin deploy_ldap "$@"
+}
+
+function expose_ingress() {
+   _cluster_provider_call expose_ingress "$@"
+}
+
+function setup_ingress_forward() {
+   expose_ingress setup
+}
+
+function status_ingress_forward() {
+   expose_ingress status
+}
+
+function remove_ingress_forward() {
+   expose_ingress remove
+}

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -454,7 +454,7 @@ function _install_istioctl() {
       echo installing istioctl
       tmp_script=$(mktemp -t istioctl-fetch.XXXXXX)
       trap 'rm -rf /tmp/istio-*' EXIT TERM
-      pushd /tmp
+      pushd /tmp || return
       curl -f -s https://raw.githubusercontent.com/istio/istio/master/release/downloadIstioCandidate.sh -o "$tmp_script"
       istio_bin=$(bash "$tmp_script" | perl -nle 'print $1 if /add the (.*) directory/')
       if [[ -z "$istio_bin" ]]; then
@@ -466,7 +466,7 @@ function _install_istioctl() {
       else
          _run_command --prefer-sudo -- cp -v "$istio_bin/istioctl" "${install_dir}/"
       fi
-      popd
+      popd || return
    fi
 
 }
@@ -624,6 +624,58 @@ function create_k3s_cluster() {
    create_cluster "$@"
 }
 
+function _deploy_cluster_prompt_provider() {
+   local choice="" provider=""
+   while true; do
+      printf 'Select cluster provider [k3d/k3s] (default: k3d): '
+      IFS= read -r choice || choice=""
+      choice="$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')"
+      if [[ -z "$choice" ]]; then
+         provider="k3d"
+         break
+      fi
+      case "$choice" in
+         k3d|k3s)
+            provider="$choice"
+            break
+            ;;
+         *)
+            _warn "Unsupported selection '$choice'. Please choose k3d or k3s."
+            ;;
+      esac
+   done
+   printf '%s' "$provider"
+}
+
+function _deploy_cluster_resolve_provider() {
+   local platform="$1" provider_cli="$2" force_k3s="$3"
+   local provider="" env_override=""
+   env_override="${CLUSTER_PROVIDER:-${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${K3D_MANAGER_CLUSTER_PROVIDER:-}}}}"
+
+   if [[ -n "$provider_cli" ]]; then
+      provider="$provider_cli"
+   elif (( force_k3s )); then
+      provider="k3s"
+   elif [[ -n "$env_override" ]]; then
+      provider="$env_override"
+   fi
+
+   provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+
+   if [[ -z "$provider" ]]; then
+      if [[ "$platform" == "mac" ]]; then
+         provider="k3d"
+      elif [[ -t 0 && -t 1 ]]; then
+         provider="$(_deploy_cluster_prompt_provider)"
+      else
+         _info "Non-interactive session detected; defaulting to k3d provider."
+         provider="k3d"
+      fi
+   fi
+
+   printf '%s' "$provider"
+}
+
 function deploy_cluster() {
    local force_k3s=0 provider_cli="" show_help=0
    local -a positional=()
@@ -698,58 +750,7 @@ EOF
    fi
 
    local provider=""
-   if [[ -n "$provider_cli" ]]; then
-      provider="$provider_cli"
-   elif (( force_k3s )); then
-      provider="k3s"
-   else
-      local env_override="${CLUSTER_PROVIDER:-${K3D_MANAGER_PROVIDER:-${K3DMGR_PROVIDER:-${K3D_MANAGER_CLUSTER_PROVIDER:-}}}}"
-      if [[ -n "$env_override" ]]; then
-         provider="$env_override"
-      fi
-   fi
-
-   provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
-
-   if [[ "$platform" == "mac" && "$provider" == "k3s" ]]; then
-      _err "k3s is not supported on macOS; please use k3d instead."
-   fi
-
-   if [[ -z "$provider" ]]; then
-      if [[ "$platform" == "mac" ]]; then
-         provider="k3d"
-      else
-         local has_tty=0
-         if [[ -t 0 && -t 1 ]]; then
-            has_tty=1
-         fi
-
-         if (( has_tty )); then
-            local choice=""
-            while true; do
-               printf 'Select cluster provider [k3d/k3s] (default: k3d): '
-               IFS= read -r choice || choice=""
-               choice="$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')"
-               if [[ -z "$choice" ]]; then
-                  provider="k3d"
-                  break
-               fi
-               case "$choice" in
-                  k3d|k3s)
-                     provider="$choice"
-                     break
-                     ;;
-                  *)
-                     _warn "Unsupported selection '$choice'. Please choose k3d or k3s."
-                     ;;
-               esac
-            done
-         else
-            provider="k3d"
-            _info "Non-interactive session detected; defaulting to k3d provider."
-         fi
-      fi
-   fi
+   provider="$(_deploy_cluster_resolve_provider "$platform" "$provider_cli" "$force_k3s")"
 
    if [[ "$platform" == "mac" && "$provider" == "k3s" ]]; then
       _err "k3s is not supported on macOS; please use k3d instead."
@@ -771,6 +772,12 @@ EOF
    export K3D_MANAGER_CLUSTER_PROVIDER="$provider"
    if declare -f _cluster_provider_set_active >/dev/null 2>&1; then
       _cluster_provider_set_active "$provider"
+   fi
+
+   local cluster_name_value="${positional[0]:-${CLUSTER_NAME:-}}"
+   if [[ -n "$cluster_name_value" ]]; then
+      positional=("$cluster_name_value" "${positional[@]:1}")
+      export CLUSTER_NAME="$cluster_name_value"
    fi
 
    _info "Using cluster provider: $provider"

--- a/scripts/lib/foundation/.clinerules
+++ b/scripts/lib/foundation/.clinerules
@@ -29,7 +29,7 @@ memory-bank/              — persistent agent context (read before any task)
 ## Key Contracts — Do Not Break
 
 `_run_command` mode flags: `--prefer-sudo`, `--require-sudo`, `--probe '<subcmd>'`, `--quiet`
-`_detect_platform` returns: `debian | rhel | arch | darwin | unknown`
+`_detect_platform` returns: `mac | wsl | debian | redhat | linux`
 `_cluster_provider` reads: `CLUSTER_PROVIDER` / `K3D_MANAGER_PROVIDER` / `K3DMGR_PROVIDER`
 
 Changing these signatures requires coordination with all consumers (k3d-manager, rigor-cli, shopping-carts).

--- a/scripts/lib/foundation/CLAUDE.md
+++ b/scripts/lib/foundation/CLAUDE.md
@@ -23,7 +23,7 @@ _run_command --probe '<subcmd>' -- <cmd>  # probe subcommand to decide privilege
 _run_command --quiet -- <cmd>         # suppress stderr
 ```
 
-**`_detect_platform` (system.sh)** — returns `debian | rhel | arch | darwin | unknown`
+**`_detect_platform` (system.sh)** — returns `mac | wsl | debian | redhat | linux`
 
 **`_cluster_provider` (core.sh)** — reads `CLUSTER_PROVIDER` / `K3D_MANAGER_PROVIDER` / `K3DMGR_PROVIDER`
 

--- a/scripts/lib/foundation/README.md
+++ b/scripts/lib/foundation/README.md
@@ -44,7 +44,7 @@ _run_command --quiet -- command_that_might_fail        # suppress stderr, return
 
 ### `_detect_platform` (system.sh)
 
-Single source of truth for OS detection. Returns: `debian`, `rhel`, `arch`, `darwin`, `unknown`.
+Single source of truth for OS detection. Returns: `mac`, `wsl`, `debian`, `redhat`, `linux`.
 
 ### `_cluster_provider` (core.sh)
 

--- a/scripts/lib/foundation/scripts/lib/core.sh
+++ b/scripts/lib/foundation/scripts/lib/core.sh
@@ -765,10 +765,6 @@ EOF
       fi
    fi
 
-   if [[ "$platform" == "mac" && "$provider" == "k3s" ]]; then
-      _err "k3s is not supported on macOS; please use k3d instead."
-   fi
-
    case "$provider" in
       k3d|orbstack|k3s)
          ;;

--- a/scripts/lib/foundation/scripts/lib/system.sh
+++ b/scripts/lib/foundation/scripts/lib/system.sh
@@ -892,7 +892,7 @@ function _install_redhat_docker() {
   fi
   # Add current user to docker group
   _run_command  -- sudo usermod -aG docker "$USER"
-  echo "Docker instsudo alled successfully. You may need to log out and back in for group changes to take effect."
+  echo "Docker installed successfully. You may need to log out and back in for group changes to take effect."
 }
 
 function _k3d_cluster_exist() {

--- a/scripts/lib/system.sh
+++ b/scripts/lib/system.sh
@@ -1,0 +1,1713 @@
+# shellcheck shell=bash
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+fi
+
+: "${K3DM_AGENT_RIGOR_LIB_SOURCED:=0}"
+
+function _k3dm_repo_root() {
+   local root=""
+
+   if command -v git >/dev/null 2>&1; then
+      root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+      if [[ -n "$root" ]]; then
+         printf '%s\n' "$root"
+         return 0
+      fi
+   fi
+
+   if [[ -n "${SCRIPT_DIR:-}" ]]; then
+      root="$(cd "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+      printf '%s\n' "$root"
+      return 0
+   fi
+
+   pwd
+}
+
+if [[ "${K3DM_AGENT_RIGOR_LIB_SOURCED}" != "1" ]]; then
+   agent_rigor_lib_path="${SCRIPT_DIR}/lib/agent_rigor.sh"
+   if [[ -r "$agent_rigor_lib_path" ]]; then
+      # shellcheck source=/dev/null
+      source "$agent_rigor_lib_path"
+      K3DM_AGENT_RIGOR_LIB_SOURCED=1
+   fi
+   unset agent_rigor_lib_path
+fi
+
+function _command_exist() {
+    command -v "$1" &> /dev/null
+}
+
+# _run_command [--quiet] [--prefer-sudo|--require-sudo] [--probe '<subcmd>'] -- <prog> [args...]
+# - --quiet         : suppress wrapper error message (still returns real exit code)
+# - --prefer-sudo   : use sudo -n if available, otherwise run as user
+# - --require-sudo  : fail if sudo -n not available
+# - --probe '...'   : subcommand to test env/permissions (e.g., for kubectl: 'config current-context')
+# - --              : end of options; after this comes <prog> and its args
+#
+# Returns the command's real exit code; prints a helpful error unless --quiet.
+function _run_command() {
+  local quiet=0 prefer_sudo=0 require_sudo=0 interactive_sudo=0 probe="" soft=0
+  local -a probe_args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-exit|--soft) soft=1; shift;;
+      --quiet)        quiet=1; shift;;
+      --prefer-sudo)  prefer_sudo=1; shift;;
+      --require-sudo) require_sudo=1; shift;;
+      --interactive-sudo) interactive_sudo=1; prefer_sudo=1; shift;;
+      --probe)        probe="$2"; shift 2;;
+      --)             shift; break;;
+      *)              break;;
+    esac
+  done
+
+  local prog="${1:?usage: _run_command [opts] -- <prog> [args...]}"
+  shift
+
+  if ! command -v "$prog" >/dev/null 2>&1; then
+    (( quiet )) || echo "$prog: not found in PATH" >&2
+    if (( soft )); then
+      return 127
+    else
+      exit 127
+    fi
+  fi
+
+  if [[ -n "$probe" ]]; then
+    read -r -a probe_args <<< "$probe"
+  fi
+
+  # Decide runner: user vs sudo -n vs sudo (interactive)
+  local runner
+  local sudo_flags=()
+  if (( interactive_sudo == 0 )); then
+    sudo_flags=(-n)  # Non-interactive sudo
+  fi
+
+  if (( require_sudo )); then
+    if (( interactive_sudo )) || sudo -n true >/dev/null 2>&1; then
+      runner=(sudo "${sudo_flags[@]}" "$prog")
+    else
+      (( quiet )) || echo "sudo non-interactive not available" >&2
+      exit 127
+    fi
+  else
+    if (( ${#probe_args[@]} )); then
+      # Try user first; if probe fails, try sudo
+      if "$prog" "${probe_args[@]}" >/dev/null 2>&1; then
+        runner=("$prog")
+      elif (( interactive_sudo )) && sudo "${sudo_flags[@]}" "$prog" "${probe_args[@]}" >/dev/null 2>&1; then
+        runner=(sudo "${sudo_flags[@]}" "$prog")
+      elif sudo -n "$prog" "${probe_args[@]}" >/dev/null 2>&1; then
+        runner=(sudo -n "$prog")
+      elif (( prefer_sudo )) && ((interactive_sudo)) ; then
+        runner=(sudo "${sudo_flags[@]}" "$prog")
+      elif (( prefer_sudo )) && sudo -n true >/dev/null 2>&1; then
+        runner=(sudo -n "$prog")
+      else
+        runner=("$prog")
+      fi
+    else
+      if (( prefer_sudo )) && (( interactive_sudo )); then
+        runner=(sudo "${sudo_flags[@]}" "$prog")
+      elif (( prefer_sudo )) && sudo -n true >/dev/null 2>&1; then
+        runner=(sudo -n "$prog")
+      else
+        runner=("$prog")
+      fi
+    fi
+  fi
+
+  # Execute and preserve exit code
+  "${runner[@]}" "$@"
+  local rc=$?
+
+  if (( rc != 0 )); then
+     local -a executed=("${runner[@]}" "$@")
+     local cmd_str=""
+     printf -v cmd_str '%q ' "${executed[@]}"
+     if (( quiet == 0 )); then
+       printf '%s command failed (%d): ' "$prog" "$rc" >&2
+       printf '%q ' "${runner[@]}" "$@" >&2
+       printf '\n' >&2
+     fi
+
+     if (( soft )); then
+         return "$rc"
+     else
+         _err "failed to execute ${cmd_str% }: $rc"
+     fi
+  fi
+
+  return 0
+}
+
+function _args_have_sensitive_flag() {
+  local arg
+  local expect_secret=0
+
+  for arg in "$@"; do
+    if (( expect_secret )); then
+      return 0
+    fi
+    case "$arg" in
+      --password|--token|--username)
+        expect_secret=1
+        ;;
+      --password=*|--token=*|--username=*)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+_ensure_secret_tool() {
+  _command_exist secret-tool && return 0
+  _is_linux || return 1
+
+  if _command_exist apt-get ; then
+    _run_command --prefer-sudo -- env DEBIAN_FRONTEND=noninteractive apt-get update
+    _run_command --prefer-sudo -- env DEBIAN_FRONTEND=noninteractive apt-get install -y libsecret-tools
+  elif _command_exist dnf ; then
+    _run_command --prefer-sudo -- dnf -y install libsecret
+  elif _command_exist yum; then
+    _run_command --prefer-sudo -- yum -y install libsecret
+  elif _command_exist microdnf ; then
+    _run_command --prefer-sudo -- microdnf -y install libsecret
+  else
+    echo "Cannot install secret-tool: no known package manager found" >&2
+    exit 127
+  fi
+
+  command -v secret-tool >/dev/null 2>&1
+}
+
+function _install_redhat_kubernetes_client() {
+  if ! _command_exist kubectl; then
+     _run_command -- sudo dnf install -y kubernetes-client
+  fi
+}
+
+function _secret_tool() {
+   _ensure_secret_tool >/dev/null 2>&1
+   _run_command --quiet -- secret-tool "$@"
+}
+
+# macOS only
+function _security() {
+   _run_command --quiet -- security "$@"
+}
+
+function _set_sensitive_var() {
+   local name="${1:?variable name required}"
+   local value="${2:-}"
+   local wasx=0
+   case $- in *x*) wasx=1; set +x;; esac
+   printf -v "$name" '%s' "$value"
+   (( wasx )) && set -x
+}
+
+function _write_sensitive_file() {
+   local path="${1:?path required}"
+   local data="${2:-}"
+   local wasx=0
+   local old_umask
+   case $- in *x*) wasx=1; set +x;; esac
+   old_umask=$(umask)
+   umask 077
+   printf '%s' "$data" > "$path"
+   local rc=$?
+   if (( rc == 0 )); then
+      chmod 600 "$path" 2>/dev/null || true
+   fi
+   umask "$old_umask"
+   (( wasx )) && set -x
+   return "$rc"
+}
+
+function _remove_sensitive_file() {
+   local path="${1:-}"
+   local wasx=0
+   if [[ -z "$path" ]]; then
+      return 0
+   fi
+   case $- in *x*) wasx=1; set +x;; esac
+   rm -f -- "$path"
+   (( wasx )) && set -x
+}
+
+function _decode_hex_blob() {
+   local blob="${1:-}"
+   local wasx=0
+   case $- in *x*) wasx=1; set +x;; esac
+   if [[ -n "$blob" && "$blob" =~ ^[0-9a-fA-F]+$ && $(( ${#blob} % 2 )) -eq 0 ]]; then
+      local decoded=""
+      decoded=$(python3 - "$blob" <<'PY'
+import binascii
+import sys
+try:
+    sys.stdout.write(binascii.unhexlify(sys.argv[1]).decode("utf-8"))
+except Exception:
+    sys.stdout.write(sys.argv[1])
+PY
+      )
+      (( wasx )) && set -x
+      printf '%s' "$decoded"
+      return 0
+   fi
+   (( wasx )) && set -x
+   printf '%s' "$blob"
+}
+
+function _json_escape() {
+   local value="${1:-}"
+   value="${value//\\/\\\\}"
+   value="${value//\"/\\\"}"
+   printf '%s' "$value"
+}
+
+function _write_registry_config() {
+   local host="${1:?registry host required}"
+   local username="${2:?username required}"
+   local password="${3:?password required}"
+   local destination="${4:?destination required}"
+
+   local auth=""
+   auth=$(printf '%s:%s' "$username" "$password" | base64 | tr -d $'\r\n')
+
+   local esc_user esc_pass
+   esc_user=$(_json_escape "$username")
+   esc_pass=$(_json_escape "$password")
+
+   local config=""
+   config=$'{\n  "auths": {\n'
+   printf -v config '%s    "%s": {\n      "username": "%s",\n      "password": "%s",\n      "auth": "%s"\n    }' \
+      "$config" "$host" "$esc_user" "$esc_pass" "$auth"
+
+   if [[ "$host" == "registry-1.docker.io" ]]; then
+      printf -v config '%s,\n    "%s": {\n      "username": "%s",\n      "password": "%s",\n      "auth": "%s"\n    }\n' \
+         "$config" "https://index.docker.io/v1/" "$esc_user" "$esc_pass" "$auth"
+   else
+      config+=$'\n'
+   fi
+
+   config+=$'  }\n}\n'
+
+   _write_sensitive_file "$destination" "$config"
+}
+
+function _build_credential_blob() {
+   local username="${1:?username required}"
+   local password="${2:?password required}"
+   local blob=""
+   local wasx=0
+   case $- in *x*) wasx=1; set +x;; esac
+   printf -v blob 'username=%s\npassword=%s\n' "$username" "$password"
+   (( wasx )) && set -x
+   printf '%s' "$blob"
+}
+
+function _parse_credential_blob() {
+   local blob="${1:-}"
+   local username_var="${2:?username variable required}"
+   local password_var="${3:?password variable required}"
+   local username=""
+   local password=""
+   local line key value
+
+   if [[ -z "$blob" ]]; then
+      return 1
+   fi
+
+   while IFS='=' read -r key value; do
+      case "$key" in
+         username) username="$value" ;;
+         password) password="$value" ;;
+      esac
+   done <<<"$blob"
+
+   if [[ -z "$username" || -z "$password" ]]; then
+      return 1
+   fi
+
+   _set_sensitive_var "$username_var" "$username"
+   _set_sensitive_var "$password_var" "$password"
+   return 0
+}
+
+function _oci_registry_host() {
+   local ref="${1:-}"
+   if [[ "$ref" == oci://* ]]; then
+      ref="${ref#oci://}"
+      printf '%s\n' "${ref%%/*}"
+      return 0
+   fi
+   return 1
+}
+
+function _secret_tool_ready() {
+   if _command_exist secret-tool; then
+      return 0
+   fi
+
+   if _is_linux; then
+      if _ensure_secret_tool >/dev/null 2>&1; then
+         return 0
+      fi
+   fi
+
+   return 1
+}
+
+function _store_registry_credentials() {
+   local context="${1:?context required}"
+   local host="${2:?registry host required}"
+   local username="${3:?username required}"
+   local password="${4:?password required}"
+   local blob=""
+   local blob_file=""
+
+   blob=$(_build_credential_blob "$username" "$password") || return 1
+   blob_file=$(mktemp -t registry-cred.XXXXXX) || return 1
+   _write_sensitive_file "$blob_file" "$blob"
+
+   if _is_mac; then
+      local service="${context}:${host}"
+      local account="${context}"
+      local rc=0
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'security delete-generic-password -s "$1" >/dev/null 2>&1 || true' _ "$service" >/dev/null 2>&1
+      # shellcheck disable=SC2016
+      if ! _no_trace bash -c 'security add-generic-password -s "$1" -a "$2" -w "$3" >/dev/null' _ "$service" "$account" "$blob"; then
+         rc=$?
+      fi
+      _remove_sensitive_file "$blob_file"
+      return $rc
+   fi
+
+   if _secret_tool_ready; then
+      local label="${context} registry ${host}"
+      local rc=0
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'secret-tool clear service "$1" registry "$2" type "$3" >/dev/null 2>&1 || true' _ "$context" "$host" "helm-oci" >/dev/null 2>&1
+      local store_output=""
+      # shellcheck disable=SC2016
+      store_output=$(_no_trace bash -c 'secret-tool store --label "$1" service "$2" registry "$3" type "$4" < "$5"' _ "$label" "$context" "$host" "helm-oci" "$blob_file" 2>&1)
+      local store_rc=$?
+      if (( store_rc != 0 )) || [[ -n "$store_output" ]]; then
+         rc=${store_rc:-1}
+         if [[ -z "$store_output" ]]; then
+            store_output="unable to persist credentials via secret-tool"
+         fi
+         _warn "[${context}] secret-tool store failed for ${host}: ${store_output}"
+      fi
+      _remove_sensitive_file "$blob_file"
+      if (( rc == 0 )); then
+         return 0
+      fi
+   fi
+
+   _remove_sensitive_file "$blob_file"
+   _warn "[${context}] unable to persist OCI credentials securely; re-supply --username/--password on next run"
+   return 1
+}
+
+function _registry_login() {
+   local host="${1:?registry host required}"
+   local username="${2:-}"
+   local password="${3:-}"
+   local registry_config="${4:-}"
+   local pass_file=""
+
+   if [[ -z "$username" || -z "$password" ]]; then
+      return 1
+   fi
+
+   pass_file=$(mktemp -t helm-pass.XXXXXX) || return 1
+   if ! _write_sensitive_file "$pass_file" "$password"; then
+      _remove_sensitive_file "$pass_file"
+      return 1
+   fi
+
+   local login_output=""
+   local login_rc=0
+   if [[ -n "$registry_config" ]]; then
+      # shellcheck disable=SC2016
+      login_output=$(_no_trace bash -c 'HELM_REGISTRY_CONFIG="$4" helm registry login "$1" --username "$2" --password-stdin < "$3"' _ "$host" "$username" "$pass_file" "$registry_config" 2>&1) || login_rc=$?
+   else
+      # shellcheck disable=SC2016
+      login_output=$(_no_trace bash -c 'helm registry login "$1" --username "$2" --password-stdin < "$3"' _ "$host" "$username" "$pass_file" 2>&1) || login_rc=$?
+   fi
+   _remove_sensitive_file "$pass_file"
+
+   if (( login_rc != 0 )); then
+      if [[ -n "$login_output" ]]; then
+         _warn "[helm] registry login failed for ${host}: ${login_output}"
+      else
+         _warn "[helm] registry login failed for ${host}; ensure credentials are valid."
+      fi
+      return 1
+   fi
+
+   _info "[helm] authenticated OCI registry ${host}"
+   return 0
+}
+
+function _load_registry_credentials() {
+   local context="${1:?context required}"
+   local host="${2:?registry host required}"
+   local username_var="${3:?username variable required}"
+   local password_var="${4:?password variable required}"
+   local blob=""
+
+   if _is_mac; then
+      local service="${context}:${host}"
+      # shellcheck disable=SC2016
+      blob=$(_no_trace bash -c 'security find-generic-password -s "$1" -w' _ "$service" 2>/dev/null || true)
+   elif _command_exist secret-tool; then
+      # shellcheck disable=SC2016
+      blob=$(_no_trace bash -c 'secret-tool lookup service "$1" registry "$2" type "$3"' _ "$context" "$host" "helm-oci" 2>/dev/null || true)
+   fi
+
+   if [[ -z "$blob" ]]; then
+      return 1
+   fi
+
+   blob=$(_decode_hex_blob "$blob")
+
+   _parse_credential_blob "$blob" "$username_var" "$password_var" || return 1
+   return 0
+}
+
+function _secret_store_data() {
+   local service="${1:?service name required}"
+   local key="${2:?entry key required}"
+   local data="${3:-}"
+   local label="${4:-${service} ${key}}"
+   local type="${5:-note}"
+
+   if _is_mac; then
+      local rc=0
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'security delete-generic-password -s "$1" -a "$2" >/dev/null 2>&1 || true' _ "$service" "$key"
+      # shellcheck disable=SC2016
+      if ! _no_trace bash -c 'security add-generic-password -s "$1" -a "$2" -w "$3" >/dev/null' _ "$service" "$key" "$data"; then
+         rc=$?
+      fi
+      return "$rc"
+   fi
+
+   if _secret_tool_ready; then
+      local tmp rc=0 store_output=""
+      tmp=$(mktemp -t secret-data.XXXXXX) || return 1
+      if ! _write_sensitive_file "$tmp" "$data"; then
+         _remove_sensitive_file "$tmp"
+         return 1
+      fi
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'secret-tool clear service "$1" name "$2" type "$3" >/dev/null 2>&1 || true' _ "$service" "$key" "$type"
+      # shellcheck disable=SC2016
+      store_output=$(_no_trace bash -c 'secret-tool store --label "$1" service "$2" name "$3" type "$4" < "$5"' _ "$label" "$service" "$key" "$type" "$tmp" 2>&1)
+      rc=$?
+      _remove_sensitive_file "$tmp"
+      if (( rc != 0 )) || [[ -n "$store_output" ]]; then
+         _warn "[secret] unable to store data for ${service}/${key}: ${store_output:-unknown error}"
+         return ${rc:-1}
+      fi
+      return 0
+   fi
+
+   _warn "[secret] secure storage unavailable; install secret-tool or run on macOS"
+   return 1
+}
+
+function _secret_load_data() {
+   local service="${1:?service name required}"
+   local key="${2:?entry key required}"
+   local type="${3:-note}"
+   local value=""
+
+   if _is_mac; then
+      # shellcheck disable=SC2016
+      value=$(_no_trace bash -c 'security find-generic-password -s "$1" -a "$2" -w' _ "$service" "$key" 2>/dev/null || true)
+   elif _command_exist secret-tool; then
+      # shellcheck disable=SC2016
+      value=$(_no_trace bash -c 'secret-tool lookup service "$1" name "$2" type "$3"' _ "$service" "$key" "$type" 2>/dev/null || true)
+   fi
+
+   if [[ -z "$value" ]]; then
+      return 1
+   fi
+
+   printf '%s' "$value"
+   return 0
+}
+
+function _secret_clear_data() {
+   local service="${1:?service name required}"
+   local key="${2:?entry key required}"
+   local type="${3:-note}"
+
+   if _is_mac; then
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'security delete-generic-password -s "$1" -a "$2" >/dev/null 2>&1 || true' _ "$service" "$key"
+      return 0
+   fi
+
+   if _command_exist secret-tool; then
+      # shellcheck disable=SC2016
+      _no_trace bash -c 'secret-tool clear service "$1" name "$2" type "$3" >/dev/null 2>&1 || true' _ "$service" "$key" "$type"
+      return 0
+   fi
+
+   return 1
+}
+
+function _install_debian_kubernetes_client() {
+   if _command_exist kubectl ; then
+      echo "kubectl already installed, skipping"
+      return 0
+   fi
+
+   echo "Installing kubectl on Debian/Ubuntu system..."
+
+   # Create the keyrings directory if it doesn't exist
+   _run_command -- sudo mkdir -p /etc/apt/keyrings
+
+   # Download the Kubernetes signing key
+   if [[ ! -e "/etc/apt/keyrings/kubernetes-apt-keyring.gpg" ]]; then
+      curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key \
+         | _run_command -- sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+   fi
+
+   # Add the Kubernetes apt repository
+   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | \
+      _run_command -- sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null
+
+   # Update apt package index
+   _run_command -- sudo apt-get update -y
+
+   # Install kubectl
+   _run_command -- sudo apt-get install -y kubectl
+
+}
+
+function _install_kubernetes_cli() {
+   if _is_redhat_family ; then
+      _install_redhat_kubernetes_client
+   elif _is_debian_family ; then
+      _install_debian_kubernetes_client
+   elif _is_mac ; then
+      if ! _command_exist kubectl ; then
+         _run_command --quiet -- brew install kubectl
+      fi
+   elif _is_wsl ; then
+      if grep "debian" /etc/os-release &> /dev/null; then
+        _install_debian_kubernetes_client
+      elif grep "redhat" /etc/os-release &> /dev/null; then
+         _install_redhat_kubernetes_client
+      fi
+   fi
+}
+
+function _is_mac() {
+   if [[ "$(uname -s)" == "Darwin" ]]; then
+      return 0
+   else
+      return 1
+   fi
+}
+
+function _install_mac_helm() {
+  _run_command --quiet -- brew install helm
+}
+
+function _install_redhat_helm() {
+  _run_command -- sudo dnf install -y helm
+}
+
+function _install_debian_helm() {
+  # 1) Prereqs
+  _run_command -- sudo apt-get update
+  _run_command -- sudo apt-get install -y curl gpg apt-transport-https
+
+   # 2) Add Helm’s signing key (to /usr/share/keyrings)
+   _run_command -- curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | \
+      _run_command -- gpg --dearmor | \
+      _run_command -- sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+
+   # 3) Add the Helm repo (with signed-by, required on 24.04)
+   echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | \
+   sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+
+   # 4) Install
+   _run_command sudo apt-get update
+   _run_command sudo apt-get install -y helm
+
+}
+
+function _install_helm() {
+  if _command_exist helm; then
+    echo helm already installed, skip
+    return 0
+  fi
+
+  if _is_mac; then
+    _install_mac_helm
+  elif _is_redhat_family ; then
+    _install_redhat_helm
+  elif _is_debian_family ; then
+    _install_debian_helm
+  elif _is_wsl ; then
+    if grep "debian" /etc/os-release &> /dev/null; then
+      _install_debian_helm
+    elif grep "redhat" /etc/os-release &> /dev/null; then
+       _install_redhat_helm
+    fi
+  fi
+}
+
+function _is_linux() {
+   if [[ "$(uname -s)" == "Linux" ]]; then
+      return 0
+   else
+      return 1
+   fi
+}
+
+function _is_redhat_family() {
+   [[ -f /etc/redhat-release ]] && return 0 || return 1
+}
+
+function _is_debian_family() {
+   [[ -f /etc/debian_version ]] && return 0 || return 1
+}
+
+function _is_wsl() {
+   if [[ -n "$WSL_DISTRO_NAME" ]]; then
+      return 0
+   elif grep -Eqi "(Microsoft|WSL)" /proc/version &> /dev/null; then
+      return 0
+   else
+      return 1
+   fi
+}
+
+function _detect_platform() {
+   if _is_mac; then
+      printf 'mac\n'
+      return 0
+   fi
+
+   if _is_wsl; then
+      printf 'wsl\n'
+      return 0
+   fi
+
+   if _is_debian_family; then
+      printf 'debian\n'
+      return 0
+   fi
+
+   if _is_redhat_family; then
+      printf 'redhat\n'
+      return 0
+   fi
+
+   if _is_linux; then
+      printf 'linux\n'
+      return 0
+   fi
+
+   _err "Unsupported platform: $(uname -s)"
+}
+
+function _install_colima() {
+   if ! _command_exist colima ; then
+      echo colima does not exist, install it
+      _run_command --quiet -- brew install colima
+   else
+      echo colima installed already
+   fi
+}
+
+function _install_mac_docker() {
+  local cpu="${1:-${COLIMA_CPU:-4}}"
+  local memory="${2:-${COLIMA_MEMORY:-8}}"
+  local disk="${3:-${COLIMA_DISK:-20}}"
+
+   if  ! _command_exist docker && _is_mac ; then
+      echo docker does not exist, install it
+      brew install docker
+   else
+      echo docker installed already
+   fi
+
+   if _is_mac; then
+      _install_colima
+      docker context use colima
+      export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock
+      colima start --cpu "$cpu" --memory "$memory" --disk "$disk"
+   fi
+
+
+   # grep DOKER_HOST $HOME/.zsh/zshrc | wc -l 2>&1 > /dev/null
+   # if $? == 0 ; then
+   #    echo "export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock" >> $HOME/.zsh/zshrc
+   #    echo "export DOCKER_CONTEXT=colima" >> $HOME/.zsh/zshrc
+   #    echo "restart your shell to apply the changes"
+   # fi
+}
+
+function _create_nfs_share_mac() {
+   local share_path="${1:-${HOME}/k3d-nfs}"
+   _ensure_path_exists "$share_path"
+
+   if grep -q "$share_path" /etc/exports 2>/dev/null; then
+      _info "NFS share already exists at $share_path"
+      return 0
+   fi
+
+   local ip mask prefix network
+   ip=$(ipconfig getifaddr en0 2>/dev/null || true)
+   mask=$(ipconfig getoption en0 subnet_mask 2>/dev/null || true)
+
+   if [[ -z "$ip" || -z "$mask" ]]; then
+      _err "Unable to determine network info for NFS share"
+   fi
+
+   prefix=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('0.0.0.0/$mask').prefixlen)" 2>/dev/null || true)
+   network=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('$ip/$prefix', strict=False).network_address)" 2>/dev/null || true)
+
+   local export_line
+   export_line="${share_path} -alldirs -rw -insecure -mapall=$(id -u):$(id -g) -network $network -mask $mask"
+
+   printf '%s\n' "$export_line" | _run_command --prefer-sudo -- tee -a /etc/exports >/dev/null
+   _run_command --prefer-sudo -- nfsd enable
+   _run_command --prefer-sudo -- nfsd restart
+   _run_command --soft -- showmount -e localhost >/dev/null || true
+}
+
+function _orbstack_cli_ready() {
+   if ! _command_exist orb; then
+      return 1
+   fi
+
+   if _run_command --quiet --no-exit -- orb status >/dev/null 2>&1; then
+      return 0
+   fi
+
+   return 1
+}
+
+function _install_orbstack() {
+   if ! _is_mac; then
+      _err "_install_orbstack is only supported on macOS"
+   fi
+
+   if _orbstack_cli_ready; then
+      return 0
+   fi
+
+   if ! _command_exist brew; then
+      _err "Homebrew is required to install OrbStack (missing 'brew'). Install Homebrew first."
+   fi
+
+   if ! _command_exist orb; then
+      _info "Installing OrbStack via Homebrew"
+      _run_command -- brew install orbstack
+   else
+      _warn "OrbStack CLI detected but daemon not running. Launching OrbStack.app to prompt for setup."
+   fi
+
+   if command -v open >/dev/null 2>&1; then
+      _run_command --no-exit -- open -g -a OrbStack >/dev/null 2>&1 || true
+   fi
+
+   _info "Waiting for OrbStack to finish one-time GUI setup. Complete prompts in OrbStack.app if it opened."
+   local attempts=20
+   while (( attempts-- > 0 )); do
+      if _orbstack_cli_ready; then
+         _info "OrbStack CLI is running."
+         return 0
+      fi
+      sleep 3
+   done
+
+   _err "OrbStack is installed but not initialized. Open OrbStack.app, complete onboarding, then rerun your command."
+}
+
+function _install_debian_docker() {
+  echo "Installing Docker on Debian/Ubuntu system..."
+  # Update apt
+  _run_command -- sudo apt-get update
+  # Install dependencies
+  _run_command -- sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+  # Add Docker's GPG key
+  if [[ ! -e "/usr/share/keyrings/docker-archive-keyring.gpg" ]]; then
+     _curl -fsSL https://download.docker.com/linux/"$(lsb_release -is \
+        | tr '[:upper:]' '[:lower:]')"/gpg \
+        | sudo gpg --dearmor \
+        -o /usr/share/keyrings/docker-archive-keyring.gpg
+  fi
+  # Add Docker repository
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | \
+     _run_command -- sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  # Update package list
+  _run_command -- sudo apt-get update
+  # Install Docker
+  _run_command -- sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+  # Start and enable Docker when systemd is available
+  if _systemd_available ; then
+     _run_command -- sudo systemctl start docker
+     _run_command -- sudo systemctl enable docker
+  else
+     _warn "systemd not available; skipping docker service activation"
+  fi
+  # Add current user to docker group
+  _run_command -- sudo usermod -aG docker "$USER"
+  echo "Docker installed successfully. You may need to log out and back in for group changes to take effect."
+}
+
+function _install_redhat_docker() {
+  echo "Installing Docker on RHEL/Fedora/CentOS system..."
+  # Install required packages
+  _run_command -- sudo dnf install -y dnf-plugins-core
+  # Add Docker repository
+  _run_command -- sudo dnf config-manager addrepo --overwrite \
+     --from-repofile https://download.docker.com/linux/fedora/docker-ce.repo
+  # Install Docker
+  _run_command -- sudo dnf install -y docker-ce docker-ce-cli containerd.io
+  # Start and enable Docker when systemd is available
+  if _systemd_available ; then
+     _run_command  -- sudo systemctl start docker
+     _run_command  -- sudo systemctl enable docker
+  else
+     _warn "systemd not available; skipping docker service activation"
+  fi
+  # Add current user to docker group
+  _run_command  -- sudo usermod -aG docker "$USER"
+  echo "Docker instsudo alled successfully. You may need to log out and back in for group changes to take effect."
+}
+
+function _k3d_cluster_exist() {
+   _cluster_provider_call cluster_exists "$@"
+}
+
+function __create_cluster() {
+   _cluster_provider_call apply_cluster_config "$@"
+}
+
+function __create_k3d_cluster() {
+   __create_cluster "$@"
+}
+
+function _list_k3d_cluster() {
+   _cluster_provider_call list_clusters "$@"
+}
+
+function _kubectl() {
+
+  if ! _command_exist kubectl; then
+     _install_kubernetes_cli
+  fi
+
+  # Pass-through mini-parser so you can do: _helm --quiet ...  (like _run_command)
+  local pre=()
+  while [[ $# -gt 0 ]]; do
+     case "$1" in
+         --quiet|--prefer-sudo|--require-sudo|--no-exit) pre+=("$1");
+            shift;;
+         --) shift;
+            break;;
+         *)  break;;
+     esac
+  done
+   _run_command "${pre[@]}" -- kubectl "$@"
+}
+
+function _istioctl() {
+   if ! _command_exist istioctl ; then
+      echo "istioctl is not installed. Please install it first."
+      exit 1
+   fi
+
+   _run_command --quiet -- istioctl "$@"
+
+}
+
+# Optional: global default flags you want on every helm call
+# export HELM_GLOBAL_ARGS="--debug"   # example
+
+function _helm() {
+  # Pass-through mini-parser so you can do: _helm --quiet ...  (like _run_command)
+  local pre=() ;
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --quiet|--prefer-sudo|--require-sudo|--no-exit) pre+=("$1"); shift;;
+      --) shift; break;;
+      *)  break;;
+    esac
+  done
+
+  # If you keep global flags, splice them in *before* user args:
+  local -a helm_global_arr=()
+  read -r -a helm_global_arr <<< "${HELM_GLOBAL_ARGS:-}"
+  _run_command "${pre[@]}" --probe 'version --short' -- helm "${helm_global_arr[@]}" "$@"
+}
+
+function _curl() {
+   if ! _command_exist curl ; then
+      echo "curl is not installed. Please install it first."
+      exit 1
+   fi
+
+   local curl_max_time="${CURL_MAX_TIME:-30}"
+   local has_max_time=0
+   local arg
+   for arg in "$@"; do
+      case "$arg" in
+         --max-time|-m|--max-time=*|-m*)
+            has_max_time=1
+            break
+            ;;
+      esac
+   done
+
+   local -a curl_args=("$@")
+   if (( ! has_max_time )) && [[ -n "$curl_max_time" ]]; then
+      curl_args=(--max-time "$curl_max_time" "${curl_args[@]}")
+   fi
+
+   _run_command --quiet -- curl "${curl_args[@]}"
+}
+
+function _kill() {
+   _run_command --quiet -- kill "$@"
+}
+
+function _ip() {
+   if _is_mac ; then
+      ifconfig en0 | grep inet | awk '$1=="inet" {print $2}'
+   else
+      ip -4 route get 8.8.8.8 | perl -nle 'print $1 if /src (.*) uid/'
+   fi
+}
+
+function _k3d() {
+   _cluster_provider_call exec "$@"
+}
+
+function _load_plugin_function() {
+  local func="${1:?usage: _load_plugin_function <function> [args...]}"
+  shift
+  local plugin
+  local restore_trace=0
+
+  if [[ $- == *x* ]]; then
+    set +x
+    if _args_have_sensitive_flag "$@"; then
+      restore_trace=1
+    else
+      set -x
+    fi
+  fi
+
+  shopt -s nullglob
+  trap 'shopt -u nullglob' RETURN
+
+  for plugin in "$PLUGINS_DIR"/*.sh; do
+    if command grep -Eq "^[[:space:]]*(function[[:space:]]+${func}[[:space:]]*\(\)|${func}[[:space:]]*\(\))[[:space:]]*\{" "$plugin"; then
+      # shellcheck source=/dev/null
+      source "$plugin"
+      if [[ "$(type -t -- "$func")" == "function" ]]; then
+        local rc=0
+        "$func" "$@" || rc=$?
+        if (( restore_trace )); then
+          set -x
+        fi
+        return "$rc"
+      fi
+    fi
+  done
+
+  if (( restore_trace )); then
+    set -x
+  fi
+
+  echo "Error: Function '$func' not found in plugins" >&2
+  return 1
+}
+
+function _try_load_plugin() {
+  local func="${1:?usage: _try_load_plugin <function> [args...]}"
+  shift
+
+  if [[ "$func" == _* ]]; then
+    echo "Error: '$func' is private (names starting with '_' cannot be invoked)." >&2
+    return 1
+  fi
+  if [[ ! "$func" =~ ^[A-Za-z][A-Za-z0-9_]*$ ]]; then
+    echo "Error: invalid function name: '$func'" >&2
+    return 1
+  fi
+
+  _load_plugin_function "$func" "$@"
+}
+
+function _sha256_12() {
+   local line hash payload
+   local -a cmd
+
+   if _command_exist shasum; then
+      cmd=(shasum -a 256)
+   elif _command_exist sha256sum; then
+      cmd=(sha256sum)
+   else
+      echo "No SHA256 command found" >&2
+      return 1
+   fi
+
+   if [[ $# -gt 0 ]]; then
+      payload="$1"
+      line=$(printf %s "$payload" | _run_command -- "${cmd[@]}")
+   else
+      line=$(_run_command -- "${cmd[@]}")
+   fi
+
+   hash="${line%% *}"
+   printf %s "${hash:0:12}"
+}
+
+function _version_ge() {
+   local lhs_str="$1"
+   local rhs_str="$2"
+   local IFS=.
+   local -a lhs rhs
+
+   read -r -a lhs <<< "$lhs_str"
+   read -r -a rhs <<< "$rhs_str"
+
+   local len=${#lhs[@]}
+   if (( ${#rhs[@]} > len )); then
+      len=${#rhs[@]}
+   fi
+
+   for ((i=0; i<len; ++i)); do
+      local l=${lhs[i]:-0}
+      local r=${rhs[i]:-0}
+      if ((10#$l > 10#$r)); then
+         return 0
+      elif ((10#$l < 10#$r)); then
+         return 1
+      fi
+   done
+
+   return 0
+}
+
+function _bats_version() {
+   if ! _command_exist bats ; then
+      return 1
+   fi
+
+   local version
+   version="$(bats --version 2>/dev/null | awk '{print $2}')"
+   if [[ -n "$version" ]]; then
+      printf '%s\n' "$version"
+      return 0
+   fi
+
+   return 1
+}
+
+function _bats_meets_requirement() {
+   local required="$1"
+   local current
+
+   current="$(_bats_version 2>/dev/null)" || return 1
+   if [[ -z "$current" ]]; then
+      return 1
+   fi
+
+   _version_ge "$current" "$required"
+}
+
+function _sudo_available() {
+   if ! command -v sudo >/dev/null 2>&1; then
+      return 1
+   fi
+
+   sudo -n true >/dev/null 2>&1
+}
+
+function _systemd_available() {
+   if ! command -v systemctl >/dev/null 2>&1; then
+      return 1
+   fi
+
+   if [[ -d /run/systemd/system ]]; then
+      return 0
+   fi
+
+   local init_comm
+   init_comm="$(ps -p 1 -o comm= 2>/dev/null || true)"
+   init_comm="${init_comm//[[:space:]]/}"
+   [[ "$init_comm" == systemd ]]
+}
+
+function _ensure_local_bin_on_path() {
+   local local_bin="${HOME}/.local/bin"
+
+   if [[ ! -d "$local_bin" ]]; then
+      mkdir -p "$local_bin" >/dev/null 2>&1 || true
+   fi
+
+   case ":${PATH}:" in
+      *":${local_bin}:"*) : ;;
+      *) PATH="${local_bin}:${PATH}" ;;
+   esac
+
+   export PATH
+}
+
+function _is_world_writable_dir() {
+   local dir="$1"
+
+   if [[ -z "$dir" || ! -d "$dir" ]]; then
+      return 1
+   fi
+
+   local perm
+   if stat -c '%a' "$dir" >/dev/null 2>&1; then
+      perm="$(stat -c '%a' "$dir" 2>/dev/null || true)"
+   else
+      perm="$(stat -f '%OLp' "$dir" 2>/dev/null || true)"
+   fi
+
+   if [[ -z "$perm" ]]; then
+      return 1
+   fi
+
+   local other="${perm: -1}"
+   case "$other" in
+      2|3|6|7) return 0 ;;
+      *) return 1 ;;
+   esac
+}
+
+function _safe_path() {
+   local entry
+   local -a unsafe=()
+   local -a path_entries=()
+
+   IFS=':' read -r -a path_entries <<< "${PATH:-}"
+
+   for entry in "${path_entries[@]}"; do
+      if [[ -z "$entry" || "$entry" != /* ]]; then
+          unsafe+=("${entry:-<empty>} (relative path entry)")
+          continue
+      fi
+      if _is_world_writable_dir "$entry"; then
+         unsafe+=("$entry (world-writable)")
+      fi
+   done
+
+   if ((${#unsafe[@]})); then
+      _err "PATH contains unsafe entries (world-writable or relative): ${unsafe[*]}"
+   fi
+}
+
+function _install_bats_from_source() {
+   local version="${1:-1.11.0}"
+   local url="https://github.com/bats-core/bats-core/archive/refs/tags/v${version}.tar.gz"
+   local tmp_dir
+
+   tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t bats-core)"
+   if [[ -z "$tmp_dir" ]]; then
+      echo "Failed to create temporary directory for bats install" >&2
+      return 1
+   fi
+
+   if ! _command_exist curl || ! _command_exist tar ; then
+      echo "Cannot install bats from source: curl and tar are required" >&2
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   echo "Installing bats ${version} from source..." >&2
+   if ! _run_command -- curl -fsSL "$url" -o "${tmp_dir}/bats-core.tar.gz"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   if ! tar -xzf "${tmp_dir}/bats-core.tar.gz" -C "$tmp_dir"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   local src_dir="${tmp_dir}/bats-core-${version}"
+   if [[ ! -d "$src_dir" ]]; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   local prefix="${HOME}/.local"
+   mkdir -p "$prefix"
+
+   if _run_command -- bash "$src_dir/install.sh" "$prefix"; then
+      rm -rf "$tmp_dir"
+      return 0
+   fi
+
+   if _sudo_available; then
+      if _run_command --prefer-sudo -- bash "$src_dir/install.sh" /usr/local; then
+         rm -rf "$tmp_dir"
+         return 0
+      fi
+   fi
+
+   echo "Cannot install bats: write access to ${prefix} or sudo is required" >&2
+   rm -rf "$tmp_dir"
+   return 1
+}
+
+function _ensure_bats() {
+   local required="1.5.0"
+
+   if _bats_meets_requirement "$required"; then
+      return 0
+   fi
+
+   local pkg_attempted=0
+
+   if _command_exist brew ; then
+      _run_command -- brew install bats-core
+      pkg_attempted=1
+   elif _command_exist apt-get && _sudo_available; then
+      _run_command --prefer-sudo -- apt-get update
+      _run_command --prefer-sudo -- apt-get install -y bats
+      pkg_attempted=1
+   elif _command_exist dnf && _sudo_available; then
+      _run_command --prefer-sudo -- dnf install -y bats
+      pkg_attempted=1
+   elif _command_exist yum && _sudo_available; then
+      _run_command --prefer-sudo -- yum install -y bats
+      pkg_attempted=1
+   elif _command_exist microdnf && _sudo_available; then
+      _run_command --prefer-sudo -- microdnf install -y bats
+      pkg_attempted=1
+   fi
+
+   if _bats_meets_requirement "$required"; then
+      return 0
+   fi
+
+   local target_version="${BATS_PREFERRED_VERSION:-1.13.0}"
+   if _install_bats_from_source "$target_version" && _bats_meets_requirement "$required"; then
+      return 0
+   fi
+
+   if (( pkg_attempted == 0 )); then
+      echo "Cannot install bats >= ${required}: no suitable package manager or sudo access available." >&2
+   else
+      echo "Cannot install bats >= ${required}. Please install it manually." >&2
+   fi
+
+   exit 127
+}
+
+function _install_node_from_release() {
+   local version="${NODE_PREFERRED_VERSION:-20.11.1}"
+   local kernel arch tarball url tmp_dir extracted install_root
+
+   kernel="$(uname -s)"
+   case "$kernel" in
+      Darwin) kernel="darwin" ;;
+      Linux) kernel="linux" ;;
+      *)
+         echo "Cannot install Node.js: unsupported platform '$kernel'" >&2
+         return 1
+         ;;
+   esac
+
+   arch="$(uname -m)"
+   case "$arch" in
+      x86_64|amd64) arch="x64" ;;
+      arm64|aarch64) arch="arm64" ;;
+      *)
+         echo "Cannot install Node.js: unsupported architecture '$arch'" >&2
+         return 1
+         ;;
+   esac
+
+   tarball="node-v${version}-${kernel}-${arch}.tar.gz"
+   url="https://nodejs.org/dist/v${version}/${tarball}"
+
+   tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t node-install)"
+   if [[ -z "$tmp_dir" ]]; then
+      echo "Failed to create temporary directory for Node.js install" >&2
+      return 1
+   fi
+
+   if ! _command_exist curl || ! _command_exist tar; then
+      echo "Cannot install Node.js: curl and tar are required" >&2
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   if ! _run_command -- curl -fsSL "$url" -o "${tmp_dir}/${tarball}"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   if ! tar -xzf "${tmp_dir}/${tarball}" -C "$tmp_dir"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   extracted="${tmp_dir}/node-v${version}-${kernel}-${arch}"
+   if [[ ! -d "$extracted" ]]; then
+      echo "Node.js archive missing expected directory" >&2
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   install_root="${HOME}/.local/node-v${version}-${kernel}-${arch}"
+   rm -rf "$install_root"
+   mkdir -p "${install_root%/*}"
+
+   if ! mv "$extracted" "$install_root"; then
+      rm -rf "$tmp_dir"
+      echo "Failed to move Node.js archive into ${install_root}" >&2
+      return 1
+   fi
+
+   _ensure_local_bin_on_path
+   ln -sf "${install_root}/bin/node" "${HOME}/.local/bin/node"
+   ln -sf "${install_root}/bin/npm" "${HOME}/.local/bin/npm"
+   ln -sf "${install_root}/bin/npx" "${HOME}/.local/bin/npx"
+
+   hash -r 2>/dev/null || true
+   rm -rf "$tmp_dir"
+
+   if _command_exist node; then
+      return 0
+   fi
+
+   echo "Node.js install completed but 'node' is still missing from PATH" >&2
+   return 1
+}
+
+function _ensure_node() {
+   if _command_exist node; then
+      return 0
+   fi
+
+   if _command_exist brew; then
+      _run_command -- brew install node
+      if _command_exist node; then
+         return 0
+      fi
+   fi
+
+   if _is_debian_family && _command_exist apt-get && _sudo_available; then
+      _run_command --prefer-sudo -- apt-get update
+      _run_command --prefer-sudo -- apt-get install -y nodejs npm
+      if _command_exist node; then
+         return 0
+      fi
+   fi
+
+   if _is_redhat_family; then
+      if _command_exist dnf && _sudo_available; then
+         _run_command --prefer-sudo -- dnf install -y nodejs npm
+      elif _command_exist yum && _sudo_available; then
+         _run_command --prefer-sudo -- yum install -y nodejs npm
+      elif _command_exist microdnf && _sudo_available; then
+         _run_command --prefer-sudo -- microdnf install -y nodejs npm
+      fi
+
+      if _command_exist node; then
+         return 0
+      fi
+   fi
+
+   if _install_node_from_release; then
+      return 0
+   fi
+
+   _err "Cannot install Node.js: missing package manager and release fallback failed"
+}
+
+function _install_copilot_from_release() {
+   if ! _command_exist curl; then
+      echo "Cannot install Copilot CLI: curl is required" >&2
+      return 1
+   fi
+
+   local version="${COPILOT_CLI_VERSION:-latest}"
+   local tmp_dir script
+
+   tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t copilot-cli)"
+   if [[ -z "$tmp_dir" ]]; then
+      echo "Failed to allocate temporary directory for Copilot CLI install" >&2
+      return 1
+   fi
+
+   script="${tmp_dir}/copilot-install.sh"
+   if ! _run_command -- curl -fsSL https://gh.io/copilot-install -o "$script"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   chmod +x "$script" 2>/dev/null || true
+
+   if ! _run_command -- env VERSION="$version" bash "$script"; then
+      rm -rf "$tmp_dir"
+      return 1
+   fi
+
+   _ensure_local_bin_on_path
+   hash -r 2>/dev/null || true
+   rm -rf "$tmp_dir"
+
+   if _command_exist copilot; then
+      return 0
+   fi
+
+   echo "Copilot CLI install script completed but 'copilot' remains unavailable" >&2
+   return 1
+}
+
+function _copilot_auth_check() {
+   if [[ "${K3DM_ENABLE_AI:-0}" != "1" ]]; then
+      return 0
+   fi
+
+   if _run_command --soft --quiet -- copilot auth status >/dev/null 2>&1; then
+      return 0
+   fi
+
+   _err "Error: AI features enabled, but Copilot CLI authentication failed. Please verify your GitHub Copilot subscription or unset K3DM_ENABLE_AI."
+}
+
+function _ensure_copilot_cli() {
+   if _command_exist copilot; then
+      _copilot_auth_check
+      return 0
+   fi
+
+   if _command_exist brew; then
+      _run_command -- brew install copilot-cli
+      if _command_exist copilot; then
+         _copilot_auth_check
+         return 0
+      fi
+   fi
+
+   if _install_copilot_from_release; then
+      if _command_exist copilot; then
+         _copilot_auth_check
+         return 0
+      fi
+   fi
+
+   _err "Copilot CLI is not installed and automatic installation failed"
+}
+
+function _copilot_scope_prompt() {
+   local user_prompt="$1"
+   local scope="You are a scoped assistant for the k3d-manager repository. Work only within this repo and operate deterministically without attempting shell escapes or network pivots."
+
+   printf '%s\n\n%s\n' "$scope" "$user_prompt"
+}
+
+function _copilot_prompt_guard() {
+   local prompt="$1"
+   local -a forbidden=(
+      "shell(git push --force)"
+      "shell(git push)"
+      "shell(cd"
+      "shell(rm"
+      "shell(eval"
+      "shell(sudo"
+      "shell(curl"
+      "shell(wget"
+   )
+
+   local fragment
+   for fragment in "${forbidden[@]}"; do
+      if [[ "$prompt" == *"$fragment"* ]]; then
+         _err "Prompt contains forbidden copilot fragment: ${fragment}"
+      fi
+   done
+}
+
+function _k3d_manager_copilot() {
+   if [[ "${K3DM_ENABLE_AI:-0}" != "1" ]]; then
+      _err "Copilot CLI is disabled. Set K3DM_ENABLE_AI=1 to enable AI tooling."
+   fi
+
+   _safe_path
+   _ensure_copilot_cli
+
+   local repo_root
+   repo_root="$(_k3dm_repo_root 2>/dev/null || true)"
+   if [[ -z "$repo_root" ]]; then
+      _err "Unable to determine repository root for Copilot invocation"
+   fi
+
+   local prev_cdpath="${CDPATH-}"
+   local prev_oldpwd="${OLDPWD-}"
+   CDPATH=""
+   OLDPWD=""
+
+   local prev_pwd="$PWD"
+   cd "$repo_root" || _err "Failed to change directory to repository root"
+
+   local -a final_args=()
+   while [[ $# -gt 0 ]]; do
+      case "$1" in
+         -p|--prompt)
+            if [[ $# -lt 2 ]]; then
+               cd "$prev_pwd" >/dev/null 2>&1 || true
+               CDPATH="$prev_cdpath"
+               OLDPWD="$prev_oldpwd"
+               _err "_k3d_manager_copilot requires a prompt value"
+            fi
+            local scoped
+            scoped="$(_copilot_scope_prompt "$2")"
+            _copilot_prompt_guard "$scoped"
+            final_args+=("$1" "$scoped")
+            shift 2
+            continue
+            ;;
+      esac
+
+      final_args+=("$1")
+      shift
+   done
+
+   local -a guard_args=(
+      "--deny-tool" "shell(cd ..)"
+      "--deny-tool" "shell(git push)"
+      "--deny-tool" "shell(git push --force)"
+      "--deny-tool" "shell(rm -rf)"
+      "--deny-tool" "shell(sudo"
+      "--deny-tool" "shell(eval"
+      "--deny-tool" "shell(curl"
+      "--deny-tool" "shell(wget"
+   )
+   local -a processed_args=("${guard_args[@]}" "${final_args[@]}")
+
+   local rc=0
+   _run_command --soft -- copilot "${processed_args[@]}" || rc=$?
+
+   cd "$prev_pwd" >/dev/null 2>&1 || true
+   CDPATH="$prev_cdpath"
+   OLDPWD="$prev_oldpwd"
+
+   return "$rc"
+}
+
+
+function _ensure_cargo() {
+   if _command_exist cargo ; then
+      return 0
+   fi
+
+   if _is_mac && _command_exist brew ; then
+      brew install rust
+      return 0
+   fi
+
+   if _is_debian_family ; then
+      _run_command -- sudo apt-get update
+      _run_command -- sudo apt-get install -y cargo
+   elif _is_redhat_family ; then
+      _run_command -- sudo dnf install -y cargo
+   elif _is_wsl && grep -qi "debian" /etc/os-release &> /dev/null; then
+      _run_command -- sudo apt-get update
+      _run_command -- sudo apt-get install -y cargo
+   elif _is_wsl && grep -qi "redhat" /etc/os-release &> /dev/null; then
+      _run_command -- sudo apt-get update
+      _run_command -- sudo apt-get install -y cargo
+   else
+      echo "Cannot install cargo: unsupported OS or missing package manager" >&2
+      exit 127
+   fi
+}
+
+function _add_exit_trap() {
+   local handler="$1"
+   local cur
+   cur="$(trap -p EXIT | sed -E "s/.*'(.+)'/\1/")"
+
+   if [[ -n "$cur" ]]; then
+      # shellcheck disable=SC2064
+      trap "${cur}; ${handler}" EXIT
+   else
+      # shellcheck disable=SC2064
+      trap "${handler}" EXIT
+   fi
+}
+
+function _cleanup_register() {
+   if [[ -z "$__CLEANUP_TRAP_INSTALLED" ]]; then
+      _add_exit_trap [[ -n "$__CLEANUP_PATHS" ]] && rm -rf "$__CLEANUP_PATHS"
+   fi
+   __CLEANUP_PATHS+=" $*"
+}
+
+function _failfast_on() {
+  set -Eeuo pipefail
+  set -o errtrace
+  trap '_err "[fatal] rc=$? at $BASH_SOURCE:$LINENO: ${BASH_COMMAND}"' ERR
+}
+
+function _failfast_off() {
+  trap - ERR
+  set +Eeuo pipefail
+}
+
+function _detect_cluster_name() {
+   local cluster_info
+   cluster_info="$(_kubectl --quiet -- get nodes | tail -1)"
+
+   if [[ -z "$cluster_info" ]]; then
+      _err "Cannot detect cluster name: no nodes found"
+   fi
+   local cluster_ready
+   cluster_ready=$(echo "$cluster_info" | awk '{print $2}')
+   local cluster_name
+   cluster_name=$(echo "$cluster_info" | awk '{print $1}')
+
+   if [[ "$cluster_ready" != "Ready" ]]; then
+      _err "Cluster node is not ready: $cluster_info"
+   fi
+   _info "Detected cluster name: $cluster_name"
+
+   printf '%s' "$cluster_name"
+}
+
+# ---------- tiny log helpers (no parentheses, no single-quote apostrophes) ----------
+function _info() { printf 'INFO: %s\n' "$*" >&2; }
+function _warn() { printf 'WARN: %s\n' "$*" >&2; }
+function _err() {
+   printf 'ERROR: %s\n' "$*" >&2
+   exit 1
+}
+
+function _no_trace() {
+  local wasx=0
+  case $- in *x*) wasx=1; set +x;; esac
+  "$@"; local rc=$?
+  (( wasx )) && set -x
+  return $rc
+}

--- a/scripts/plugins/vault.sh
+++ b/scripts/plugins/vault.sh
@@ -1529,8 +1529,8 @@ SH
 
   if [[ -n "$role_namespaces_override" ]]; then
      bound_namespaces="$role_namespaces_override"
-  elif [[ "$role" == "eso-ldap-directory" ]]; then
-     bound_namespaces="directory,identity"
+  elif [[ "$role" == "eso-ldap-directory" && "$service_namespace" != "identity" ]]; then
+     bound_namespaces="${service_namespace},identity"
   fi
 
   printf -v role_cmd 'vault write "auth/kubernetes/role/%s" bound_service_account_names="%s" bound_service_account_namespaces="%s" policies="%s" ttl=1h token_audiences="%s"' \

--- a/scripts/plugins/vault.sh
+++ b/scripts/plugins/vault.sh
@@ -1416,6 +1416,7 @@ function _vault_configure_secret_reader_role() {
   local secret_prefix_arg="${6:-ldap}"
   local role="${7:-eso-ldap-directory}"
   local policy="${8:-${role}}"
+  local role_namespaces_override="${9:-}"
   local pod="${release}-0"
 
   local sanitized_prefixes="${secret_prefix_arg//,/ }"
@@ -1524,8 +1525,16 @@ SH
 
   local token_audience="${K8S_TOKEN_AUDIENCE:-https://kubernetes.default.svc.cluster.local}"
   local role_cmd=""
+  local bound_namespaces="$service_namespace"
+
+  if [[ -n "$role_namespaces_override" ]]; then
+     bound_namespaces="$role_namespaces_override"
+  elif [[ "$role" == "eso-ldap-directory" ]]; then
+     bound_namespaces="directory,identity"
+  fi
+
   printf -v role_cmd 'vault write "auth/kubernetes/role/%s" bound_service_account_names="%s" bound_service_account_namespaces="%s" policies="%s" ttl=1h token_audiences="%s"' \
-     "$role" "$service_account" "$service_namespace" "$policy" "$token_audience"
+     "$role" "$service_account" "$bound_namespaces" "$policy" "$token_audience"
 
   _vault_exec "$ns" "$role_cmd" "$release"
 }

--- a/scripts/tests/lib/core.bats
+++ b/scripts/tests/lib/core.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+setup() {
+  CORE_LIB="${BATS_TEST_DIRNAME}/../../lib/core.sh"
+}
+
+_make_test_script() {
+  local target="$1"
+  cat <<SCRIPT > "$target"
+#!/usr/bin/env bash
+source "$CORE_LIB"
+SCRIPT_DIR="\$(_resolve_script_dir)"
+printf '%s\n' "\$SCRIPT_DIR"
+SCRIPT
+  chmod +x "$target"
+}
+
+@test "_resolve_script_dir returns absolute path" {
+  test_dir="${BATS_TEST_TMPDIR}/direct"
+  mkdir -p "$test_dir"
+  script_path="$test_dir/original.sh"
+  _make_test_script "$script_path"
+
+  run "$script_path"
+  [ "$status" -eq 0 ]
+  expected="$(cd "$test_dir" && pwd -P)"
+  [ "$output" = "$expected" ]
+}
+
+@test "_resolve_script_dir resolves symlinked script from different directory" {
+  real_dir="${BATS_TEST_TMPDIR}/real"
+  link_dir="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$real_dir" "$link_dir"
+  script_path="$real_dir/original.sh"
+  _make_test_script "$script_path"
+  link_path="$link_dir/link.sh"
+  ln -sf "$script_path" "$link_path"
+
+  run "$link_path"
+  [ "$status" -eq 0 ]
+  expected="$(cd "$real_dir" && pwd -P)"
+  [ "$output" = "$expected" ]
+}


### PR DESCRIPTION
## Summary

- Pull lib-foundation shared library into `scripts/lib/foundation/` via git subtree
- Update dispatcher to source from subtree (fallback to local copies during transition)
- Refactor `deploy_cluster` — extract provider selection helpers, fix if-count violation
- Fix `CLUSTER_NAME` env var ignored during `deploy_cluster`
- Fix ESO SecretStore Vault role binding — `eso-ldap-directory` now covers both `directory` and `identity` namespaces
- Full cluster validation on OrbStack (macOS ARM64) and Ubuntu k3s — all services healthy

## Changes

### Production code
- `scripts/k3d-manager` — sources `scripts/lib/foundation/scripts/lib/` with local fallback
- `scripts/lib/core.sh` — extracted `_deploy_cluster_prompt_provider` + `_deploy_cluster_resolve_provider`; `deploy_cluster` if-count reduced from 12 → 5; `CLUSTER_NAME` env var respected
- `scripts/plugins/vault.sh` — `_vault_configure_secret_reader_role` binds `eso-ldap-directory` to `directory,identity` namespaces

### Subtree
- `scripts/lib/foundation/` — lib-foundation `main` squash-merged (contains `core.sh`, `system.sh`, `_resolve_script_dir`)

### Docs / issues filed
- `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`
- `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`
- `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
- `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md`

## Validation

| Platform | Cluster | BATS | Services |
|---|---|---|---|
| macOS ARM64 (OrbStack/k3d) | Rebuilt from scratch | 158/158 | Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak — all Running |
| Ubuntu k3s | Rebuilt from scratch | 158/158 | Vault, ESO, Istio, OpenLDAP, SecretStores 3/3 Ready |

## Known issues deferred

- BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up (Gemini — v0.7.x backlog)
- inotify limit in colima VM not persistent (ops note)
- ESO + shopping-cart deployment on Ubuntu app cluster (next milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)