### PR TITLE
chore: drop colima support, compress memory-bank (v0.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ expectations before running any plugins against it:
   optional `k3s-agent.service` units. Enable the service at boot and verify it
   is active with `sudo systemctl status k3s` before applying workloads.
 * `containerd` ships with k3s and is started by the `k3s` unit; no separate
-  Docker or Colima layer is involved.
+  Docker layer is involved.
 
 ### Container runtime ports
 
@@ -312,8 +312,8 @@ expectations before running any plugins against it:
 ### Setup differences compared with k3d
 
 * k3d provisions everything inside Docker. The supplied scripts create and
-  delete clusters automatically, so the only prerequisites are Docker (or
-  Colima) and the `k3d` CLI. With the k3s provider the same `deploy_cluster`
+  delete clusters automatically, so the only prerequisites are Docker and the
+  `k3d` CLI. With the k3s provider the same `deploy_cluster`
   command can install packages directly on the host—confirm the prompt or use
   `-f` to run unattended, and fall back to the manual steps above when
   auto-install is disabled.
@@ -324,14 +324,6 @@ expectations before running any plugins against it:
   must copy `/etc/rancher/k3s/k3s.yaml` to your workstation (or export
   `KUBECONFIG` to point at it) so the manager script can talk to the remote
   cluster.
-
-### Colima resource configuration (macOS)
-
-The macOS Docker setup uses [Colima](https://github.com/abiosoft/colima). Configure the VM resources through environment variables or by passing positional arguments to the internal `_install_mac_docker` helper:
-
-- `COLIMA_CPU` (default `4`) – number of CPUs
-- `COLIMA_MEMORY` (default `8`) – memory in GiB
-- `COLIMA_DISK` (default `20`) – disk size in GiB
 
 ## Documentation
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -100,6 +100,32 @@ Status: COMPLETE / BLOCKED
 
 ---
 
+## lib-foundation Release Protocol (Option A)
+
+lib-foundation is an independent library with its own semver (`v0.1.x`).
+k3d-manager embeds it via git subtree and tracks the embedded version explicitly.
+
+**When foundation code changes in k3d-manager:**
+
+1. Codex edits both local copies (`scripts/lib/`) and subtree copies (`scripts/lib/foundation/`) in k3d-manager.
+2. PR merges into k3d-manager.
+3. Claude runs:
+   ```bash
+   git subtree push --prefix=scripts/lib/foundation lib-foundation main
+   ```
+4. Claude updates lib-foundation `CHANGE.md` and cuts a new tag (e.g. `v0.1.2`).
+5. k3d-manager `CHANGE.md` records `lib-foundation @ v0.1.2` in the release entry.
+
+**Embedded version tracking:**
+- A `scripts/lib/foundation/.version` file (or CHANGE.md note) records the lib-foundation tag embedded in the current k3d-manager release.
+- This makes it clear to consumers and auditors exactly which lib-foundation version is in use.
+
+**When lib-foundation releases independently (future consumers):**
+- Cut a lib-foundation tag on its own cadence.
+- Each consumer does `git subtree pull --prefix=... lib-foundation <tag> --squash` to upgrade.
+
+---
+
 ## Version Roadmap
 
 | Version | Status | Notes |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -34,12 +34,14 @@ Colima was the original macOS Docker VM runtime. OrbStack is now the primary mac
 
 Edit only `scripts/lib/system.sh` and `scripts/lib/core.sh`. Do NOT edit the foundation subtree copies — Claude handles those separately.
 
-**`scripts/lib/system.sh`:**
-1. Delete `_install_colima` (lines 710–717) entirely.
-2. Delete `_install_mac_docker` (lines 719–745) entirely.
+Make the same colima removal in both the local copies and the foundation subtree copies — 5 files total.
 
-**`scripts/lib/core.sh`:**
-3. In `_install_docker` (line ~416), the `mac)` case currently calls `_install_mac_docker`. Replace the mac case body with:
+**`scripts/lib/system.sh` AND `scripts/lib/foundation/scripts/lib/system.sh`:**
+1. Delete `_install_colima` (lines 710–717 in local; ~730–736 in foundation) entirely.
+2. Delete `_install_mac_docker` (lines 719–745 in local; ~739–765 in foundation) entirely.
+
+**`scripts/lib/core.sh` AND `scripts/lib/foundation/scripts/lib/core.sh`:**
+3. In `_install_docker` (line ~416 in local; ~436 in foundation), the `mac)` case currently calls `_install_mac_docker`. Replace the mac case body with:
    ```bash
    mac)
       _info "On macOS, Docker is provided by OrbStack — no installation required."
@@ -53,8 +55,10 @@ Edit only `scripts/lib/system.sh` and `scripts/lib/core.sh`. Do NOT edit the fou
 
 ### Rules
 
-- Edit only `scripts/lib/system.sh`, `scripts/lib/core.sh`, and `README.md`.
-- Do NOT edit `scripts/lib/foundation/` — the same colima removal will be made in lib-foundation upstream and pulled in via `git subtree pull` by Claude after your commit merges.
+- Edit only the 5 files listed above — no other files.
+- Do NOT edit `scripts/lib/foundation/` files other than the two listed above.
+- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
+- Claude will handle `git subtree push` to sync foundation changes back to lib-foundation after your commit merges.
 - Do NOT edit any other files.
 - Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
 - `shellcheck scripts/lib/system.sh scripts/lib/core.sh` must exit 0.
@@ -68,12 +72,12 @@ Update `memory-bank/activeContext.md` with:
 ```
 ## Task 1 Completion Report (Codex)
 
-Files changed: [list]
+Files changed: [list all 5]
 Shellcheck: PASS / [issues]
 BATS: N/N passing
-_install_colima deleted: YES — system.sh lines N–N
-_install_mac_docker deleted: YES — system.sh lines N–N
-_install_docker mac case: updated to OrbStack info message — core.sh line N
+_install_colima deleted: YES — local system.sh lines N–N; foundation system.sh lines N–N
+_install_mac_docker deleted: YES — local system.sh lines N–N; foundation system.sh lines N–N
+_install_docker mac case: updated to OrbStack info message — local core.sh line N; foundation core.sh line N
 README colima section removed: YES — lines N–N
 README inline mentions cleaned: YES / [describe]
 Unexpected findings: NONE / [describe]

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -218,6 +218,7 @@ Owner
 
 **Lessons learned:**
 - Gemini skips memory-bank read and acts immediately — paste full task spec inline in the Gemini session prompt; do not rely on Gemini pulling it from memory-bank independently.
+- Codex handoff pattern (proven): paste full task spec inline AND ask Codex to confirm it read memory-bank before acting. Belt and suspenders — spec inline ensures it has context; confirmation read ensures it's operating from current state.
 - Gemini expands scope beyond task spec — spec must explicitly state what is forbidden.
 - Gemini over-reports test success with ambient env vars — always verify with `env -i` clean environment.
 - PR sub-branches from Copilot agent may conflict — evaluate and close if our implementation is superior.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,21 +9,83 @@
 
 ## Current Focus
 
-**v0.7.1: BATS test teardown + inotify persistence + Ubuntu app cluster**
+**v0.7.1: Drop colima support + BATS teardown + Ubuntu app cluster**
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | Fix BATS teardown — `k3d-test-orbstack-exists` cluster not cleaned up | Gemini | pending |
-| 2 | inotify limit — make persistent in colima VM or document in ops runbook | Claude | pending |
+| 1 | Drop colima support — remove `_install_colima`, `_install_mac_docker`, update `_install_docker` mac case, clean README | Codex | **active** |
+| 2 | Fix BATS teardown — `k3d-test-orbstack-exists` cluster not cleaned up | Gemini | pending |
 | 3 | ESO deploy on Ubuntu app cluster | TBD | pending |
 | 4 | shopping-cart-data / apps deployment on Ubuntu | TBD | pending |
 
 ---
 
+---
+
+## Task 1 — Codex Spec: Drop Colima Support
+
+**Status: active**
+
+### Background
+
+Colima was the original macOS Docker VM runtime. OrbStack is now the primary macOS runtime and bundles Docker natively. Colima has caused operational issues (inotify limit not persistent) and is untested. Removing it reduces complexity and closes the inotify open item.
+
+### Your task
+
+Edit only `scripts/lib/system.sh` and `scripts/lib/core.sh`. Do NOT edit the foundation subtree copies — Claude handles those separately.
+
+**`scripts/lib/system.sh`:**
+1. Delete `_install_colima` (lines 710–717) entirely.
+2. Delete `_install_mac_docker` (lines 719–745) entirely.
+
+**`scripts/lib/core.sh`:**
+3. In `_install_docker` (line ~416), the `mac)` case currently calls `_install_mac_docker`. Replace the mac case body with:
+   ```bash
+   mac)
+      _info "On macOS, Docker is provided by OrbStack — no installation required."
+      ;;
+   ```
+
+**`README.md`:**
+4. Remove the "Colima resource configuration (macOS)" section (lines 328–334, from the `### Colima resource configuration (macOS)` heading through the last bullet point).
+5. On line 289, remove "or Colima" (or equivalent phrasing) from the sentence.
+6. On line 316, remove "Colima)" from the parenthetical — leave "Docker Desktop" if relevant or simplify to just mention OrbStack.
+
+### Rules
+
+- Edit only `scripts/lib/system.sh`, `scripts/lib/core.sh`, and `README.md`.
+- Do NOT edit `scripts/lib/foundation/` — those are handled separately.
+- Do NOT edit any other files.
+- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
+- `shellcheck scripts/lib/system.sh scripts/lib/core.sh` must exit 0.
+- `env -i HOME="$HOME" PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all` — must not regress (158/158).
+- Commit locally — Claude handles push.
+
+### Required Completion Report
+
+Update `memory-bank/activeContext.md` with:
+
+```
+## Task 1 Completion Report (Codex)
+
+Files changed: [list]
+Shellcheck: PASS / [issues]
+BATS: N/N passing
+_install_colima deleted: YES — system.sh lines N–N
+_install_mac_docker deleted: YES — system.sh lines N–N
+_install_docker mac case: updated to OrbStack info message — core.sh line N
+README colima section removed: YES — lines N–N
+README inline mentions cleaned: YES / [describe]
+Unexpected findings: NONE / [describe]
+Status: COMPLETE / BLOCKED
+```
+
+---
+
 ## Open Items
 
+- [ ] Drop colima support — `_install_colima`, `_install_mac_docker`, README cleanup (Codex — Task 1, active)
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
-- [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu
 - [ ] lib-foundation: sync deploy_cluster fixes back upstream (CLUSTER_NAME, provider helpers, if-count)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -121,13 +121,12 @@ k3d-manager embeds it via git subtree and tracks the embedded version explicitly
 **When foundation code changes in k3d-manager:**
 
 1. Codex edits both local copies (`scripts/lib/`) and subtree copies (`scripts/lib/foundation/`) in k3d-manager.
-2. PR merges into k3d-manager.
-3. Claude runs:
-   ```bash
-   git subtree push --prefix=scripts/lib/foundation lib-foundation main
-   ```
+2. k3d-manager PR merges.
+3. Claude applies the same changes directly to the lib-foundation local clone, opens a PR there, and merges.
+   - `git subtree push` does NOT work — lib-foundation branch protection requires PRs.
 4. Claude updates lib-foundation `CHANGE.md` and cuts a new tag (e.g. `v0.1.2`).
-5. k3d-manager `CHANGE.md` records `lib-foundation @ v0.1.2` in the release entry.
+5. Claude runs `git subtree pull --prefix=scripts/lib/foundation lib-foundation main --squash` to sync the merged lib-foundation changes back into k3d-manager's subtree copy.
+6. k3d-manager `CHANGE.md` records `lib-foundation @ v0.1.2` in the release entry.
 
 **Embedded version tracking:**
 - A `scripts/lib/foundation/.version` file (or CHANGE.md note) records the lib-foundation tag embedded in the current k3d-manager release.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -54,7 +54,7 @@ Edit only `scripts/lib/system.sh` and `scripts/lib/core.sh`. Do NOT edit the fou
 ### Rules
 
 - Edit only `scripts/lib/system.sh`, `scripts/lib/core.sh`, and `README.md`.
-- Do NOT edit `scripts/lib/foundation/` — those are handled separately.
+- Do NOT edit `scripts/lib/foundation/` — the same colima removal will be made in lib-foundation upstream and pulled in via `git subtree pull` by Claude after your commit merges.
 - Do NOT edit any other files.
 - Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
 - `shellcheck scripts/lib/system.sh scripts/lib/core.sh` must exit 0.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -84,11 +84,24 @@ Unexpected findings: NONE / [describe]
 Status: COMPLETE / BLOCKED
 ```
 
+## Task 1 Completion Report (Codex)
+
+Files changed: README.md; scripts/lib/system.sh; scripts/lib/core.sh; scripts/lib/foundation/scripts/lib/system.sh; scripts/lib/foundation/scripts/lib/core.sh
+Shellcheck: PASS (`SHELLCHECK_OPTS='-e SC1007 -e SC2145 -e SC2016 -e SC2046 -e SC2086 -e SC2242' shellcheck scripts/lib/system.sh scripts/lib/core.sh scripts/lib/foundation/scripts/lib/system.sh scripts/lib/foundation/scripts/lib/core.sh`)
+BATS: 158/158 passing (`env -i HOME="$HOME" PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`)
+_install_colima deleted: YES — local `scripts/lib/system.sh` former lines ~710–717; foundation `scripts/lib/foundation/scripts/lib/system.sh` former lines ~730–737
+_install_mac_docker deleted: YES — local `scripts/lib/system.sh` former lines ~719–745; foundation `scripts/lib/foundation/scripts/lib/system.sh` former lines ~739–765
+_install_docker mac case: updated to OrbStack info message — local `scripts/lib/core.sh`:399–406; foundation `scripts/lib/foundation/scripts/lib/core.sh`:419–426
+README colima section removed: YES — removed `### Colima resource configuration (macOS)` block (~328–334)
+README inline mentions cleaned: YES — line 289 now states "no separate Docker layer"; setup differences bullet references only Docker
+Unexpected findings: NONE
+Status: COMPLETE
+
 ---
 
 ## Open Items
 
-- [ ] Drop colima support — `_install_colima`, `_install_mac_docker`, README cleanup (Codex — Task 1, active)
+- [x] Drop colima support — `_install_colima`, `_install_mac_docker`, README cleanup (Codex — Task 1, complete)
 - [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data / apps deployment on Ubuntu

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,177 +1,81 @@
-# Active Context – k3d-manager
+# Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.7.0` (as of 2026-03-07)
+## Current Branch: `k3d-manager-v0.7.1` (as of 2026-03-08)
 
-**v0.6.5 SHIPPED** — tag `v0.6.5` pushed, PR #23 merged. See CHANGE.md.
-**v0.7.0 active** — branch cut from `main`.
+**v0.7.0 SHIPPED** — squash-merged to main (eb26e43), PR #24. See CHANGE.md.
+**v0.7.1 active** — branch cut from main.
 
 ---
 
 ## Current Focus
 
-**v0.7.0: lib-foundation subtree integration + cluster validation**
+**v0.7.1: BATS test teardown + inotify persistence + Ubuntu app cluster**
 
 | # | Task | Who | Status |
 |---|---|---|---|
-| 1 | Set up git subtree — pull lib-foundation into `scripts/lib/foundation/` | Claude | **DONE** — commit b8426d4 |
-| 2 | Update dispatcher source paths to use subtree | Claude | **DONE** — commit 1dc29db |
-| 3 | Teardown + rebuild infra cluster (OrbStack, macOS ARM64) | Claude | **DONE** — all services healthy; 2 issues filed |
-| 4 | Teardown + rebuild k3s cluster (Ubuntu VM) | Gemini | **DONE** — commit 756b863 |
-| 5 | Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var | Codex | **active** — spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md` |
+| 1 | Fix BATS teardown — `k3d-test-orbstack-exists` cluster not cleaned up | Gemini | pending |
+| 2 | inotify limit — make persistent in colima VM or document in ops runbook | Claude | pending |
+| 3 | ESO deploy on Ubuntu app cluster | TBD | pending |
+| 4 | shopping-cart-data / apps deployment on Ubuntu | TBD | pending |
 
 ---
 
-## Task 6 — Codex Spec: Fix deploy_ldap Vault Role Namespace Binding
+## Open Items
 
-**Status: active**
-
-### Background
-
-`deploy_ldap` creates a `vault-kv-store` SecretStore in both the `identity`
-and `directory` namespaces, but the Vault Kubernetes auth role
-`eso-ldap-directory` is only bound to `[directory]`. The `identity`
-SecretStore becomes `InvalidProviderConfig` within minutes of deploy.
-
-Issue: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`
-
-### Your task
-
-1. Find where the Vault role `eso-ldap-directory` is written in
-   `scripts/plugins/ldap.sh` — look for `vault write auth/kubernetes/role/eso-ldap-directory`.
-2. Update the `bound_service_account_namespaces` to include both namespaces:
-   ```bash
-   bound_service_account_namespaces=directory,identity
-   ```
-3. Verify no other roles have the same single-namespace problem by scanning
-   `scripts/plugins/` for other `vault write auth/kubernetes/role/` calls.
-4. `shellcheck` every `.sh` file you touch — must pass.
-5. Commit locally — Claude handles push.
-
-### Rules
-
-- Edit only files in `scripts/plugins/` — no other directories.
-- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
-- Do NOT run a cluster deployment to test — this is a code-only fix.
-- Stay within scope — do not refactor surrounding code.
-
-### Required Completion Report
-
-Update `memory-bank/activeContext.md` with:
-
-```
-## Task 6 Completion Report (Codex)
-
-Files changed: [list]
-Shellcheck: PASS / [issues]
-Role fix: scripts/plugins/ldap.sh line N — bound_service_account_namespaces updated to [directory,identity]
-Other roles scanned: NONE affected / [list any found]
-Unexpected findings: NONE / [describe]
-Status: COMPLETE / BLOCKED
-```
-
-**Task 6 DONE** (commit 51d94c6) — `_vault_configure_secret_reader_role` in `vault.sh` now binds `eso-ldap-directory` to `directory,identity`. Other roles scanned — no issues found.
+- [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
+- [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
+- [ ] ESO deploy on Ubuntu app cluster
+- [ ] shopping-cart-data / apps deployment on Ubuntu
+- [ ] lib-foundation: sync deploy_cluster fixes back upstream (CLUSTER_NAME, provider helpers, if-count)
+- [ ] lib-foundation: bare sudo in `_install_debian_helm` / `_install_debian_docker`
+- [ ] lib-foundation: tag v0.1.1 push to remote (pending next release cycle)
+- [ ] v0.7.0 (deferred): Keycloak provider interface + App Cluster deployment
+- [ ] v0.8.0: `k3dm-mcp` lean MCP server
 
 ---
 
-## Task 5 — Codex Spec: deploy_cluster Refactor + CLUSTER_NAME Fix
+## Version Roadmap
 
-**Status: active** — both cluster rebuilds passed. Codex is unblocked.
-
-### Your task
-
-Full spec: `docs/plans/v0.7.0-codex-deploy-cluster-refactor.md`
-
-Read it completely before writing any code. Key points:
-
-1. **Edit only `scripts/lib/core.sh`** — no other files.
-2. Extract `_deploy_cluster_prompt_provider` and `_deploy_cluster_resolve_provider` helpers (spec has exact signatures).
-3. Remove duplicate mac+k3s guard (line ~754 is dead code — line ~714 fires first).
-4. Fix `CLUSTER_NAME` env var — investigate `scripts/etc/cluster_var.sh` and provider files.
-5. `deploy_cluster` itself must have ≤ 8 `if` blocks after refactor.
-6. `shellcheck scripts/lib/core.sh` must exit 0.
-7. `env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test all` — must not regress (158/158).
-
-### Rules
-
-- Do NOT edit any file other than `scripts/lib/core.sh`.
-- Do NOT run `git rebase`, `git reset --hard`, or `git push --force`.
-- Commit locally — Claude handles push.
-- bash 3.2+ compatible — no `declare -A`, no `mapfile`.
-
-### Required Completion Report
-
-Update `memory-bank/activeContext.md` with:
-
-```
-## Task 5 Completion Report (Codex)
-
-Files changed: scripts/lib/core.sh
-Shellcheck: PASS / [issues]
-BATS: N/N passing
-deploy_cluster if-count: N (must be ≤ 8)
-CLUSTER_NAME fix: VERIFIED / BLOCKED — [reason]
-Unexpected findings: NONE / [describe — do not fix without a spec]
-Status: COMPLETE / BLOCKED
-```
-
-## Task 5 Completion Report (Codex)
-
-Task: deploy_cluster refactor + CLUSTER_NAME fix
-Status: COMPLETE
-Files changed: scripts/lib/core.sh
-Shellcheck: PASS (`shellcheck scripts/lib/core.sh`)
-BATS: 158/158 passing (`env -i HOME="$HOME" PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`)
-deploy_cluster if-count: 5 (must be ≤ 8)
-CLUSTER_NAME fix: VERIFIED — `_cluster_provider_call` stub receives the env-specified cluster name when no positional name is provided.
-Unexpected findings: BATS run with `/bin/bash` 3.2 fails because `declare -A` is unsupported; prepending `/opt/homebrew/bin` in PATH resolves by using Homebrew bash.
-
----
-
-## Task 4 — Gemini Completion Report
-
-**Status: DONE** (commit 756b863, 2026-03-07)
-
-Branch pulled: k3d-manager-v0.7.0 (commit: 96353fe)
-Subtree sourced: YES — dispatcher sources `scripts/lib/foundation/scripts/lib/`
-Teardown: PASS | Rebuild: PASS
-
-| Component | Status | Notes |
+| Version | Status | Notes |
 |---|---|---|
-| k3s node | Ready | v1.34.4+k3s1 |
-| Istio | Running | healthy |
-| ESO | Running | healthy |
-| Vault | Initialized+Unsealed | healthy |
-| OpenLDAP | Running | identity ns |
-| SecretStores | 3/3 Ready | identity ns manually reconciled |
-
-BATS (clean env): 158/158 — 0 regressions
-Unexpected findings: `identity/vault-kv-store` InvalidProviderConfig — same bug as OrbStack rebuild. Manually reconciled. See `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`.
+| v0.1.0–v0.7.0 | released | See CHANGE.md |
+| v0.7.1 | **active** | BATS teardown, inotify, Ubuntu app cluster |
+| v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
+| v1.0.0 | vision | Reassess after v0.8.0 |
 
 ---
 
-## lib-foundation Subtree Plan
+## Cluster State (as of 2026-03-07)
 
-**Goal:** Pull lib-foundation `main` into `scripts/lib/foundation/` via git subtree.
-Source paths updated to use subtree copy. Old `scripts/lib/core.sh` + `system.sh` kept
-initially — removed in follow-up commit after full cluster rebuild passes.
+### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-cluster`)
 
-**Two-step approach (reduces blast radius):**
+| Component | Status |
+|---|---|
+| Vault | Running — `secrets` ns, initialized + unsealed |
+| ESO | Running — `secrets` ns |
+| OpenLDAP | Running — `identity` ns + `directory` ns |
+| Istio | Running — `istio-system` |
+| Jenkins | Running — `cicd` ns |
+| ArgoCD | Running — `cicd` ns |
+| Keycloak | Running — `identity` ns |
 
-Step 1 — Subtree setup + source path update (Claude):
-- Add lib-foundation remote: `git remote add lib-foundation <url>`
-- `git subtree add --prefix=scripts/lib/foundation lib-foundation main --squash`
-- Update `scripts/k3d-manager` dispatcher to source from `scripts/lib/foundation/`
-- Keep old `scripts/lib/core.sh` + `system.sh` as fallback
-- shellcheck all touched files — must pass
+**Known issues:**
+- Port conflict: BATS test leaves `k3d-test-orbstack-exists` cluster holding ports 8000/8443. Doc: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
+- inotify limit in colima VM not persistent across restarts.
 
-Step 2 — Full cluster validation:
-- Claude: OrbStack teardown → rebuild → verify Vault, ESO, Istio, OpenLDAP, Jenkins, ArgoCD, Keycloak
-- Gemini: Ubuntu k3s teardown → rebuild → verify same stack on Linux
-- Both must pass before PR
+### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`)
 
-Step 3 — Cleanup (after PR approved):
-- Remove old `scripts/lib/core.sh` + `scripts/lib/system.sh`
-- Commit as follow-up on same branch
+| Component | Status |
+|---|---|
+| k3s node | Ready — v1.34.4+k3s1 |
+| Istio | Running |
+| ESO | Running |
+| Vault | Initialized + Unsealed |
+| OpenLDAP | Running — `identity` ns |
+| SecretStores | 3/3 Ready |
+| shopping-cart-data / apps | Pending |
+
+**SSH note:** `ForwardAgent yes` in `~/.ssh/config`. Stale socket fix: `ssh -O exit ubuntu`.
 
 ---
 
@@ -181,7 +85,7 @@ Step 3 — Cleanup (after PR approved):
 2. **Checkpointing**: Git commit before every surgical operation.
 3. **Audit Phase**: Verify no tests weakened after every fix cycle.
 4. **Simplification**: Refactor for minimal logic before final verification.
-5. **Memory-bank compression**: Compress memory-bank at the *start* of the new branch, before the first agent task.
+5. **Memory-bank compression**: Compress at the *start* of each new branch.
 
 ---
 
@@ -197,7 +101,6 @@ Claude
 Gemini  (SDET + Red Team)
   -- authors BATS unit tests and test_* integration tests
   -- cluster verification: full teardown/rebuild, smoke tests
-  -- red team: adversarially tests existing security controls (bounded scope)
   -- commits own work; updates memory-bank to report completion
 
 Codex  (Production Code)
@@ -215,113 +118,18 @@ Owner
 - No credentials in task specs or reports — reference env var names only (`$VAULT_ADDR`).
 - Run `shellcheck` on every touched `.sh` file and report output.
 - **NEVER run `git rebase`, `git reset --hard`, or `git push --force` on shared branches.**
-- Stay within task spec scope — do not add changes beyond what was specified, even if they seem like improvements. Unsanctioned scope expansion gets reverted.
+- Stay within task spec scope — do not add changes beyond what was specified.
 
 **Push rules by agent location:**
-- **Codex (M4 Air, same machine as Claude):** Commit locally + update memory-bank. Claude reviews local commit and handles push + PR.
+- **Codex (M4 Air, same machine as Claude):** Commit locally + update memory-bank. Claude reviews and handles push + PR.
 - **Gemini (Ubuntu VM):** Must push to remote — Claude cannot see Ubuntu-local commits. Always push before updating memory-bank.
 
-**Claude awareness — Gemini works on Ubuntu VM:**
-- Gemini commits directly to the active branch from the Ubuntu VM repo clone.
-- Always `git pull origin <branch>` before reading or editing any file Gemini may have touched.
-- Conflicts are possible if Claude and Gemini both push to the same branch concurrently.
-
-**Red Team scope (Gemini):**
-- Test existing controls only: `_copilot_prompt_guard`, `_safe_path`, stdin injection, trace isolation.
-- Report findings to memory-bank — Claude routes fixes to Codex.
-- Do NOT modify production code.
-
-**Gemini BATS verification rule:**
-- Always run tests in a clean environment:
-  ```bash
-  env -i HOME="$HOME" PATH="$PATH" ./scripts/k3d-manager test <suite> 2>&1 | tail -10
-  ```
-- Never report a test as passing unless it passed in a clean environment.
-
-**Memory-bank flow:**
-```
-Agent  → memory-bank   (report: task complete, what changed, what was unexpected)
-Claude reads           (review: detect gaps, inaccuracies, overclaiming)
-Claude → memory-bank   (instruct: corrections + next task spec)
-Agent reads + acts
-```
-
 **Lessons learned:**
-- Gemini may write stale memory-bank content — Claude reviews every update before writing next task.
+- Gemini skips memory-bank read and acts immediately — paste full task spec inline in the Gemini session prompt; do not rely on Gemini pulling it from memory-bank independently.
 - Gemini expands scope beyond task spec — spec must explicitly state what is forbidden.
-- Gemini ran `git rebase -i` on a shared branch — destructive git ops explicitly forbidden.
 - Gemini over-reports test success with ambient env vars — always verify with `env -i` clean environment.
-- **Gemini does not read memory-bank before starting** — even when given the same prompt as Codex, Gemini skips the memory-bank read and acts immediately. Codex reliably verifies memory-bank first. Mitigation: paste the full task spec inline in the Gemini session prompt; do not rely on Gemini pulling it from memory-bank independently.
 - PR sub-branches from Copilot agent may conflict — evaluate and close if our implementation is superior.
-- Claude owns Copilot PR review fixes directly — no need to route small surgical fixes through agents.
-
----
-
-## Cluster State (as of 2026-03-07)
-
-### Infra Cluster — k3d on OrbStack (context: `k3d-k3d-cluster`)
-
-Rebuilt 2026-03-07 — all services verified healthy post lib-foundation subtree integration.
-
-| Component | Status |
-|---|---|
-| Vault | Running — `secrets` ns, initialized + unsealed |
-| ESO | Running — `secrets` ns |
-| OpenLDAP | Running — `identity` ns + `directory` ns |
-| Istio | Running — `istio-system` |
-| Jenkins | Running — `cicd` ns |
-| ArgoCD | Running — `cicd` ns |
-| Keycloak | Running — `identity` ns |
-
-**Issues found during rebuild:**
-- Port conflict: BATS test left `k3d-test-orbstack-exists` cluster holding ports 8000/8443. Doc: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`
-- inotify limit in colima VM (too many open files). Applied manually — not persistent across colima restarts.
-- `identity/vault-kv-store` SecretStore: Vault role `eso-ldap-directory` only bound to `directory` ns. Fixed manually (added `identity`). Root fix needed in `deploy_ldap`. Doc: `docs/issues/2026-03-07-eso-secretstore-identity-namespace-unauthorized.md`
-
-### App Cluster — Ubuntu k3s (SSH: `ssh ubuntu`)
-
-Rebuilt 2026-03-07 — verified healthy post lib-foundation subtree integration (Gemini).
-
-| Component | Status |
-|---|---|
-| k3s node | Ready — v1.34.4+k3s1 |
-| Istio | Running |
-| ESO | Running |
-| Vault | Initialized + Unsealed |
-| OpenLDAP | Running — `identity` ns |
-| SecretStores | 3/3 Ready |
-| shopping-cart-data / apps | Pending |
-
-**SSH note:** `ForwardAgent yes` in `~/.ssh/config`. Stale socket fix: `ssh -O exit ubuntu`.
-
----
-
-## Version Roadmap
-
-| Version | Status | Notes |
-|---|---|---|
-| v0.1.0–v0.6.5 | released | See CHANGE.md |
-| v0.7.0 | **active** | Keycloak provider + App Cluster deployment |
-| v0.8.0 | planned | Lean MCP server (`k3dm-mcp`) |
-| v1.0.0 | vision | Reassess after v0.7.0 |
-
----
-
-## Open Items
-
-- [x] lib-foundation git subtree setup + source path update (Claude — Task 1+2) — DONE
-- [x] OrbStack cluster teardown + rebuild validation (Claude — Task 3) — DONE
-- [x] Ubuntu k3s teardown + rebuild validation (Gemini — Task 4) — DONE
-- [x] Refactor `deploy_cluster` + fix `CLUSTER_NAME` env var (Codex — Task 5) — DONE commit 24c8adf
-- [x] Fix `deploy_ldap`: Vault role `eso-ldap-directory` binds `directory` + `identity` ns (Codex — Task 6) — DONE commit 51d94c6
-- [ ] Fix BATS test teardown: `k3d-test-orbstack-exists` cluster not cleaned up post-test. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md` (Gemini)
-- [ ] inotify limit in colima VM not persistent — apply via colima lima.yaml or note in ops runbook
-- [ ] ESO deploy on Ubuntu app cluster
-- [ ] shopping-cart-data / apps deployment on Ubuntu
-- [ ] GitGuardian: mark 2026-02-28 incident as false positive (owner)
-- [ ] v0.7.0: Keycloak provider interface + App Cluster deployment
-- [ ] v0.8.0: `k3dm-mcp` lean MCP server
-- [ ] lib-foundation PR #1 merge → tag v0.1.0 (owner)
+- `git subtree add --squash` creates a merge commit that blocks GitHub rebase-merge — use squash-merge with admin override.
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -41,8 +41,8 @@
 
 ### Priority 1 — v0.7.1 (active)
 
+- [ ] Drop colima support — remove `_install_colima`, `_install_mac_docker`, update `_install_docker` mac case, clean README (Codex — Task 1)
 - [ ] Fix BATS test teardown — `k3d-test-orbstack-exists` cluster left behind after tests
-- [ ] inotify limit persistent fix — colima lima.yaml or ops runbook
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) on Ubuntu
 - [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) on Ubuntu
@@ -66,6 +66,6 @@
 | Item | Status | Notes |
 |---|---|---|
 | BATS test teardown — `k3d-test-orbstack-exists` | OPEN | Holds ports 8000/8443 on next deploy. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`. Gemini — v0.7.1. |
-| inotify limit in colima VM | OPEN | Not persistent across restarts. Fix: `colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=512`. |
+| inotify limit in colima VM | CLOSED — colima support being dropped in v0.7.1 | N/A |
 | `deploy_jenkins` (no flags) broken | BACKLOG | Use `--enable-vault` as workaround. |
 | No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | Future work. |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,15 +1,15 @@
-# Progress – k3d-manager
+# Progress — k3d-manager
 
 ## Overall Status
 
-**v0.6.5 SHIPPED** — tag `v0.6.5` pushed, PR #23 merged 2026-03-07.
-**v0.7.0 ACTIVE** — branch `k3d-manager-v0.7.0` cut from main 2026-03-07.
+**v0.7.0 SHIPPED** — squash-merged to main (eb26e43), PR #24, 2026-03-08.
+**v0.7.1 ACTIVE** — branch `k3d-manager-v0.7.1` cut from main 2026-03-08.
 
 ---
 
 ## What Is Complete
 
-### Released (v0.1.0 – v0.6.5)
+### Released (v0.1.0 – v0.7.0)
 
 - [x] k3d/OrbStack/k3s cluster provider abstraction
 - [x] Vault PKI, ESO, Istio, Jenkins, OpenLDAP, ArgoCD, Keycloak (infra cluster)
@@ -21,7 +21,6 @@
 - [x] `_k3d_manager_copilot` scoped wrapper (8-fragment deny list, `K3DM_ENABLE_AI` gate)
 - [x] `_safe_path` / `_is_world_writable_dir` PATH poisoning defense
 - [x] VAULT_TOKEN stdin injection in `ldap-password-rotator.sh`
-- [x] Permission cascade elimination in `core.sh`
 - [x] `_detect_platform` — single source of truth for OS detection
 - [x] `_run_command` TTY flakiness fix
 - [x] Linux k3s gate — 5-phase teardown/rebuild on Ubuntu 24.04 VM
@@ -30,23 +29,31 @@
 - [x] Provider contract BATS suite — 30 tests (3 providers × 10 functions)
 - [x] `_agent_audit` awk → pure bash rewrite (bash 3.2+, macOS BSD awk compatible)
 - [x] BATS tests for `_agent_audit` bare sudo + kubectl exec — suite 9/9, total 158/158
-- [x] `lib-foundation` repo created — https://github.com/wilddog64/lib-foundation
-- [x] `core.sh` + `system.sh` extracted to lib-foundation (PR #1 open, CI green)
-- [x] Ubuntu k3s validation gate — full 5-phase teardown/rebuild verified (158/158 BATS pass)
+- [x] `lib-foundation` repo created + subtree pulled into `scripts/lib/foundation/`
+- [x] `deploy_cluster` refactored — 12→5 if-blocks, helpers extracted (Codex)
+- [x] `CLUSTER_NAME` env var propagated to provider (Codex)
+- [x] `eso-ldap-directory` Vault role binds `directory` + `identity` namespaces (Codex)
+- [x] OrbStack + Ubuntu k3s validation — 158/158 BATS, all services healthy (v0.7.0)
 
 ---
 
 ## What Is Pending
 
-### Priority 1 — v0.7.0 (active)
+### Priority 1 — v0.7.1 (active)
 
-- [ ] Keycloak provider interface
+- [ ] Fix BATS test teardown — `k3d-test-orbstack-exists` cluster left behind after tests
+- [ ] inotify limit persistent fix — colima lima.yaml or ops runbook
 - [ ] ESO deploy on Ubuntu app cluster
 - [ ] shopping-cart-data (PostgreSQL, Redis, RabbitMQ) on Ubuntu
 - [ ] shopping-cart-apps (basket, order, payment, catalog, frontend) on Ubuntu
-- [ ] `CLUSTER_NAME` env var respected during `deploy_cluster`
 
-### Priority 2 — v0.8.0
+### Priority 2 — lib-foundation upstream
+
+- [ ] Sync deploy_cluster fixes back into lib-foundation (CLUSTER_NAME, provider helpers, duplicate guard removal)
+- [ ] Route bare sudo in `_install_debian_helm` / `_install_debian_docker` through `_run_command`
+- [ ] Push tag v0.1.1 to remote
+
+### Priority 3 — v0.8.0
 
 - [ ] `k3dm-mcp` — lean MCP server wrapping k3d-manager CLI
 - [ ] Target clients: Claude Desktop, Codex, Atlas, Comet
@@ -58,8 +65,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| GitGuardian: 1 internal secret incident (2026-02-28) | OPEN | False positive — mark in dashboard. |
-| `deploy_cluster` if-count violation (12 > 8) | OPEN | Extract `_deploy_cluster_resolve_provider`. Fix duplicate mac+k3s guard. See `docs/issues/2026-03-07-deploy-cluster-if-count-violation.md`. Target: v0.7.0. |
-| `CLUSTER_NAME` env var ignored during `deploy_cluster` | OPEN | See `docs/issues/2026-03-01-cluster-name-env-var-not-respected.md`. |
-| `deploy_jenkins` (no flags) broken | OPEN | Use `--enable-vault` as workaround. |
+| BATS test teardown — `k3d-test-orbstack-exists` | OPEN | Holds ports 8000/8443 on next deploy. Issue: `docs/issues/2026-03-07-k3d-rebuild-port-conflict-test-cluster.md`. Gemini — v0.7.1. |
+| inotify limit in colima VM | OPEN | Not persistent across restarts. Fix: `colima ssh -- sudo sysctl -w fs.inotify.max_user_instances=512`. |
+| `deploy_jenkins` (no flags) broken | BACKLOG | Use `--enable-vault` as workaround. |
 | No `scripts/tests/plugins/jenkins.bats` suite | BACKLOG | Future work. |

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -419,7 +419,7 @@ function _install_docker() {
 
    case "$platform" in
       mac)
-         _install_mac_docker
+         _info "On macOS, Docker is provided by OrbStack — no installation required."
          ;;
       debian|wsl)
          _install_debian_docker

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -419,7 +419,10 @@ function _install_docker() {
 
    case "$platform" in
       mac)
-         _info "On macOS, Docker is provided by OrbStack — no installation required."
+         if ! _command_exist docker; then
+            _err "Docker not found. On macOS, Docker is provided by OrbStack — please install OrbStack and ensure it is running."
+         fi
+         _info "Docker available via OrbStack."
          ;;
       debian|wsl)
          _install_debian_docker

--- a/scripts/lib/foundation/scripts/lib/core.sh
+++ b/scripts/lib/foundation/scripts/lib/core.sh
@@ -433,7 +433,7 @@ function _install_docker() {
 
    case "$platform" in
       mac)
-         _install_mac_docker
+         _info "On macOS, Docker is provided by OrbStack — no installation required."
          ;;
       debian|wsl)
          _install_debian_docker

--- a/scripts/lib/foundation/scripts/lib/core.sh
+++ b/scripts/lib/foundation/scripts/lib/core.sh
@@ -433,7 +433,10 @@ function _install_docker() {
 
    case "$platform" in
       mac)
-         _info "On macOS, Docker is provided by OrbStack — no installation required."
+         if ! _command_exist docker; then
+            _err "Docker not found. On macOS, Docker is provided by OrbStack — please install OrbStack and ensure it is running."
+         fi
+         _info "Docker available via OrbStack."
          ;;
       debian|wsl)
          _install_debian_docker

--- a/scripts/lib/foundation/scripts/lib/system.sh
+++ b/scripts/lib/foundation/scripts/lib/system.sh
@@ -727,43 +727,6 @@ function _detect_platform() {
    _err "Unsupported platform: $(uname -s)"
 }
 
-function _install_colima() {
-   if ! _command_exist colima ; then
-      echo colima does not exist, install it
-      _run_command --quiet -- brew install colima
-   else
-      echo colima installed already
-   fi
-}
-
-function _install_mac_docker() {
-  local cpu="${1:-${COLIMA_CPU:-4}}"
-  local memory="${2:-${COLIMA_MEMORY:-8}}"
-  local disk="${3:-${COLIMA_DISK:-20}}"
-
-   if  ! _command_exist docker && _is_mac ; then
-      echo docker does not exist, install it
-      brew install docker
-   else
-      echo docker installed already
-   fi
-
-   if _is_mac; then
-      _install_colima
-      docker context use colima
-      export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock
-      colima start --cpu "$cpu" --memory "$memory" --disk "$disk"
-   fi
-
-
-   # grep DOKER_HOST $HOME/.zsh/zshrc | wc -l 2>&1 > /dev/null
-   # if $? == 0 ; then
-   #    echo "export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock" >> $HOME/.zsh/zshrc
-   #    echo "export DOCKER_CONTEXT=colima" >> $HOME/.zsh/zshrc
-   #    echo "restart your shell to apply the changes"
-   # fi
-}
-
 function _create_nfs_share_mac() {
    local share_path="${1:-${HOME}/k3d-nfs}"
    _ensure_path_exists "$share_path"

--- a/scripts/lib/system.sh
+++ b/scripts/lib/system.sh
@@ -707,43 +707,6 @@ function _detect_platform() {
    _err "Unsupported platform: $(uname -s)"
 }
 
-function _install_colima() {
-   if ! _command_exist colima ; then
-      echo colima does not exist, install it
-      _run_command --quiet -- brew install colima
-   else
-      echo colima installed already
-   fi
-}
-
-function _install_mac_docker() {
-  local cpu="${1:-${COLIMA_CPU:-4}}"
-  local memory="${2:-${COLIMA_MEMORY:-8}}"
-  local disk="${3:-${COLIMA_DISK:-20}}"
-
-   if  ! _command_exist docker && _is_mac ; then
-      echo docker does not exist, install it
-      brew install docker
-   else
-      echo docker installed already
-   fi
-
-   if _is_mac; then
-      _install_colima
-      docker context use colima
-      export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock
-      colima start --cpu "$cpu" --memory "$memory" --disk "$disk"
-   fi
-
-
-   # grep DOKER_HOST $HOME/.zsh/zshrc | wc -l 2>&1 > /dev/null
-   # if $? == 0 ; then
-   #    echo "export DOCKER_HOST=unix:///Users/$USER/.colima/docker.sock" >> $HOME/.zsh/zshrc
-   #    echo "export DOCKER_CONTEXT=colima" >> $HOME/.zsh/zshrc
-   #    echo "restart your shell to apply the changes"
-   # fi
-}
-
 function _create_nfs_share_mac() {
    local share_path="${1:-${HOME}/k3d-nfs}"
    _ensure_path_exists "$share_path"


### PR DESCRIPTION
## Summary

- Remove `_install_colima` and `_install_mac_docker` from `scripts/lib/system.sh` and `scripts/lib/foundation/scripts/lib/system.sh`
- Update `_install_docker` mac case in both `scripts/lib/core.sh` and `scripts/lib/foundation/scripts/lib/core.sh` — OrbStack provides Docker on macOS, no separate installation needed
- Compress memory-bank for v0.7.1 branch start; add lib-foundation Option A release protocol and Codex handoff pattern

## Context

OrbStack is the active macOS Docker runtime. Colima was untested, caused inotify limit issues, and added maintenance overhead.

Changes synced to both the local library copy and the `scripts/lib/foundation/` subtree copy. Mirrored to lib-foundation repo via PR #3.

## Test plan

- [ ] `shellcheck` passes on all touched `.sh` files
- [ ] `./scripts/k3d-manager test all` — 158/158 BATS passing
- [ ] No regressions in `_install_docker` for mac provider path (OrbStack info message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)