### PR TITLE
v0.9.1 — vCluster Plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,9 @@ hostname && uname -n
 ```
 Confirm you are on the correct machine before doing anything else.
 
-### 3. Proof of work — PR URL required
+### 3. Proof of work — commit SHA + test results required
 Reporting "done" requires:
-- A real PR URL (e.g. `https://github.com/wilddog64/k3d-manager/pull/31`)
-- CI green on that PR (`gh run list --branch <branch> --limit 1`)
+- A real commit SHA pushed to the remote branch (verify with `git log origin/<branch> --oneline -3`)
 - BATS output showing all tests passing (`bats scripts/tests/...`)
 - `shellcheck` clean on every touched `.sh` file
 - `_agent_audit` passing — all functions ≤ 8 if-blocks
@@ -51,22 +50,27 @@ A memory-bank update alone is NOT proof of completion.
 Every task ends with a real git commit pushed to the remote branch.
 Never report completion without a verifiable commit SHA on the remote.
 
-### 5. Do not revert intentional decisions
+### 5. Do NOT create PRs — that is Claude's job
+Your task ends at: commit + push to branch + update memory-bank.
+Do NOT run `gh pr create`. Do NOT rerun CI jobs (`gh run rerun`).
+If CI fails, read the failure logs (`gh run view <id> --log-failed`), fix the root cause, and push a new commit.
+
+### 6. Do not revert intentional decisions
 Comments marked `# DO NOT REMOVE` or `<!-- DO NOT REMOVE -->` in code must not be deleted.
 Decisions recorded in `memory-bank/` must not be silently reversed.
 If you believe a decision is wrong, report it — do not quietly undo it.
 
-### 6. Stay within spec scope
+### 7. Stay within spec scope
 Do not add features, refactor code, or make improvements beyond what the spec requires.
 Do not modify files outside the scope of the current task.
 If you find a bug outside your scope, report it in the memory-bank — do not fix it silently.
 
-### 7. Never bypass hooks
+### 8. Never bypass hooks
 - Never use `git commit --no-verify`
 - Never use `git push --force` on shared branches
 - Never use `git rebase` or `git reset --hard` on shared branches
 - If a pre-commit hook fails, fix the underlying issue and retry
 
-### 8. Update memory-bank on completion
+### 9. Update memory-bank on completion
 When your task is done, update `memory-bank/activeContext.md` and `memory-bank/progress.md`
 to reflect what you completed. Include the real commit SHA and PR URL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`scripts/` houses the dispatcher (`k3d-manager`), shared libs in `scripts/lib/`, provider glue in `scripts/lib/providers/`, and optional `scripts/plugins/*.sh`. Tests live under `scripts/tests/` with helper BATS harness files beside suite directories (`lib`, `plugins`). Documentation is in `docs/` (architecture, providers, guides, issues) while `memory-bank/` tracks active spec context. Use `bin/` for helper binaries and keep user-specific scratch work in `scratch/`.
+
+## Build, Test, and Development Commands
+- `./scripts/k3d-manager <function>` — primary entrypoint; run `deploy_cluster`, `deploy_vault`, etc. from repo root.
+- `./scripts/k3d-manager test all` — runs the curated BATS bundles defined in `scripts/lib/test.sh`.
+- `bats scripts/tests` — executes every suite; handy before large refactors.
+- `shellcheck scripts/**/*.sh` — lint every touched shell file; CI blocks on failures.
+- `./install.sh` — bootstrap local deps (bash 5, bats, shellcheck, jq) if the host is fresh.
+
+## Coding Style & Naming Conventions
+Write pure Bash with portable `#!/usr/bin/env bash`. Match the existing 2-space indentation used in `scripts/`, prefer snake_case for functions/files (`deploy_vault`, `plugins/shopping_cart.sh`), and guard sourced files with `# shellcheck source=` hints. Keep functions idempotent, avoid unbounded `if` depth (Agent Rigor flags this), and favor `_run_command` helpers instead of raw subshell pipelines. Templates in `scripts/etc/` should stay `.yaml.tmpl` and load values from `vars.sh`.
+
+## Testing Guidelines
+BATS is the canonical framework. Name suites `<area>.bats` and tests `@test "<component>: <expectation>"`. Extend shared helpers via `scripts/tests/test_helpers.bash` rather than duplicating logic. Every PR must keep `./scripts/k3d-manager test all` green, preserve or increase `@test` counts (enforced by `_agent_audit`), and document new suites in `docs/tests` if they cover novel flows. For provider-specific behavior, add focused suites under `scripts/tests/lib/provider_contract.bats` or create plugin-level suites mirroring the file under test.
+
+## Commit & Pull Request Guidelines
+Follow the short, Conventional-style prefixes seen in history (`docs:`, `fix:`, `v0.9.0 — …`). Squash unrelated work, explain *why* in the body, and mention linked issues or specs when possible. Before committing, run `_agent_checkpoint`, `_agent_lint`, and `_agent_audit` (pre-commit hook) to prove specs, lint, and security gates pass. Pull requests should state the scenario exercised, include command output for key flows (e.g., `bats` summary), and attach screenshots when UI manifests (Jenkins, ArgoCD) change. Keep branches rebased so Agent Rigor diffs stay tight.
+
+---
+
+## Agent Session Rules (read every session — no exceptions)
+
+### 1. Read memory-bank first
+Before touching any file, read both:
+- `memory-bank/activeContext.md` — current branch, focus, open items
+- `memory-bank/progress.md` — what is complete, what is pending
+
+These contain decisions already made. Do not re-derive them from scratch.
+
+### 2. Verify your machine
+First command of every session:
+```bash
+hostname && uname -n
+```
+Confirm you are on the correct machine before doing anything else.
+
+### 3. Proof of work — PR URL required
+Reporting "done" requires:
+- A real PR URL (e.g. `https://github.com/wilddog64/k3d-manager/pull/31`)
+- CI green on that PR (`gh run list --branch <branch> --limit 1`)
+- BATS output showing all tests passing (`bats scripts/tests/...`)
+- `shellcheck` clean on every touched `.sh` file
+- `_agent_audit` passing — all functions ≤ 8 if-blocks
+
+A memory-bank update alone is NOT proof of completion.
+
+### 4. Commit before reporting done
+Every task ends with a real git commit pushed to the remote branch.
+Never report completion without a verifiable commit SHA on the remote.
+
+### 5. Do not revert intentional decisions
+Comments marked `# DO NOT REMOVE` or `<!-- DO NOT REMOVE -->` in code must not be deleted.
+Decisions recorded in `memory-bank/` must not be silently reversed.
+If you believe a decision is wrong, report it — do not quietly undo it.
+
+### 6. Stay within spec scope
+Do not add features, refactor code, or make improvements beyond what the spec requires.
+Do not modify files outside the scope of the current task.
+If you find a bug outside your scope, report it in the memory-bank — do not fix it silently.
+
+### 7. Never bypass hooks
+- Never use `git commit --no-verify`
+- Never use `git push --force` on shared branches
+- Never use `git rebase` or `git reset --hard` on shared branches
+- If a pre-commit hook fails, fix the underlying issue and retry
+
+### 8. Update memory-bank on completion
+When your task is done, update `memory-bank/activeContext.md` and `memory-bank/progress.md`
+to reflect what you completed. Include the real commit SHA and PR URL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,12 @@ Uses a dispatcher pattern with lazy plugin loading.
 **Current state:** `memory-bank/activeContext.md` and `memory-bank/progress.md`
 **Task specs:** `docs/plans/`
 
+## Claude Session Rules
+
+- **Memory-bank update is mandatory and immediate** — after every completed action (spec written, PR created, agent assigned, merge done, task status changed), update `memory-bank/activeContext.md` and `memory-bank/progress.md` before doing anything else. Do not wait for the user to ask.
+- **PR creation gate** — do NOT create a PR until ALL of these pass: CI green, Copilot review comments addressed, Gemini live smoke test, Claude scope check. Draft PR is acceptable only as an explicit placeholder.
+- **Verify before trust** — never trust a commit SHA, BATS result, or "done" report from any agent without independently verifying via `gh api`, `gh run view`, or `git log`.
+
 ---
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -46,10 +46,29 @@ UBUNTU_K3S_SSH_HOST=ubuntu \
 ## Usage
 
 ```bash
-./scripts/k3d-manager                     # show usage and core functions
+./scripts/k3d-manager                     # short summary: categories + function counts
+./scripts/k3d-manager --help              # full function list grouped by category
 ./scripts/k3d-manager <function> [args]   # invoke a core or plugin function
-./scripts/k3d-manager <function> -h       # brief help for any function
 ```
+
+Running without arguments prints a concise overview:
+
+```
+Usage: ./k3d-manager <function> [args]
+
+Categories:
+  Cluster lifecycle      (9 functions)
+  Infrastructure         (5 functions)
+  Secrets                (7 functions)
+  Directory service      (9 functions)
+  Networking             (4 functions)
+  Shopping cart          (2 functions)
+  Testing                (9 functions)
+
+Run ./k3d-manager --help for full function list.
+```
+
+`--help` expands each category with the full function list, cluster provider info, and environment variables.
 
 ```bash
 ./scripts/k3d-manager create_cluster mycluster          # default 8000/8443

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Categories:
   Shopping cart          (2 functions)
   Testing                (9 functions)
 
-Run ./k3d-manager --help for full function list.
+Run ./scripts/k3d-manager --help for full function list.
 ```
 
 `--help` expands each category with the full function list, cluster provider info, and environment variables.

--- a/docs/issues/2026-03-15-test-function-refactor.md
+++ b/docs/issues/2026-03-15-test-function-refactor.md
@@ -1,0 +1,18 @@
+# Issue: `test()` exceeded Agent Rigor if-count
+
+## Context
+- `scripts/k3d-manager` dispatcher owns the `test` entrypoint.
+- Legacy implementation packed argument parsing, smoke routing, suite selection, and BATS logging (27 `if` blocks) into a single function.
+- Agent Rigor gate of 8 if-blocks prevented future edits and made manual reasoning difficult.
+
+## Resolution
+- Added helpers `_test_run_smoke`, `_test_select_suite`, `_test_execute` inside the dispatcher.
+- Slimmed `function test()` to delegate after argument parsing and inline `::case` handling.
+- Preserved all behaviour (same CLI flags, logging, artifacts) while meeting the if-count budget.
+
+## Verification
+- `shellcheck scripts/k3d-manager`
+- `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`
+- `./scripts/k3d-manager --help`
+- `./scripts/k3d-manager test --help`
+- `./scripts/k3d-manager test all`

--- a/docs/issues/2026-03-15-vcluster-cli-missing-on-m2-air.md
+++ b/docs/issues/2026-03-15-vcluster-cli-missing-on-m2-air.md
@@ -1,0 +1,36 @@
+# Issue: vCluster CLI missing on M2 Air infra cluster
+
+**Date:** 2026-03-15
+**Component:** `scripts/plugins/vcluster.sh`
+
+## Description
+
+During the Gemini smoke test of the `vcluster` plugin on the M2 Air infra cluster (`k3d-k3d-cluster`), the `vcluster_create` command failed. The `vcluster` CLI binary was expected to be installed on the host but was not found in any common binary directories (`/usr/local/bin`, `/opt/homebrew/bin`, etc.).
+
+## Evidence
+
+Running the following commands on `m2-air.local`:
+
+```bash
+which vcluster
+ls /opt/homebrew/bin/vcluster
+```
+
+Result:
+```
+vcluster not found
+ls: /opt/homebrew/bin/vcluster: No such file or directory
+```
+
+Attempting to run `vcluster_create smoke-test`:
+```
+ERROR: vcluster CLI is not installed; see https://github.com/loft-sh/vcluster
+```
+
+## Impact
+
+The `vcluster` plugin functions (`vcluster_create`, `vcluster_list`, `vcluster_destroy`, `vcluster_use`) all depend on the `vcluster` CLI binary being available in the system PATH. Without this binary, the plugin is unusable on the M2 Air.
+
+## Recommendation
+
+Install the `vcluster` CLI on `m2-air.local` via Homebrew or direct binary download. Alternatively, consider adding a `deploy_vcluster_cli` or similar helper function to `k3d-manager` to automate the installation of required binaries, similar to how `istioctl` or `helm` might be handled.

--- a/docs/issues/2026-03-15-vcluster-copilot-review-findings.md
+++ b/docs/issues/2026-03-15-vcluster-copilot-review-findings.md
@@ -1,0 +1,205 @@
+# Issue: Copilot PR #31 Review — vCluster plugin findings (two rounds)
+
+## Date
+2026-03-15
+
+## PR
+[#31 v0.9.1 — vCluster Plugin](https://github.com/wilddog64/k3d-manager/pull/31)
+
+## Reviewer
+`copilot-pull-request-reviewer` (GitHub Copilot) — two review passes
+
+---
+
+## Round 1 — initial vCluster plugin (commits `68b263c`, `f444c4b`)
+
+### Finding 1 — `vcluster_destroy` deletes shared namespace (P1)
+
+**File:** `scripts/plugins/vcluster.sh`
+
+**Problem:** `vcluster delete ... --delete-namespace` was passed unconditionally. Since all
+vClusters share `VCLUSTER_NAMESPACE` (default: `vclusters`), deleting one tenant would
+remove the entire namespace and terminate all other active vClusters — including parallel
+CI jobs creating ephemeral clusters in the same namespace.
+
+**Fix:** Removed `--delete-namespace`. `vcluster delete` without the flag removes only the
+vCluster resources, leaving the shared namespace intact.
+
+**Status:** FIXED — commit `68b263c`
+
+---
+
+### Finding 2 — KUBECONFIG multi-file merge overwrites partial config (P2)
+
+**File:** `scripts/plugins/vcluster.sh` line 78
+
+**Problem:** `vcluster_use` extracted only the first path from a multi-file `KUBECONFIG`
+chain (`IFS=':' read -r base_config _ <<< "$KUBECONFIG"`), merged the vCluster kubeconfig
+against just that file, then rewrote it and exported `KUBECONFIG` pointing only to it.
+Contexts from all other files in the chain were silently dropped.
+
+**Fix:** `merge_chain="${KUBECONFIG:-$base_config}"` — pass the full chain to
+`kubectl config view --flatten` so all existing contexts are preserved in the merged output.
+
+**Status:** FIXED — commit `68b263c`
+
+---
+
+### Finding 3 — kubeconfig written with world-readable permissions (P1)
+
+**File:** `scripts/plugins/vcluster.sh`
+
+**Problem:** Both `vcluster_use` and `_vcluster_export_kubeconfig` wrote kubeconfig content
+using `printf > file` followed by `chmod 600`. A window existed between file creation and
+`chmod` where the file was readable by anyone with access to the filesystem (process umask
+applies on creation, not retroactively).
+
+**Fix:** Replaced both writes with `_write_sensitive_file`, which sets `umask 077` before
+creating the file — permissions are safe from the first byte written.
+
+**Status:** FIXED — commit `68b263c`
+
+---
+
+### Finding 4 — `_vcluster_ensure_exists` partial name match (P2)
+
+**File:** `scripts/plugins/vcluster.sh`
+
+**Problem:** Existence check used `[[ "$list_output" != *"$name"* ]]` — a substring match.
+A cluster named `dev` would falsely match `dev2`, `dev-staging`, or even the `NAME` header
+row. Could silently proceed with a destroy on the wrong cluster.
+
+**Fix:** Parse `vcluster list` output column by column, skip the header row, and match the
+first column exactly.
+
+**Status:** FIXED — commit `68b263c`
+
+---
+
+### Finding 5 — DNS-label validation missing on vCluster name (P2)
+
+**File:** `scripts/plugins/vcluster.sh` line 200
+
+**Problem:** The `name` argument was used both to construct a filesystem path
+(`$VCLUSTER_KUBECONFIG_DIR/$name.yaml`) and as a kubectl label selector value. No
+validation prevented names containing `/`, `..`, leading hyphens, or shell metacharacters —
+enabling path traversal and invalid selectors.
+
+**Fix:** Added regex validation against `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$` (DNS-label
+pattern) in `_vcluster_kubeconfig_path`. Rejects all special characters before any path
+construction or selector use.
+
+**Status:** FIXED — commit `f444c4b`
+
+---
+
+## Round 2 — after test refactor + smoke test fixes (commit `a89ba81`)
+
+### Finding 6 — Linux CLI auto-install hardcodes amd64 (P1)
+
+**File:** `scripts/plugins/vcluster.sh` line 137
+
+**Problem:** `_vcluster_install_cli` on Linux fetched `vcluster-linux-amd64` unconditionally.
+On ARM64 Linux hosts (e.g., Raspberry Pi, Ampere VMs, ARM64 CI runners), the binary is not
+runnable — all `vcluster_*` commands would fail at the prerequisites check on first use.
+
+**Fix:** Detect `uname -m` and map `x86_64 → amd64`, `aarch64/arm64 → arm64`. Unknown
+architectures get a clear error. Download URL uses the detected `$dl_arch` variable.
+
+**Status:** FIXED — commit `a89ba81`
+
+---
+
+### Finding 7 — `brew install` with `--prefer-sudo` breaks Homebrew (P2)
+
+**File:** `scripts/plugins/vcluster.sh` line 131
+
+**Problem:** `_run_command --prefer-sudo -- brew install loft-sh/tap/vcluster` would run
+Homebrew as root whenever passwordless sudo was available. Homebrew explicitly forbids
+running as root — it causes ownership issues on formula files and leaves the installation in
+a broken state for the normal user.
+
+**Fix:** Changed to `_run_command -- brew install loft-sh/tap/vcluster` (no `--prefer-sudo`).
+Homebrew always runs as the current user.
+
+**Status:** FIXED — commit `a89ba81`
+
+---
+
+### Finding 8 — KUBECONFIG merge skips flatten when first file absent (P2)
+
+**File:** `scripts/plugins/vcluster.sh` line 103
+
+**Problem:** After the Round 1 fix, `vcluster_use` still gated `kubectl config view --flatten`
+on `[[ -f "$base_config" ]]`. If `KUBECONFIG=/tmp/new:/path/existing` and `/tmp/new` did
+not yet exist, the condition was false — only the bare vCluster kubeconfig was written,
+silently dropping all contexts from `/path/existing`.
+
+**Fix:** Removed the conditional branch entirely. `kubectl config view --flatten` is always
+called against the full `merge_chain`, regardless of whether `base_config` exists. The
+flatten command handles missing files in the chain gracefully.
+
+**Status:** FIXED — commit `a89ba81`
+
+---
+
+### Finding 9 — `_match_category` inner function leaks into global namespace (P2)
+
+**File:** `scripts/lib/help/utils.sh` line 122
+
+**Problem:** `_match_category()` was declared inside `_usage()`. Bash function declarations
+are always global — not block-scoped — so calling `_usage` permanently added `_match_category`
+to the global function table. A function with that name in a plugin or library would be
+silently overridden after the first `_usage` call.
+
+**Fix:** Renamed to `__usage_match_category` (double-underscore prefix signals internal/
+private utility). All call sites updated. The name is now collision-resistant by convention.
+
+**Status:** FIXED — commit `a89ba81`
+
+---
+
+### Finding 10 — README invocation path mismatch (nit)
+
+**File:** `README.md` line 72 / `scripts/lib/help/utils.sh`
+
+**Problem:** README examples showed `./scripts/k3d-manager` (correct — invoked from repo
+root), but the usage text output by `_usage()` said `Usage: ./k3d-manager ...` and
+`Run ./k3d-manager --help ...`. New users reading the help output would try the wrong path.
+
+**Fix:** Updated `_usage()` to output `./scripts/k3d-manager` in both the `Usage:` line and
+the `Run ... --help` footer. Updated the README sample block to match.
+
+**Status:** FIXED — commit `a89ba81`
+
+---
+
+### Finding 11 — `--delete-namespace` spec/implementation conflict (doc)
+
+**File:** `docs/plans/v0.9.1-vcluster-plugin.md`, `docs/plans/v0.9.1-vcluster-codex-task.md`
+
+**Problem:** Both spec docs still described `vcluster delete ... --delete-namespace --wait`
+as the intended behavior. The implementation removed this flag in Round 1 (Finding 1), but
+the specs were never updated — creating confusion when Copilot re-flagged the discrepancy.
+
+**Fix:** Updated both spec docs to document the intentional omission with rationale: shared
+namespace must not be deleted when a single tenant is removed.
+
+**Status:** FIXED — commit `d9ed235`
+
+---
+
+## Lessons
+
+- **Shared namespace + `--delete-namespace` is a footgun** — always check whether a CLI
+  delete flag targets a shared or per-resource namespace before using it.
+- **Inner bash functions are not scoped** — never define helper functions inside another
+  function if they might collide with the global namespace. Use `__` prefix for private utils.
+- **KUBECONFIG merge logic is subtle** — both the "first file only" bug and the "missing
+  first file" bug came from trying to be clever about the merge path. The simple fix
+  (always flatten the full chain) was also the most correct.
+- **Brew must not run as root** — `--prefer-sudo` is appropriate for filesystem operations
+  but not package managers that manage their own file ownership.
+- **Always detect architecture for binary downloads** — amd64 hardcodes are a common
+  oversight; `uname -m` + a case statement is a one-time fix that future-proofs all
+  ARM64 environments.

--- a/docs/issues/2026-03-15-vcluster-smoke-test-failures.md
+++ b/docs/issues/2026-03-15-vcluster-smoke-test-failures.md
@@ -1,0 +1,39 @@
+# Issue: vCluster plugin smoke test failures (v0.9.1)
+
+**Date:** 2026-03-15
+**Component:** `scripts/plugins/vcluster.sh`, Help System
+
+## Description
+
+During the Gemini smoke test of v0.9.1 on the M2 Air infra cluster, two issues were identified:
+
+1.  **vCluster pod selector mismatch:** `vcluster_create` fails during the readiness check because it uses a pod selector that does not match the labels applied by vCluster v0.32.1.
+2.  **Missing help categories:** `vcluster` functions are missing from the `./scripts/k3d-manager --help` output because the plugin script lacks `@category` tags.
+
+## Evidence
+
+### 1. vCluster Pod Selector Mismatch
+
+The `_vcluster_wait_ready` function uses:
+`selector="app.kubernetes.io/name=vcluster,app.kubernetes.io/instance=${name}"`
+
+However, `kubectl get pods -n vclusters --show-labels` shows the following labels for the `smoke-test` vCluster:
+`app=vcluster,release=smoke-test,apps.kubernetes.io/pod-index=0,controller-revision-hash=smoke-test-7fbf6f756,statefulset.kubernetes.io/pod-name=smoke-test-0`
+
+This causes `kubectl wait` to fail with `error: no matching resources found`, which prevents the function from exporting the kubeconfig.
+
+### 2. Missing Help Categories
+
+Running `./scripts/k3d-manager --help` shows the standard categories, but `vcluster_create`, `vcluster_list`, etc., are not listed. This is because `scripts/plugins/vcluster.sh` does not contain the required `@category` comments used by the help parser in `scripts/lib/help/utils.sh`.
+
+## Impact
+
+-   `vcluster_create` cannot complete successfully, leaving the vCluster in an "unmanaged" state (created but without a local kubeconfig).
+-   Users cannot discover vCluster functions via the built-in help system.
+
+## Recommendation
+
+1.  Update `scripts/plugins/vcluster.sh`:
+    -   Change the pod selector in `_vcluster_wait_ready` to `app=vcluster,release=${name}`.
+    -   Add `@category Cluster lifecycle` (or a new category) to the public functions.
+2.  Verify the fix by re-running the Gemini smoke test.

--- a/docs/plans/roadmap-v1.md
+++ b/docs/plans/roadmap-v1.md
@@ -165,6 +165,43 @@ tools callable from any MCP-compatible AI client. Owns its own memory-bank and r
   a shared-team concern, not a local dev tool concern.
 - **Dependency:** Docker — optional. k3s/bare metal environments use span file output only.
 
+## v0.9.1 — vCluster Plugin + Playwright E2E in CI
+*Focus: Ephemeral tenant clusters for isolated testing*
+
+**Motivation:** Shopping-cart has no real traffic — the value is fast lifecycle, not scale.
+Spin up a clean vCluster tenant, deploy the full stack, run Playwright E2E tests, tear it down.
+Clean slate every PR run, no shared cluster state pollution.
+
+**Track 1a — vCluster plugin (`scripts/plugins/vcluster.sh`):**
+```bash
+./scripts/k3d-manager vcluster_create  <name>   # spin up tenant cluster inside host
+./scripts/k3d-manager vcluster_destroy <name>   # tear it down
+./scripts/k3d-manager vcluster_use     <name>   # switch kubeconfig to tenant
+./scripts/k3d-manager vcluster_list            # list active tenant clusters
+```
+- `VCLUSTER_NAMESPACE` env var — target namespace in host (default: `vclusters`)
+- `VCLUSTER_VERSION` env var — pin chart version, no floating `latest`
+- Prerequisite check: verify host cluster context is active before any operation
+- dry-run gate inherited from `_run_command`
+- BATS coverage: `scripts/tests/plugins/vcluster.bats` (`env -i` clean)
+
+**Track 1b — Playwright E2E in CI (`shopping-cart-infra`):**
+```
+PR opened on any shopping-cart repo
+→ CI: vcluster_create shopping-cart-e2e
+→ deploy full stack (ESO + shopping-cart-data + apps) into tenant
+→ Playwright runs E2E against tenant services
+→ pass/fail reported to PR
+→ vcluster_destroy shopping-cart-e2e
+```
+- Playwright runs outside the cluster on the CI runner (no Chrome-in-cluster)
+- Tests live in `shopping-cart-e2e-tests/` repo
+- Prerequisite: images in ghcr.io (CI stabilization complete ✅)
+
+**Spec:** `docs/plans/v0.9.1-vcluster-plugin.md`
+
+---
+
 ## v0.9.0 — Messaging Gateway
 *Focus: Natural language interface for cluster operations*
 
@@ -191,48 +228,29 @@ JSON-RPC stdio. No direct k3d-manager calls — always through the MCP security 
 
 ---
 
-## v1.0.0 — vCluster Plugin
-*Focus: Tenant clusters on top of existing infra — on-demand isolation without new VMs*
+## v1.0.0 — k3dm-mcp
+*Focus: MCP server wrapping k3d-manager CLI — AI-driven cluster operations*
 
-**Motivation:** vCluster (by Loft Labs) creates fully functional virtual Kubernetes clusters
-inside a namespace of an existing host cluster. Pods schedule on the host cluster nodes —
-no new VMs, no new cloud infrastructure. Spin up in seconds, destroy in seconds.
+**Motivation:** k3d-manager (v0.9.1) has vCluster + full stack ops. k3dm-mcp exposes those
+as structured MCP tools callable from any MCP-compatible AI client (Claude Desktop, Copilot).
 
-**Why a plugin, not a provider:**
-vCluster is not a standalone runtime — it requires a host cluster to already exist.
-It cannot satisfy the `CLUSTER_PROVIDER` contract (create a cluster from nothing).
-The correct model is a plugin that layered on top of whichever provider is active:
+**Discrete repo:** [`wilddog64/k3dm-mcp`](https://github.com/wilddog64/k3dm-mcp)
 
-```bash
-# Host cluster already running (orbstack/k3d/k3s)
-./scripts/k3d-manager vcluster_create  my-tenant   # spin up vCluster inside host
-./scripts/k3d-manager vcluster_destroy my-tenant   # tear it down
-./scripts/k3d-manager vcluster_use     my-tenant   # switch kubeconfig to tenant
-./scripts/k3d-manager vcluster_list                # list all tenant clusters
-```
+**Key design decisions:**
+- One AI Layer Rule: `K3DM_ENABLE_AI=0` always set in subprocess env
+- Explicit subprocess env — no ambient shell state
+- SQLite state cache — never dump raw kubectl output to LLM
+- Blast radius classification, dry-run gate, pre-destroy snapshot
+- Loop detection + session call limit + credential scan on tool args
+- BATS-based MCP test harness (`env -i`, record-replay fixtures)
 
-**Use cases this unlocks:**
-- Per-feature isolated test environments — spin up, deploy stack, test, destroy
-- Team isolation — each developer gets their own cluster namespace without VM overhead
-- CI pipelines — ephemeral cluster per pipeline run, no teardown race conditions
-- Prerequisite validation for multi-cloud (v1.1.0) — provider contract proven locally first
+**MCP tools exposed (initial set):**
+- `deploy_cluster` / `destroy_cluster`
+- `deploy_vault`, `deploy_eso`, `deploy_argocd`
+- `vcluster_create` / `vcluster_destroy` / `vcluster_use` / `vcluster_list`
+- `sync_state` — cluster health snapshot into SQLite
 
-**Plugin implementation (`scripts/plugins/vcluster.sh`):**
-- `vcluster_create <name>` — `vcluster create <name> -n <namespace>` + export kubeconfig
-- `vcluster_destroy <name>` — `vcluster delete <name> -n <namespace>` — dry-run gate inherited
-- `vcluster_use <name>` — merge vCluster kubeconfig, switch context
-- `vcluster_list` — list active tenant clusters in host
-- `VCLUSTER_NAMESPACE` env var — target namespace in host (default: `vclusters`)
-- `VCLUSTER_VERSION` env var — pin chart version explicitly, no floating `latest`
-- Prerequisite check: verify host cluster context is active before any operation
-
-**What stays the same:** once `vcluster_use` hands off a kubeconfig, all existing plugins
-(Vault, ESO, Istio, Jenkins, ArgoCD) work identically — they speak only Kubernetes primitives.
-
-**BATS coverage:** new `vcluster.bats` suite; pure logic tests (`env -i` clean).
-
-*Note: vCluster team made contact after k3d-manager articles — potential collaboration
-for integration testing and early access to new vCluster features.*
+**Full scope:** see `k3dm-mcp/docs/plans/roadmap.md`
 
 ---
 

--- a/docs/plans/v0.9.1-gemini-smoke-test-task.md
+++ b/docs/plans/v0.9.1-gemini-smoke-test-task.md
@@ -1,0 +1,120 @@
+# Gemini Task: Smoke Test v0.9.1 on M2 Air
+
+## Before you start
+
+1. Read `AGENTS.md`
+2. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+3. **First command:** `hostname && uname -n` — confirm you are on M2 Air
+4. Run `git checkout k3d-manager-v0.9.1 && git pull origin k3d-manager-v0.9.1`
+
+---
+
+## Context
+
+v0.9.1 adds:
+- vCluster plugin (`scripts/plugins/vcluster.sh`) with `vcluster_create`,
+  `vcluster_destroy`, `vcluster_use`, `vcluster_list`
+- `_vcluster_install_cli` — auto-installs the `vcluster` binary if missing
+- Two-tier help: `./scripts/k3d-manager` (summary) vs `--help` (full list)
+- `function test()` refactored into `_test_run_smoke`, `_test_select_suite`,
+  `_test_execute`
+
+Your job is to verify all of this works on the real M2 Air cluster.
+
+---
+
+## Pre-conditions
+
+- Host cluster must be running (`kubectl cluster-info` must succeed)
+- Vault must be unsealed (`kubectl get pods -n secrets` — vault-0 Running)
+- If Vault is sealed, run:
+  ```bash
+  KEY=$(kubectl get secret vault-unseal -n secrets -o jsonpath='{.data.shard-1}' | base64 -d)
+  kubectl exec -n secrets vault-0 -- vault operator unseal "$KEY"
+  ```
+
+---
+
+## Tasks — run in order, one step at a time
+
+### 1. BATS unit tests
+```bash
+./scripts/k3d-manager test all
+```
+Expected: all tests pass (190 total). Report exact count.
+
+### 2. Help output
+```bash
+./scripts/k3d-manager
+./scripts/k3d-manager --help
+./scripts/k3d-manager test --help
+```
+Expected:
+- Bare: shows category summary with function counts
+- `--help`: shows full categorized function list
+- `test --help`: shows test usage with suite options
+
+### 3. vCluster CLI install check
+```bash
+which vcluster || echo "not installed"
+```
+If not installed, `vcluster_create` will auto-install it. Note the result.
+
+### 4. vCluster create
+```bash
+./scripts/k3d-manager vcluster_create smoke-test
+```
+Expected: vCluster created, kubeconfig written to `~/.kube/vclusters/smoke-test.yaml`.
+
+### 5. vCluster list
+```bash
+./scripts/k3d-manager vcluster_list
+```
+Expected: `smoke-test` appears in output.
+
+### 6. vCluster use
+```bash
+./scripts/k3d-manager vcluster_use smoke-test
+```
+Expected: context switched to the vCluster context. Verify with `kubectl config current-context`.
+
+### 7. vCluster destroy
+```bash
+./scripts/k3d-manager vcluster_destroy smoke-test
+```
+Expected: vCluster deleted, kubeconfig file removed.
+
+---
+
+## Definition of Done
+
+- [ ] `test all` — report pass count
+- [ ] `--help` shows categorized output
+- [ ] `vcluster_create smoke-test` — succeeds
+- [ ] `vcluster_list` — shows `smoke-test`
+- [ ] `vcluster_use smoke-test` — context switched
+- [ ] `vcluster_destroy smoke-test` — cleaned up
+- [ ] All output logged to `scratch/logs/gemini-smoke-test-<timestamp>.log`
+- [ ] Commit pushed to `k3d-manager-v0.9.1` with real SHA (even if only memory-bank update)
+- [ ] `memory-bank/activeContext.md` + `memory-bank/progress.md` updated with results
+
+---
+
+## What NOT to do
+
+- Do NOT run on M4 Air — this task requires the live k3d/OrbStack cluster on M2 Air
+- Do NOT create a PR — that is Claude's job
+- Do NOT rerun CI jobs
+- Do NOT modify any `.sh` files
+- Do NOT skip steps — report failures honestly, do not work around them silently
+- If a step fails, stop and report the error in memory-bank — do not continue
+
+---
+
+## When Done
+
+Update `memory-bank/activeContext.md` and `memory-bank/progress.md` with:
+- Each step result (pass/fail)
+- Exact test count from `test all`
+- Any errors encountered
+- Commit SHA of memory-bank update (pushed to remote)

--- a/docs/plans/v0.9.1-gemini-smoke-test-task.md
+++ b/docs/plans/v0.9.1-gemini-smoke-test-task.md
@@ -1,4 +1,4 @@
-# Gemini Task: Smoke Test v0.9.1 on M2 Air
+# Gemini Task: Smoke Test v0.9.1 — Retry (vCluster steps)
 
 ## Before you start
 
@@ -9,17 +9,23 @@
 
 ---
 
-## Context
+## What already passed (do NOT re-run)
 
-v0.9.1 adds:
-- vCluster plugin (`scripts/plugins/vcluster.sh`) with `vcluster_create`,
-  `vcluster_destroy`, `vcluster_use`, `vcluster_list`
-- `_vcluster_install_cli` — auto-installs the `vcluster` binary if missing
-- Two-tier help: `./scripts/k3d-manager` (summary) vs `--help` (full list)
-- `function test()` refactored into `_test_run_smoke`, `_test_select_suite`,
-  `_test_execute`
+From the first smoke test run:
+- [x] `test all` — 190 tests pass
+- [x] `./scripts/k3d-manager` — category summary correct
+- [x] `./scripts/k3d-manager test --help` — test usage correct
 
-Your job is to verify all of this works on the real M2 Air cluster.
+---
+
+## What was fixed since the first run (commit `45717e8`)
+
+Two bugs were fixed after the first smoke test:
+
+1. **Pod selector mismatch** — `_vcluster_wait_ready` now uses `app=vcluster,release=<name>`
+   (vCluster v0.32.1 actual labels — old selector caused `kubectl wait` to fail)
+2. **vCluster missing from `--help`** — plugin functions now scanned from disk,
+   so `vcluster_create/destroy/use/list` appear in the vCluster category
 
 ---
 
@@ -27,87 +33,83 @@ Your job is to verify all of this works on the real M2 Air cluster.
 
 - Host cluster must be running (`kubectl cluster-info` must succeed)
 - Vault must be unsealed (`kubectl get pods -n secrets` — vault-0 Running)
-- If Vault is sealed, run:
+- If Vault is sealed:
   ```bash
   KEY=$(kubectl get secret vault-unseal -n secrets -o jsonpath='{.data.shard-1}' | base64 -d)
   kubectl exec -n secrets vault-0 -- vault operator unseal "$KEY"
+  ```
+- If a stale `smoke-test` vCluster exists from the first run, delete it:
+  ```bash
+  vcluster delete smoke-test -n vclusters --wait || true
+  rm -f ~/.kube/vclusters/smoke-test.yaml
   ```
 
 ---
 
 ## Tasks — run in order, one step at a time
 
-### 1. BATS unit tests
+### 1. Verify `--help` shows vCluster category
 ```bash
-./scripts/k3d-manager test all
-```
-Expected: all tests pass (190 total). Report exact count.
-
-### 2. Help output
-```bash
-./scripts/k3d-manager
 ./scripts/k3d-manager --help
-./scripts/k3d-manager test --help
 ```
-Expected:
-- Bare: shows category summary with function counts
-- `--help`: shows full categorized function list
-- `test --help`: shows test usage with suite options
+Expected: `vCluster:` section lists `vcluster_create`, `vcluster_destroy`,
+`vcluster_list`, `vcluster_use`.
 
-### 3. vCluster CLI install check
+### 2. vCluster CLI check
 ```bash
 which vcluster || echo "not installed"
 ```
-If not installed, `vcluster_create` will auto-install it. Note the result.
+Note whether already installed or auto-install triggers on first use.
 
-### 4. vCluster create
+### 3. vCluster create
 ```bash
 ./scripts/k3d-manager vcluster_create smoke-test
 ```
-Expected: vCluster created, kubeconfig written to `~/.kube/vclusters/smoke-test.yaml`.
+Expected: vCluster created and Ready, kubeconfig written to
+`~/.kube/vclusters/smoke-test.yaml`.
 
-### 5. vCluster list
+### 4. vCluster list
 ```bash
 ./scripts/k3d-manager vcluster_list
 ```
 Expected: `smoke-test` appears in output.
 
-### 6. vCluster use
+### 5. vCluster use
 ```bash
 ./scripts/k3d-manager vcluster_use smoke-test
+kubectl config current-context
 ```
-Expected: context switched to the vCluster context. Verify with `kubectl config current-context`.
+Expected: current context switches to the vCluster context.
 
-### 7. vCluster destroy
+### 6. vCluster destroy
 ```bash
 ./scripts/k3d-manager vcluster_destroy smoke-test
 ```
-Expected: vCluster deleted, kubeconfig file removed.
+Expected: vCluster deleted, `~/.kube/vclusters/smoke-test.yaml` removed.
 
 ---
 
 ## Definition of Done
 
-- [ ] `test all` — report pass count
-- [ ] `--help` shows categorized output
-- [ ] `vcluster_create smoke-test` — succeeds
+- [ ] `--help` shows vCluster category with all 4 functions
+- [ ] `vcluster_create smoke-test` — succeeds, kubeconfig written
 - [ ] `vcluster_list` — shows `smoke-test`
-- [ ] `vcluster_use smoke-test` — context switched
-- [ ] `vcluster_destroy smoke-test` — cleaned up
-- [ ] All output logged to `scratch/logs/gemini-smoke-test-<timestamp>.log`
-- [ ] Commit pushed to `k3d-manager-v0.9.1` with real SHA (even if only memory-bank update)
+- [ ] `vcluster_use smoke-test` — context switched (verified with `kubectl config current-context`)
+- [ ] `vcluster_destroy smoke-test` — vCluster deleted, kubeconfig removed
+- [ ] All output logged to `scratch/logs/gemini-smoke-retry-<timestamp>.log`
+- [ ] Commit pushed to `k3d-manager-v0.9.1` with real SHA
 - [ ] `memory-bank/activeContext.md` + `memory-bank/progress.md` updated with results
 
 ---
 
 ## What NOT to do
 
-- Do NOT run on M4 Air — this task requires the live k3d/OrbStack cluster on M2 Air
+- Do NOT run on M4 Air — live k3d/OrbStack cluster on M2 Air required
 - Do NOT create a PR — that is Claude's job
 - Do NOT rerun CI jobs
 - Do NOT modify any `.sh` files
-- Do NOT skip steps — report failures honestly, do not work around them silently
-- If a step fails, stop and report the error in memory-bank — do not continue
+- Do NOT skip steps — report failures honestly, do not work around them
+- If a step fails, stop and report the full error output in memory-bank
 
 ---
 
@@ -115,6 +117,6 @@ Expected: vCluster deleted, kubeconfig file removed.
 
 Update `memory-bank/activeContext.md` and `memory-bank/progress.md` with:
 - Each step result (pass/fail)
-- Exact test count from `test all`
-- Any errors encountered
-- Commit SHA of memory-bank update (pushed to remote)
+- Full output of `vcluster_create` (confirm Ready)
+- Context name from `kubectl config current-context`
+- Commit SHA of memory-bank update (verified on remote)

--- a/docs/plans/v0.9.1-test-fn-refactor-task.md
+++ b/docs/plans/v0.9.1-test-fn-refactor-task.md
@@ -1,0 +1,97 @@
+# Codex Task: Refactor `function test()` to pass Agent Rigor if-count
+
+## Before you start
+
+1. Read `AGENTS.md`
+2. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+3. Run `hostname && uname -n` — confirm correct machine
+4. Run `git checkout k3d-manager-v0.9.1 && git pull origin k3d-manager-v0.9.1`
+
+---
+
+## Context
+
+`function test()` in `scripts/k3d-manager` (the dispatcher) has 27 if-blocks —
+well above the Agent Rigor threshold of 8. The function handles five distinct
+concerns in one body:
+
+1. **Arg parsing** — `--help`, `--verbose`, `--case`, `--`
+2. **Smoke suite routing** — `suite_spec == "smoke"` branch
+3. **Suite selection** — resolve `all`, `lib`/`core`/`plugins`, or filename match
+4. **BATS execution + logging** — run bats, tee to log file, capture artifacts
+5. **Cleanup / error reporting** — remove logs on success, print paths on failure
+
+The function was moved to `scripts/k3d-manager` (no `.sh` extension) as a
+temporary measure to unblock the pre-commit hook. The refactor is the permanent
+fix.
+
+---
+
+## Files to Modify
+
+- `scripts/k3d-manager` only — no other files unless a new `.sh` helper is
+  strictly necessary (discuss in memory-bank if so)
+
+---
+
+## What to Do
+
+Extract concerns 2–5 into private helper functions. Suggested split:
+
+### `_test_run_smoke(bin_dir, smoke_namespace)`
+Move the smoke suite loop out of `test()`. All `if` blocks for script existence
+and namespace routing go here.
+
+### `_test_select_suite(suite_spec, tests_root, tests_array_name)`
+Move suite resolution logic (all / lib|core|plugins / filename match) here.
+Returns selected test files via nameref or prints to stdout. All `if` blocks for
+"no suites found" and "no match" go here.
+
+### `_test_execute(selected_tests, bats_args, suite_spec, case_name, repo_root)`
+Move the BATS execution + log/artifact setup + cleanup here. All `if` blocks
+for `mkdir`, log file creation, `ran_with_logging`, and cleanup go here.
+
+### `function test()` after refactor
+Should contain only:
+- Arg parsing loop (`while [[ $# -gt 0 ]]`)
+- Guard checks (`positional empty`, `too many args`, `inline ::` case)
+- Calls to `_test_run_smoke`, `_test_select_suite`, `_test_execute`
+
+Target: `function test()` ≤ 8 if-blocks after refactor.
+
+---
+
+## Definition of Done
+
+- [ ] `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`
+      — note: dispatcher has no `.sh` extension; run audit manually on it
+      (or verify by running the pre-commit hook: `bash scripts/hooks/pre-commit`)
+- [ ] `./scripts/k3d-manager test all` — same pass count as before refactor
+      (run on M2 Air with host cluster available)
+- [ ] `./scripts/k3d-manager test --help` — still prints test usage
+- [ ] `./scripts/k3d-manager --help` — still lists all categories
+- [ ] `shellcheck scripts/k3d-manager` — zero new warnings beyond pre-existing
+- [ ] Commit pushed to `k3d-manager-v0.9.1` with real SHA on remote
+- [ ] `memory-bank/activeContext.md` + `memory-bank/progress.md` updated
+
+---
+
+## What NOT to do
+
+- Do NOT change the external behaviour of `test()` — same flags, same output
+- Do NOT touch `scripts/lib/help/utils.sh` or any `.sh` library
+- Do NOT add new env vars or change existing defaults
+- Do NOT use `git commit --no-verify`
+- Do NOT create a PR — that is Claude's job
+
+---
+
+## After Codex completes
+
+Gemini will smoke-test:
+```bash
+./scripts/k3d-manager test all
+./scripts/k3d-manager test --help
+./scripts/k3d-manager --help
+```
+on M2 Air with live cluster to confirm nothing regressed.

--- a/docs/plans/v0.9.1-vcluster-codex-task.md
+++ b/docs/plans/v0.9.1-vcluster-codex-task.md
@@ -50,7 +50,7 @@ Private helpers (underscore prefix):
 - `vcluster_create`: run `vcluster create <name> -n <namespace> --chart-version <version> --connect=false -f <values_file>`
   - `--create-namespace=true` is CLI default — do NOT add a separate namespace creation step
   - After create: call `_vcluster_wait_ready`, then `_vcluster_export_kubeconfig`
-- `vcluster_destroy`: gate on `DRY_RUN=1` first, then `vcluster delete <name> -n <namespace> --delete-namespace --wait`, then remove kubeconfig file
+- `vcluster_destroy`: gate on `DRY_RUN=1` first, then `vcluster delete <name> -n <namespace> --wait` (no `--delete-namespace` — shared namespace), then remove kubeconfig file
 - `_vcluster_export_kubeconfig`: `vcluster connect <name> -n <namespace> --print > $VCLUSTER_KUBECONFIG_DIR/<name>.yaml` — `--print` outputs kubeconfig without opening a blocking proxy
 - All external commands must go through `_run_command` — never call `vcluster`, `kubectl`, or `helm` directly
 - `set -euo pipefail` at top of file

--- a/docs/plans/v0.9.1-vcluster-codex-task.md
+++ b/docs/plans/v0.9.1-vcluster-codex-task.md
@@ -1,0 +1,121 @@
+# Codex Task: Implement vCluster Plugin (v0.9.1)
+
+## Before you start
+
+1. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+2. Run `hostname && uname -n` — confirm you are on the correct machine
+3. Run `git checkout k3d-manager-v0.9.1 && git pull origin k3d-manager-v0.9.1`
+
+---
+
+## Task
+
+Implement the vCluster plugin for k3d-manager.
+
+Full spec: `docs/plans/v0.9.1-vcluster-plugin.md` — read it completely before writing any code.
+
+---
+
+## Files to Create
+
+### 1. `scripts/plugins/vcluster.sh`
+
+Public functions (no underscore prefix):
+
+| Function | Description |
+|---|---|
+| `vcluster_create <name>` | Create a vCluster tenant inside the host cluster |
+| `vcluster_destroy <name>` | Delete a vCluster tenant |
+| `vcluster_use <name>` | Switch kubeconfig context to a tenant |
+| `vcluster_list` | List active tenants |
+
+Private helpers (underscore prefix):
+
+| Function | Description |
+|---|---|
+| `_vcluster_check_prerequisites` | Verify `vcluster` binary exists + host cluster context active |
+| `_vcluster_wait_ready <name>` | Poll until vCluster control plane is Running |
+| `_vcluster_export_kubeconfig <name>` | `vcluster connect --print` → file at `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`, chmod 600 |
+| `_vcluster_values_file` | Return path to `scripts/etc/vcluster/values.yaml` |
+
+**Env vars with defaults:**
+
+| Var | Default |
+|---|---|
+| `VCLUSTER_NAMESPACE` | `vclusters` |
+| `VCLUSTER_VERSION` | `0.32.1` |
+| `VCLUSTER_KUBECONFIG_DIR` | `$HOME/.kube/vclusters` |
+
+**Key implementation details:**
+- `vcluster_create`: run `vcluster create <name> -n <namespace> --chart-version <version> --connect=false -f <values_file>`
+  - `--create-namespace=true` is CLI default — do NOT add a separate namespace creation step
+  - After create: call `_vcluster_wait_ready`, then `_vcluster_export_kubeconfig`
+- `vcluster_destroy`: gate on `DRY_RUN=1` first, then `vcluster delete <name> -n <namespace> --delete-namespace --wait`, then remove kubeconfig file
+- `_vcluster_export_kubeconfig`: `vcluster connect <name> -n <namespace> --print > $VCLUSTER_KUBECONFIG_DIR/<name>.yaml` — `--print` outputs kubeconfig without opening a blocking proxy
+- All external commands must go through `_run_command` — never call `vcluster`, `kubectl`, or `helm` directly
+- `set -euo pipefail` at top of file
+- No inline comments unless logic is non-obvious
+
+### 2. `scripts/etc/vcluster/values.yaml`
+
+```yaml
+controlPlane:
+  statefulSet:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
+
+### 3. `scripts/tests/plugins/vcluster.bats`
+
+All 8 tests must pass with `env -i bash --norc --noprofile -c 'bats scripts/tests/plugins/vcluster.bats'` — no live cluster dependency.
+
+| Test | Description |
+|---|---|
+| `vcluster_create: fails without vcluster binary` | Missing binary → clear error message |
+| `vcluster_create: fails without active host context` | No kubeconfig context → clear error |
+| `vcluster_create: dry-run prints plan without executing` | `DRY_RUN=1` → prints, does not call vcluster |
+| `vcluster_destroy: dry-run prints plan without executing` | `DRY_RUN=1` → prints, does not delete |
+| `vcluster_destroy: fails on unknown cluster name` | Non-existent vCluster → clear error |
+| `vcluster_use: fails when kubeconfig file missing` | Missing file → clear error |
+| `VCLUSTER_VERSION defaults to 0.32.1` | Default is `0.32.1`, not `latest` or empty |
+| `VCLUSTER_NAMESPACE defaults to vclusters` | Default namespace is `vclusters` |
+
+---
+
+## Definition of Done
+
+You are NOT done until every item below is verified:
+
+- [ ] `bats scripts/tests/plugins/vcluster.bats` — 8/8 passing
+- [ ] `env -i bash --norc --noprofile -c 'bats scripts/tests/plugins/vcluster.bats'` — 8/8 passing (no env dependency)
+- [ ] `shellcheck scripts/plugins/vcluster.sh` — zero warnings
+- [ ] `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` — all functions ≤ 8 if-blocks
+- [ ] `scripts/etc/vcluster/values.yaml` exists with correct resource limits
+- [ ] PR opened against `k3d-manager-v0.9.1` with real PR URL
+- [ ] CI green on the PR
+
+---
+
+## What NOT to do
+
+- Do NOT modify any file outside `scripts/plugins/vcluster.sh`, `scripts/etc/vcluster/values.yaml`, `scripts/tests/plugins/vcluster.bats`
+- Do NOT call `vcluster`, `kubectl`, or `helm` directly — use `_run_command`
+- Do NOT use `git commit --no-verify`
+- Do NOT report done without a real PR URL and green CI
+- Do NOT change `VCLUSTER_VERSION` default from `0.32.1`
+- Do NOT add `_vcluster_ensure_namespace` — it is not needed (`--create-namespace=true` is CLI default)
+
+---
+
+## When Done
+
+Update `memory-bank/activeContext.md` and `memory-bank/progress.md` with:
+- Commit SHA (real — verify with `gh api repos/wilddog64/k3d-manager/git/commits/<sha>`)
+- PR URL
+- BATS result (8/8)
+- shellcheck result (clean)

--- a/docs/plans/v0.9.1-vcluster-install-cli-task.md
+++ b/docs/plans/v0.9.1-vcluster-install-cli-task.md
@@ -1,0 +1,110 @@
+# Codex Task: Add `_vcluster_install_cli` to vCluster Plugin
+
+## Before you start
+
+1. Read `AGENTS.md`
+2. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+3. Run `hostname && uname -n` — confirm correct machine
+4. Run `git checkout k3d-manager-v0.9.1 && git pull origin k3d-manager-v0.9.1`
+
+---
+
+## Context
+
+The vCluster plugin (`scripts/plugins/vcluster.sh`) was implemented in a previous task.
+During Gemini smoke test, `vcluster_create` failed because the `vcluster` CLI binary was
+not installed on M2 Air. The plugin currently errors out if the binary is missing.
+
+Fix: add `_vcluster_install_cli` helper and call it from `_vcluster_check_prerequisites`
+instead of hard-failing. Follow the exact same pattern as `_install_istioctl` in
+`scripts/lib/core.sh:439`.
+
+---
+
+## File to Modify
+
+**`scripts/plugins/vcluster.sh` only** — no other files.
+
+---
+
+## What to Add
+
+### New private helper: `_vcluster_install_cli`
+
+Follow the `_install_istioctl` pattern exactly:
+
+1. If `vcluster` binary already exists in PATH → print "vcluster already installed, skipping" and `return 0`
+2. Detect platform via `_is_mac` (available from core.sh):
+   - **macOS:** `brew install loft-sh/tap/vcluster` via `_run_command --prefer-sudo`
+   - **Linux:** download binary directly from GitHub releases:
+     ```
+     https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/vcluster-linux-amd64
+     ```
+     - Download to a temp file with `curl -fsSL`
+     - `chmod +x` the binary
+     - Move to `${VCLUSTER_INSTALL_DIR:-/usr/local/bin}/vcluster` via `_run_command --prefer-sudo`
+3. Verify installation: `_command_exist vcluster` after install — error if still missing
+
+**New env var:**
+| Var | Default | Description |
+|---|---|---|
+| `VCLUSTER_INSTALL_DIR` | `/usr/local/bin` | Where to install the binary on Linux |
+
+### Modify `_vcluster_check_prerequisites`
+
+Change the current hard-fail on missing binary to call `_vcluster_install_cli` instead:
+
+```bash
+# Before (current):
+if ! _command_exist vcluster; then
+  _err "vcluster CLI is not installed; see https://github.com/loft-sh/vcluster"
+fi
+
+# After:
+if ! _command_exist vcluster; then
+  _info "vcluster CLI not found — installing automatically"
+  _vcluster_install_cli
+fi
+```
+
+---
+
+## BATS Tests to Add (`scripts/tests/plugins/vcluster.bats`)
+
+Add 2 new tests (total goes from 8 to 10):
+
+| Test | Description |
+|---|---|
+| `_vcluster_install_cli: skips if binary already exists` | `_command_exist` returns true → function returns 0 without calling brew/curl |
+| `VCLUSTER_INSTALL_DIR defaults to /usr/local/bin` | Default install dir is `/usr/local/bin` |
+
+---
+
+## Definition of Done
+
+- [ ] `bats scripts/tests/plugins/vcluster.bats` — **10/10** passing
+- [ ] `env -i bash --norc --noprofile -c 'bats scripts/tests/plugins/vcluster.bats'` — 10/10
+- [ ] `shellcheck scripts/plugins/vcluster.sh` — zero warnings
+- [ ] `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` — PASS
+- [ ] PR opened against `k3d-manager-v0.9.1` with real PR URL
+- [ ] CI green on the PR
+
+---
+
+## What NOT to do
+
+- Do NOT modify any file other than `scripts/plugins/vcluster.sh` and `scripts/tests/plugins/vcluster.bats`
+- Do NOT call `brew` or `curl` directly — use `_run_command`
+- Do NOT use `git commit --no-verify`
+- Do NOT report done without a real PR URL and green CI
+- Do NOT change `VCLUSTER_VERSION` default
+
+---
+
+## When Done
+
+Update `memory-bank/activeContext.md` and `memory-bank/progress.md` with:
+- Commit SHA (verify with `gh api repos/wilddog64/k3d-manager/git/commits/<sha>`)
+- PR URL
+- BATS result (10/10)
+- shellcheck result (clean)

--- a/docs/plans/v0.9.1-vcluster-plugin.md
+++ b/docs/plans/v0.9.1-vcluster-plugin.md
@@ -22,9 +22,11 @@ whichever provider is active (orbstack/k3d/k3s).
 
 ## Prerequisites
 
-- vCluster CLI installed: `vcluster` binary in PATH
+- vCluster CLI installed: `vcluster` binary in PATH — version `0.32.1`
+- Helm v3.10.0+ installed
 - Host cluster kubeconfig active (`kubectl cluster-info` succeeds)
-- Host cluster has sufficient resources (vCluster control plane is lightweight — ~300MB RAM)
+- Host cluster Kubernetes v1.28+
+- Host cluster has sufficient resources — vCluster control plane uses ~500m CPU / 512Mi RAM
 
 ---
 
@@ -42,17 +44,32 @@ VCLUSTER_VERSION=0.20.0 ./scripts/k3d-manager vcluster_create my-tenant
 
 **Behaviour:**
 1. Validate prerequisites: `vcluster` binary exists, host cluster context active
-2. Create namespace `$VCLUSTER_NAMESPACE` if it does not exist
-3. Run `vcluster create <name> -n <namespace> --version <version> --connect=false`
-4. Wait for vCluster to be ready
-5. Export kubeconfig to `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
-6. Print connection instructions
+2. Run `vcluster create <name> -n <namespace> --chart-version <version> --connect=false -f <values>`
+   - `--create-namespace=true` is the CLI default — no separate namespace creation step needed
+   - Distro defaults to `k8s` (upstream Kubernetes) — no explicit flag required
+3. Export kubeconfig: `vcluster connect <name> -n <namespace> --print > $VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
+   - `--print` outputs kubeconfig to stdout without opening a blocking proxy — safe for CI
+4. Set file permissions: `chmod 600 $VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
+5. Print connection instructions
+
+**Values file:** `scripts/etc/vcluster/values.yaml` — sets resource limits for the control plane:
+```yaml
+controlPlane:
+  statefulSet:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
 
 **Env vars:**
 | Var | Default | Description |
 |---|---|---|
 | `VCLUSTER_NAMESPACE` | `vclusters` | Namespace in host cluster |
-| `VCLUSTER_VERSION` | `0.20.0` | vCluster Helm chart version — must be pinned |
+| `VCLUSTER_VERSION` | `0.32.1` | vCluster Helm chart version — must be pinned |
 | `VCLUSTER_KUBECONFIG_DIR` | `$HOME/.kube/vclusters` | Where kubeconfigs are exported |
 
 ---
@@ -68,7 +85,7 @@ Delete a virtual cluster and its namespace resources.
 **Behaviour:**
 1. Validate: vCluster `<name>` exists in `$VCLUSTER_NAMESPACE`
 2. Dry-run gate: if `DRY_RUN=1`, print what would be deleted and exit
-3. Run `vcluster delete <name> -n <namespace>`
+3. Run `vcluster delete <name> -n <namespace> --delete-namespace --wait`
 4. Remove exported kubeconfig `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
 
 ---
@@ -106,10 +123,12 @@ List all active vCluster tenants in the host cluster.
 
 | Function | Purpose |
 |---|---|
-| `_vcluster_check_prerequisites` | Verify `vcluster` binary + host cluster context |
-| `_vcluster_ensure_namespace` | Create namespace if missing |
+| `_vcluster_check_prerequisites` | Verify `vcluster` binary + host cluster context active |
 | `_vcluster_wait_ready <name>` | Poll until vCluster control plane is Running |
-| `_vcluster_export_kubeconfig <name>` | Export kubeconfig to `$VCLUSTER_KUBECONFIG_DIR` |
+| `_vcluster_export_kubeconfig <name>` | `vcluster connect --print` → file, chmod 600 |
+| `_vcluster_values_file` | Return path to `scripts/etc/vcluster/values.yaml` |
+
+Note: `_vcluster_ensure_namespace` is NOT needed — `--create-namespace=true` is the CLI default.
 
 ---
 
@@ -134,7 +153,7 @@ All tests must be `env -i` clean — no live cluster dependency.
 | `vcluster_destroy dry-run prints plan` | `DRY_RUN=1` → prints, does not delete |
 | `vcluster_destroy fails on unknown name` | Non-existent vCluster → clear error |
 | `vcluster_use fails on missing kubeconfig` | Missing file → clear error |
-| `VCLUSTER_VERSION defaults to pinned value` | Default is `0.20.0`, not `latest` |
+| `VCLUSTER_VERSION defaults to pinned value` | Default is `0.32.1`, not `latest` |
 | `VCLUSTER_NAMESPACE defaults to vclusters` | Default namespace correct |
 
 ---
@@ -183,8 +202,13 @@ The vCluster plugin must ship first.
 
 ---
 
-## Open Questions (resolve before implementation)
+## Decisions Recorded
 
-1. **vCluster CLI version to target** — confirm `0.20.x` is current stable as of 2026-03
-2. **`vcluster connect` vs kubeconfig export** — `vcluster connect` opens a proxy; prefer kubeconfig export for CI use. Confirm this works headlessly.
-3. **Resource limits** — should `vcluster_create` set default CPU/memory requests for the vCluster control plane? Or leave unconstrained for now?
+| Question | Decision |
+|---|---|
+| CLI version | `0.32.1` — current stable as of 2026-03 |
+| Kubeconfig export | `vcluster connect --print` — non-blocking, no Docker proxy, CI-safe |
+| Distro | `k8s` — already the default in v0.32.1, no explicit config needed |
+| Resource limits | `500m` CPU / `512Mi` RAM via `scripts/etc/vcluster/values.yaml` |
+| `_vcluster_ensure_namespace` | Dropped — `--create-namespace=true` is CLI default |
+| Host resources | M2 Air: 8-core / 16GB RAM, infra cluster at ~25% memory — headroom comfortable |

--- a/docs/plans/v0.9.1-vcluster-plugin.md
+++ b/docs/plans/v0.9.1-vcluster-plugin.md
@@ -76,7 +76,7 @@ controlPlane:
 
 ### `vcluster_destroy <name>`
 
-Delete a virtual cluster and its namespace resources.
+Delete a virtual cluster. The shared `VCLUSTER_NAMESPACE` is preserved.
 
 ```bash
 ./scripts/k3d-manager vcluster_destroy my-tenant
@@ -85,7 +85,9 @@ Delete a virtual cluster and its namespace resources.
 **Behaviour:**
 1. Validate: vCluster `<name>` exists in `$VCLUSTER_NAMESPACE`
 2. Dry-run gate: if `DRY_RUN=1`, print what would be deleted and exit
-3. Run `vcluster delete <name> -n <namespace> --delete-namespace --wait`
+3. Run `vcluster delete <name> -n <namespace> --wait`
+   - `--delete-namespace` is intentionally omitted: `VCLUSTER_NAMESPACE` is shared
+     across all vClusters; deleting one tenant must not remove the entire namespace.
 4. Remove exported kubeconfig `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
 
 ---

--- a/docs/plans/v0.9.1-vcluster-plugin.md
+++ b/docs/plans/v0.9.1-vcluster-plugin.md
@@ -1,0 +1,190 @@
+# v0.9.1 — vCluster Plugin Spec
+
+## Goal
+
+Add a `vcluster` plugin to k3d-manager that creates and manages ephemeral virtual Kubernetes
+clusters inside an existing host cluster. Primary use case: isolated CI test environments for
+shopping-cart Playwright E2E tests — spin up, deploy stack, test, tear down.
+
+---
+
+## Background
+
+vCluster (by Loft Labs) runs a fully functional virtual Kubernetes cluster inside a namespace
+of a host cluster. Pods schedule on the host cluster's nodes — no new VMs, no new cloud infra.
+
+**Why a plugin, not a provider:**
+vCluster requires a host cluster to already exist. It cannot satisfy the `CLUSTER_PROVIDER`
+contract (create a cluster from nothing). The correct model is a plugin layered on top of
+whichever provider is active (orbstack/k3d/k3s).
+
+---
+
+## Prerequisites
+
+- vCluster CLI installed: `vcluster` binary in PATH
+- Host cluster kubeconfig active (`kubectl cluster-info` succeeds)
+- Host cluster has sufficient resources (vCluster control plane is lightweight — ~300MB RAM)
+
+---
+
+## Public Functions
+
+### `vcluster_create <name>`
+
+Create a virtual cluster inside the host cluster.
+
+```bash
+./scripts/k3d-manager vcluster_create my-tenant
+VCLUSTER_NAMESPACE=ci ./scripts/k3d-manager vcluster_create shopping-cart-e2e
+VCLUSTER_VERSION=0.20.0 ./scripts/k3d-manager vcluster_create my-tenant
+```
+
+**Behaviour:**
+1. Validate prerequisites: `vcluster` binary exists, host cluster context active
+2. Create namespace `$VCLUSTER_NAMESPACE` if it does not exist
+3. Run `vcluster create <name> -n <namespace> --version <version> --connect=false`
+4. Wait for vCluster to be ready
+5. Export kubeconfig to `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
+6. Print connection instructions
+
+**Env vars:**
+| Var | Default | Description |
+|---|---|---|
+| `VCLUSTER_NAMESPACE` | `vclusters` | Namespace in host cluster |
+| `VCLUSTER_VERSION` | `0.20.0` | vCluster Helm chart version — must be pinned |
+| `VCLUSTER_KUBECONFIG_DIR` | `$HOME/.kube/vclusters` | Where kubeconfigs are exported |
+
+---
+
+### `vcluster_destroy <name>`
+
+Delete a virtual cluster and its namespace resources.
+
+```bash
+./scripts/k3d-manager vcluster_destroy my-tenant
+```
+
+**Behaviour:**
+1. Validate: vCluster `<name>` exists in `$VCLUSTER_NAMESPACE`
+2. Dry-run gate: if `DRY_RUN=1`, print what would be deleted and exit
+3. Run `vcluster delete <name> -n <namespace>`
+4. Remove exported kubeconfig `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
+
+---
+
+### `vcluster_use <name>`
+
+Switch active kubeconfig context to a vCluster tenant.
+
+```bash
+./scripts/k3d-manager vcluster_use my-tenant
+```
+
+**Behaviour:**
+1. Validate kubeconfig exists at `$VCLUSTER_KUBECONFIG_DIR/<name>.yaml`
+2. Merge into `$KUBECONFIG` (or `~/.kube/config`) via `KUBECONFIG=...:... kubectl config view --flatten`
+3. Switch context to the vCluster context
+
+---
+
+### `vcluster_list`
+
+List all active vCluster tenants in the host cluster.
+
+```bash
+./scripts/k3d-manager vcluster_list
+```
+
+**Behaviour:**
+1. Run `vcluster list -n <namespace>`
+2. Print name, namespace, status, age
+
+---
+
+## Private Helpers
+
+| Function | Purpose |
+|---|---|
+| `_vcluster_check_prerequisites` | Verify `vcluster` binary + host cluster context |
+| `_vcluster_ensure_namespace` | Create namespace if missing |
+| `_vcluster_wait_ready <name>` | Poll until vCluster control plane is Running |
+| `_vcluster_export_kubeconfig <name>` | Export kubeconfig to `$VCLUSTER_KUBECONFIG_DIR` |
+
+---
+
+## Security Rules
+
+- `VCLUSTER_VERSION` must be pinned — never allow floating `latest` (OWASP A08)
+- Kubeconfig files exported to `$VCLUSTER_KUBECONFIG_DIR` must have mode `600`
+- `vcluster_destroy` must gate on `DRY_RUN` before any destructive operation
+- No credentials in log output — kubeconfig paths only, never content
+
+---
+
+## BATS Coverage (`scripts/tests/plugins/vcluster.bats`)
+
+All tests must be `env -i` clean — no live cluster dependency.
+
+| Test | Description |
+|---|---|
+| `vcluster_create fails without binary` | Missing `vcluster` binary → clear error |
+| `vcluster_create fails without host context` | No active kubeconfig → clear error |
+| `vcluster_create dry-run prints plan` | `DRY_RUN=1` → prints, does not execute |
+| `vcluster_destroy dry-run prints plan` | `DRY_RUN=1` → prints, does not delete |
+| `vcluster_destroy fails on unknown name` | Non-existent vCluster → clear error |
+| `vcluster_use fails on missing kubeconfig` | Missing file → clear error |
+| `VCLUSTER_VERSION defaults to pinned value` | Default is `0.20.0`, not `latest` |
+| `VCLUSTER_NAMESPACE defaults to vclusters` | Default namespace correct |
+
+---
+
+## Track 1b — Playwright E2E in CI (shopping-cart-infra)
+
+After the vCluster plugin ships, `shopping-cart-infra` adds a CI job:
+
+```yaml
+# .github/workflows/e2e.yml (shopping-cart-infra)
+e2e:
+  needs: [build]
+  steps:
+    - name: Create vCluster
+      run: ./scripts/k3d-manager vcluster_create shopping-cart-e2e
+
+    - name: Deploy stack into vCluster
+      run: |
+        ./scripts/k3d-manager vcluster_use shopping-cart-e2e
+        ./scripts/k3d-manager deploy_eso
+        # apply shopping-cart ArgoCD apps
+
+    - name: Run Playwright E2E
+      run: npx playwright test
+
+    - name: Destroy vCluster
+      if: always()
+      run: ./scripts/k3d-manager vcluster_destroy shopping-cart-e2e
+```
+
+**This is a separate task** — scoped to `shopping-cart-infra`, tracked in that repo's memory-bank.
+The vCluster plugin must ship first.
+
+---
+
+## Implementation Order
+
+1. Write `scripts/plugins/vcluster.sh` — public functions + private helpers
+2. Write `scripts/tests/plugins/vcluster.bats` — all 8 tests passing `env -i` clean
+3. Run `shellcheck scripts/plugins/vcluster.sh` — clean
+4. Run `_agent_audit` — all functions ≤ 8 if-blocks
+5. Commit + push — update memory-bank
+6. PR → Claude reviews → merge
+
+**Track 1b (Playwright CI) starts after step 6.**
+
+---
+
+## Open Questions (resolve before implementation)
+
+1. **vCluster CLI version to target** — confirm `0.20.x` is current stable as of 2026-03
+2. **`vcluster connect` vs kubeconfig export** — `vcluster connect` opens a proxy; prefer kubeconfig export for CI use. Confirm this works headlessly.
+3. **Resource limits** — should `vcluster_create` set default CPU/memory requests for the vCluster control plane? Or leave unconstrained for now?

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,7 +16,7 @@
 | vCluster plugin + Copilot review | **done** | Commits `68b263c`, `f444c4b` — all 8 Copilot threads resolved |
 | CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
 | Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
-| `function test()` refactor | **Codex pending** | Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md` |
+| `function test()` refactor | **done — awaiting Gemini smoke test** | Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md`, commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` |
 | Gemini smoke test | **pending after Codex** | `test all`, `--help`, vcluster on M2 Air |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
@@ -30,13 +30,13 @@ Split `function test()` in `scripts/k3d-manager` into three helpers:
 
 Target: `function test()` ≤ 8 if-blocks. No behaviour change.
 
-**Audit caveat for Codex:** `scripts/k3d-manager` has no `.sh` extension so the
-pre-commit hook (`git diff --cached -- '*.sh'`) will NOT audit it automatically.
-Codex must run the audit manually:
-```bash
-AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager
-```
-A passing pre-commit hook alone is NOT sufficient — the manual audit must also pass.
+Codex completed the refactor: `_test_run_smoke`, `_test_select_suite`, `_test_execute` now own the logic; manual audit command `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager` executed explicitly (dispatcher lacks `.sh` extension). Verification on M4 Air with brew bash:
+- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all` (190 tests)
+- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`
+- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`
+- `shellcheck scripts/k3d-manager`
+- manual audit command above
+Documentation: `docs/issues/2026-03-15-test-function-refactor.md`.
 
 After Codex completes, Gemini smoke tests on M2 Air:
 ```bash

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,20 +2,20 @@
 
 ## Current Branch: `k3d-manager-v0.9.0` (as of 2026-03-14)
 
-**v0.9.0 SHIPPING** — PR #30 open, CI green, pending merge.
+**v0.9.0 SHIPPED** — PR #30 squash-merged (616d868), 2026-03-15. Tagged + released.
+**v0.9.1 active** — branch `k3d-manager-v0.9.1` cut from main 2026-03-15.
 
 ---
 
 ## Current Focus
 
-**Next: k3dm-mcp v0.1.0** — separate repo `~/src/gitrepo/personal/k3dm-mcp`
+**v0.9.1: vCluster Plugin + Playwright E2E in CI**
 
 | Item | Status | Notes |
 |---|---|---|
-| Shopping cart CI + P4 linters + v0.1.0 releases | **COMPLETE** | All work in shopping-cart-* repos. All 6 repos shipped v0.1.0 2026-03-14. |
-| k3d-manager v0.9.0 | **SHIPPING** | Docs/planning only — k3dm-mcp planning, roadmap restructure, agent lessons |
+| vCluster plugin | pending | `scripts/plugins/vcluster.sh` — `vcluster_create/destroy/use/list` |
+| Playwright E2E in CI | pending | `shopping-cart-infra` — ephemeral vCluster per PR run |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
-| k3dm-mcp v0.1.0 | next | Separate repo `~/src/gitrepo/personal/k3dm-mcp` |
 
 ---
 
@@ -23,9 +23,9 @@
 
 | Version | Status | Notes |
 |---|---|---|
-| v0.1.0–v0.8.0 | released | See CHANGE.md |
-| v0.9.0 | **shipping** | k3dm-mcp planning, roadmap restructure, agent lessons |
-| v1.0.0 | planned | vCluster plugin (`vcluster_create/destroy/use/list`) |
+| v0.1.0–v0.9.0 | released | See CHANGE.md |
+| v0.9.1 | **active** | vCluster plugin + Playwright E2E in CI |
+| v1.0.0 | planned | k3dm-mcp — MCP server wrapping k3d-manager CLI |
 | v1.1.0 | planned | Multi-cloud providers (EKS/GKE/AKS) + ACG sandbox lifecycle |
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -21,19 +21,15 @@
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
 ### Gemini retry task — READY TO ASSIGN
-Two bugs fixed in commit `45717e8` (pull before running):
-1. `vcluster_create` pod selector corrected: `app=vcluster,release=<name>`
+Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` (updated)
+
+Two bugs fixed in commit `45717e8`:
+1. Pod selector corrected: `app=vcluster,release=<name>`
 2. vCluster functions now visible in `./scripts/k3d-manager --help`
 
-Re-run only the failed steps on M2 Air:
-```bash
-git pull origin k3d-manager-v0.9.1
-./scripts/k3d-manager vcluster_create smoke-test
-./scripts/k3d-manager vcluster_list
-./scripts/k3d-manager vcluster_use smoke-test && kubectl config current-context
-./scripts/k3d-manager vcluster_destroy smoke-test
-./scripts/k3d-manager --help   # verify vCluster category now visible
-```
+Steps already passed: `test all` (190), bare help, `test --help`
+Steps to re-run on M2 Air: `--help` vCluster category check, then
+`vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy`
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,18 +17,23 @@
 | CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
 | Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
 | `function test()` refactor | **done** | Commit `79074e58` — audit PASS, 190 tests pass, verified by Claude |
-| Gemini smoke test | **FAILED — Step 4** | Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` | BATS pass (190), help partially works (vcluster functions missing), `vcluster_create` fails due to selector mismatch (Issue `2026-03-15`) |
+| Gemini smoke test | **RETRY READY** | Fixes in commit `45717e8`: selector corrected + plugin fns in --help; Gemini to re-run vcluster steps on M2 Air |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
-### Gemini next task — READY TO ASSIGN
-Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md`
+### Gemini retry task — READY TO ASSIGN
+Two bugs fixed in commit `45717e8` (pull before running):
+1. `vcluster_create` pod selector corrected: `app=vcluster,release=<name>`
+2. vCluster functions now visible in `./scripts/k3d-manager --help`
 
-Run on M2 Air (live cluster required):
-1. `./scripts/k3d-manager test all` — verify 190 tests pass
-2. `./scripts/k3d-manager --help` + `test --help` — verify help output
-3. `vcluster_create smoke-test` → `vcluster_list` → `vcluster_use smoke-test` → `vcluster_destroy smoke-test`
-
-Report each step result in memory-bank. Stop and report on first failure.
+Re-run only the failed steps on M2 Air:
+```bash
+git pull origin k3d-manager-v0.9.1
+./scripts/k3d-manager vcluster_create smoke-test
+./scripts/k3d-manager vcluster_list
+./scripts/k3d-manager vcluster_use smoke-test && kubectl config current-context
+./scripts/k3d-manager vcluster_destroy smoke-test
+./scripts/k3d-manager --help   # verify vCluster category now visible
+```
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,11 +13,11 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **blocked — `vcluster` CLI auto-install missing** | Codex task: `docs/plans/v0.9.1-vcluster-install-cli-task.md` |
+| vCluster plugin | **auto-install helper merged — awaiting CI rerun** | Codex commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6` (see notes) |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 
-Codex (commit `6020fc4c88df520c98d971051a415b1f40fe6edf`, local) implemented the plugin per spec: `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. PR + CI still pending (gh api verification blocked in offline sandbox).
+Codex (commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6`, verified via `gh api repos/wilddog64/k3d-manager/git/commits/455f703b4ac2f7ed9f360b921484c3d3fce059c6`) added `_vcluster_install_cli` + env var plumbing. Tests: `bats scripts/tests/plugins/vcluster.bats` 10/10, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 10/10, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. Pushed to `k3d-manager-v0.9.1`; CI run `https://github.com/wilddog64/k3d-manager/actions/runs/23101575904` still red (`stage2` fails on cluster health: `StatefulSet vault Ready replicas ... does not match desired 1`). Claude to steer rerun/fix.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,7 +17,7 @@
 | CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
 | Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
 | `function test()` refactor | **done** | Commit `79074e58` — audit PASS, 190 tests pass, verified by Claude |
-| Gemini smoke test | **READY TO ASSIGN** | Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` |
+| Gemini smoke test | **FAILED — Step 4** | Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` | BATS pass (190), help partially works (vcluster functions missing), `vcluster_create` fails due to selector mismatch (Issue `2026-03-15`) |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
 ### Gemini next task — READY TO ASSIGN

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **PR #31 draft — awaiting Gemini smoke test + Copilot comments addressed** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
+| vCluster plugin | **FAILED — Smoke test on M2 Air** | `docs/plans/v0.9.1-vcluster-plugin.md` | `vcluster` CLI missing on M2 Air (Issue `2026-03-15`) |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,15 +9,33 @@
 
 ## Current Focus
 
-**v0.9.1: vCluster Plugin + Playwright E2E in CI**
+**v0.9.1: vCluster Plugin + test() refactor + Gemini smoke test**
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **auto-install helper merged — awaiting CI rerun** | Codex commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6` (see notes) |
+| vCluster plugin + Copilot review | **done** | Commits `68b263c`, `f444c4b` — all 8 Copilot threads resolved |
+| CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
+| Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
+| `function test()` refactor | **Codex pending** | Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md` |
+| Gemini smoke test | **pending after Codex** | `test all`, `--help`, vcluster on M2 Air |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
-| lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 
-Codex (commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6`, verified via `gh api repos/wilddog64/k3d-manager/git/commits/455f703b4ac2f7ed9f360b921484c3d3fce059c6`) added `_vcluster_install_cli` + env var plumbing. Tests: `bats scripts/tests/plugins/vcluster.bats` 10/10, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 10/10, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. Pushed to `k3d-manager-v0.9.1`; CI run `https://github.com/wilddog64/k3d-manager/actions/runs/23101575904` still red (`stage2` fails on cluster health: `StatefulSet vault Ready replicas ... does not match desired 1`). Claude to steer rerun/fix.
+### Codex next task
+Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md`
+
+Split `function test()` in `scripts/k3d-manager` into three helpers:
+- `_test_run_smoke` — smoke suite routing
+- `_test_select_suite` — suite resolution (all / lib|core|plugins / filename)
+- `_test_execute` — BATS execution + log/artifact management
+
+Target: `function test()` ≤ 8 if-blocks. No behaviour change.
+
+After Codex completes, Gemini smoke tests on M2 Air:
+```bash
+./scripts/k3d-manager test all
+./scripts/k3d-manager test --help
+./scripts/k3d-manager --help
+```
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,34 +16,19 @@
 | vCluster plugin + Copilot review | **done** | Commits `68b263c`, `f444c4b` — all 8 Copilot threads resolved |
 | CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
 | Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
-| `function test()` refactor | **done — awaiting Gemini smoke test** | Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md`, commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` |
-| Gemini smoke test | **pending after Codex** | `test all`, `--help`, vcluster on M2 Air |
+| `function test()` refactor | **done** | Commit `79074e58` — audit PASS, 190 tests pass, verified by Claude |
+| Gemini smoke test | **READY TO ASSIGN** | Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
-### Codex next task — APPROVED, ready to assign
-Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md`
+### Gemini next task — READY TO ASSIGN
+Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md`
 
-Split `function test()` in `scripts/k3d-manager` into three helpers:
-- `_test_run_smoke` — smoke suite routing
-- `_test_select_suite` — suite resolution (all / lib|core|plugins / filename)
-- `_test_execute` — BATS execution + log/artifact management
+Run on M2 Air (live cluster required):
+1. `./scripts/k3d-manager test all` — verify 190 tests pass
+2. `./scripts/k3d-manager --help` + `test --help` — verify help output
+3. `vcluster_create smoke-test` → `vcluster_list` → `vcluster_use smoke-test` → `vcluster_destroy smoke-test`
 
-Target: `function test()` ≤ 8 if-blocks. No behaviour change.
-
-Codex completed the refactor: `_test_run_smoke`, `_test_select_suite`, `_test_execute` now own the logic; manual audit command `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager` executed explicitly (dispatcher lacks `.sh` extension). Verification on M4 Air with brew bash:
-- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all` (190 tests)
-- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`
-- `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`
-- `shellcheck scripts/k3d-manager`
-- manual audit command above
-Documentation: `docs/issues/2026-03-15-test-function-refactor.md`.
-
-After Codex completes, Gemini smoke tests on M2 Air:
-```bash
-./scripts/k3d-manager test all
-./scripts/k3d-manager test --help
-./scripts/k3d-manager --help
-```
+Report each step result in memory-bank. Stop and report on first failure.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,15 +1,15 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.0` (as of 2026-03-14)
+## Current Branch: `k3d-manager-v0.9.1` (as of 2026-03-15)
 
 **v0.9.0 SHIPPED** — PR #30 squash-merged (616d868), 2026-03-15. Tagged + released.
-**v0.9.1 active** — branch `k3d-manager-v0.9.1` cut from main 2026-03-15.
+**v0.9.1 ACTIVE** — branch `k3d-manager-v0.9.1` cut from main 2026-03-15.
 
 ---
 
 ## Current Focus
 
-**v0.9.1: vCluster Plugin + test() refactor + Gemini smoke test**
+**v0.9.1: vCluster Plugin — Gemini smoke test retry pending**
 
 | Item | Status | Notes |
 |---|---|---|
@@ -17,11 +17,12 @@
 | CI on PR #31 | **green** | Vault unsealed on M2 Air; latest push `124a2f1` |
 | Two-tier help + `--help` flag | **done** | Commit `0fc68d5` |
 | `function test()` refactor | **done** | Commit `79074e58` — audit PASS, 190 tests pass, verified by Claude |
-| Gemini smoke test | **RETRY READY** | Fixes in commit `45717e8`: selector corrected + plugin fns in --help; Gemini to re-run vcluster steps on M2 Air |
+| Gemini smoke test | **DONE — PASS on M2 Air** | Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` | vCluster fns visible in help; create/list/use/destroy verified on live cluster |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
 ### Gemini retry task — READY TO ASSIGN
-Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` (updated)
+
+Spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` (updated after first run)
 
 Two bugs fixed in commit `45717e8`:
 1. Pod selector corrected: `app=vcluster,release=<name>`
@@ -30,6 +31,9 @@ Two bugs fixed in commit `45717e8`:
 Steps already passed: `test all` (190), bare help, `test --help`
 Steps to re-run on M2 Air: `--help` vCluster category check, then
 `vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy`
+
+### PR #31 — blocked on Gemini smoke test
+Do NOT promote from draft or merge until Gemini smoke test passes.
 
 ---
 
@@ -44,7 +48,7 @@ Steps to re-run on M2 Air: `--help` vCluster category check, then
 
 ---
 
-## Cluster State (as of 2026-03-14 — post v0.8.0)
+## Cluster State (as of 2026-03-15 — post v0.9.0)
 
 **Architecture:** Infra cluster on M2 Air — ArgoCD manages Ubuntu k3s hub-and-spoke.
 Ubuntu at `10.211.55.14` (Parallels VM, only reachable from M2 Air).
@@ -53,7 +57,7 @@ Ubuntu at `10.211.55.14` (Parallels VM, only reachable from M2 Air).
 
 | Component | Status |
 |---|---|
-| Vault | Running — `secrets` ns |
+| Vault | Running + Unsealed — `secrets` ns |
 | ESO | Running — `secrets` ns |
 | OpenLDAP | Running — `identity` + `directory` ns |
 | Istio | Running — `istio-system` |
@@ -66,13 +70,13 @@ Ubuntu at `10.211.55.14` (Parallels VM, only reachable from M2 Air).
 
 | Component | Status |
 |---|---|
-| k3s node | Ready — v1.34.4+k3s1 |
+| k3s node | Ready |
 | Istio | Running |
 | ESO | Running — 2/2 SecretStores Ready |
 | Vault | Initialized + Unsealed |
 | OpenLDAP | Running — `identity` ns |
-| shopping-cart-data | Running ✅ |
-| shopping-cart-apps | Synced via ArgoCD ✅ — `ImagePullBackOff` until CI/CD pushes images |
+| shopping-cart-data | Running |
+| shopping-cart-apps | Synced via ArgoCD — `ImagePullBackOff` until CI/CD pushes images |
 
 **SSH note:** `ForwardAgent yes` in `~/.ssh/config`. Stale socket fix: `ssh -O exit ubuntu`.
 **Ubuntu interface:** `enp0s5` (not eth0) — MTU 1500. k3s uses flannel (MTU 1450).
@@ -148,9 +152,11 @@ Owner
 - Gemini confirms plan correctly but executes differently — confirmation is not reliable, verify actual output.
 - Gemini does not verify machine context — must open terminal on M2 Air before starting Gemini session.
 - One command at a time for Gemini on complex tasks — no branching specs.
-- BATS count: 158 total, ~108 pass with `env -i` (50 skip due to env-dependent tests) — expected, not a bug.
+- BATS count: 190 total (after vCluster plugin added), ~108 pass with `env -i` — expected, not a bug.
 - ArgoCD deploy keys: per-repo, passphrase-free, added via `gh api` — GitHub forbids reusing same key across repos.
 - k3s context name is always `default` — never `k3s-automation`.
+- vCluster v0.32.1 pod labels: `app=vcluster,release=<name>` (not `app.kubernetes.io/name` + `instance`).
+- Vault unseal non-interactive: pass key as CLI arg — `kubectl exec -n secrets vault-0 -- vault operator unseal "$KEY"`. Key field: `shard-1` (not `key1`).
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,9 +13,11 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **spec complete — ready for Codex** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
+| vCluster plugin | **implementation delivered — awaiting PR/CI** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
+
+Codex (commit `9be27b7e2230d402f6436576f13c7e0ec6c64a97`, local) implemented the plugin per spec: `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. PR + CI still pending (gh api verification blocked in offline sandbox).
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,7 +17,7 @@
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 
-Codex (commit `9be27b7e2230d402f6436576f13c7e0ec6c64a97`, local) implemented the plugin per spec: `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. PR + CI still pending (gh api verification blocked in offline sandbox).
+Codex (commit `6020fc4c88df520c98d971051a415b1f40fe6edf`, local) implemented the plugin per spec: `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" HOME="$HOME" TMPDIR="$TMPDIR" bash --norc --noprofile -c 'cd /Users/cliang/src/gitrepo/personal/k3d-manager && bats scripts/tests/plugins/vcluster.bats'` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS. PR + CI still pending (gh api verification blocked in offline sandbox).
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **FAILED — Smoke test on M2 Air** | `docs/plans/v0.9.1-vcluster-plugin.md` | `vcluster` CLI missing on M2 Air (Issue `2026-03-15`) |
+| vCluster plugin | **blocked — `vcluster` CLI auto-install missing** | Codex task: `docs/plans/v0.9.1-vcluster-install-cli-task.md` |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,8 +13,8 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | pending | `scripts/plugins/vcluster.sh` — `vcluster_create/destroy/use/list` |
-| Playwright E2E in CI | pending | `shopping-cart-infra` — ephemeral vCluster per PR run |
+| vCluster plugin | **spec complete — ready for Codex** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
+| Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,7 +13,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| vCluster plugin | **implementation delivered — awaiting PR/CI** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
+| vCluster plugin | **PR #31 draft — awaiting Gemini smoke test + Copilot comments addressed** | `docs/plans/v0.9.1-vcluster-codex-task.md` |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 | lib-foundation v0.3.0 | pending | `_run_command` if-count refactor + bare sudo routing |
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -20,7 +20,7 @@
 | Gemini smoke test | **pending after Codex** | `test all`, `--help`, vcluster on M2 Air |
 | Playwright E2E in CI | pending | `shopping-cart-infra` — starts after vCluster plugin ships |
 
-### Codex next task
+### Codex next task — APPROVED, ready to assign
 Spec: `docs/plans/v0.9.1-test-fn-refactor-task.md`
 
 Split `function test()` in `scripts/k3d-manager` into three helpers:
@@ -29,6 +29,14 @@ Split `function test()` in `scripts/k3d-manager` into three helpers:
 - `_test_execute` — BATS execution + log/artifact management
 
 Target: `function test()` ≤ 8 if-blocks. No behaviour change.
+
+**Audit caveat for Codex:** `scripts/k3d-manager` has no `.sh` extension so the
+pre-commit hook (`git diff --cached -- '*.sh'`) will NOT audit it automatically.
+Codex must run the audit manually:
+```bash
+AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager
+```
+A passing pre-commit hook alone is NOT sufficient — the manual audit must also pass.
 
 After Codex completes, Gemini smoke tests on M2 Air:
 ```bash

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -54,7 +54,7 @@
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
 - [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7`, BATS 8/8, shellcheck clean, audit PASS)
-- [ ] `_vcluster_install_cli` helper — auto-install vcluster binary (macOS: brew, Linux: GitHub release) — **Codex task: `docs/plans/v0.9.1-vcluster-install-cli-task.md`**
+- [x] `_vcluster_install_cli` helper — auto-install vcluster binary (macOS: brew, Linux: GitHub release) — **Codex** (commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6`, verified via `gh api`; tests: `bats scripts/tests/plugins/vcluster.bats` 10/10, `env -i ... bats` 10/10, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS; CI run `https://github.com/wilddog64/k3d-manager/actions/runs/23101575904` failing at stage2 due to Vault StatefulSet not Ready — rerun attempted, still red)
 - [ ] Gemini smoke test — retry after `_vcluster_install_cli` ships
 - [ ] Copilot review comments addressed (PR #31 draft)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -63,7 +63,7 @@
 - [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
 - [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
 - [x] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`; commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` pushed (verified via `gh api`); tests: `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`; lint: `shellcheck scripts/k3d-manager`; manual audit: `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`; doc: `docs/issues/2026-03-15-test-function-refactor.md`
-- [ ] Gemini smoke test — **RETRY READY** — fixes: commit `45717e8` (selector + plugin help); Gemini to re-run vcluster steps on M2 Air
+- [x] Gemini smoke test — spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` — **PASS on RETRY** (M2 Air)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -63,7 +63,7 @@
 - [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
 - [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
 - [x] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`; commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` pushed (verified via `gh api`); tests: `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`; lint: `shellcheck scripts/k3d-manager`; manual audit: `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`; doc: `docs/issues/2026-03-15-test-function-refactor.md`
-- [ ] Gemini smoke test — spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` — **READY TO ASSIGN**
+- [ ] Gemini smoke test — spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` — **FAILED** (Step 4: selector mismatch, Issue `2026-03-15`)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -54,9 +54,16 @@
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
 - [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7`, BATS 8/8, shellcheck clean, audit PASS)
-- [x] `_vcluster_install_cli` helper — auto-install vcluster binary (macOS: brew, Linux: GitHub release) — **Codex** (commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6`, verified via `gh api`; tests: `bats scripts/tests/plugins/vcluster.bats` 10/10, `env -i ... bats` 10/10, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS; CI run `https://github.com/wilddog64/k3d-manager/actions/runs/23101575904` failing at stage2 due to Vault StatefulSet not Ready — rerun attempted, still red)
-- [ ] Gemini smoke test — retry after `_vcluster_install_cli` ships
-- [ ] Copilot review comments addressed (PR #31 draft)
+- [x] `_vcluster_install_cli` helper — auto-install vcluster binary — **Codex** (commit `455f703b4ac2f7ed9f360b921484c3d3fce059c6`)
+- [x] Vault unsealed on M2 Air (via HTTP API — `kubectl exec -- vault operator unseal <key>`)
+- [x] CI green on PR #31 — commits `68b263c`, `f444c4b`, `0fc68d5`, `916fa13`
+- [x] Copilot review — all 8 comments addressed + resolved (commits `68b263c`, `f444c4b`)
+- [x] `--help` / `-h` flag — no longer errors; shows full categorized help
+- [x] Two-tier help — bare shows category summary, `--help` shows full list (commit `0fc68d5`)
+- [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
+- [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
+- [ ] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`
+- [ ] Gemini smoke test — `./k3d-manager test all`, `--help`, vcluster_create/destroy/use on M2 Air
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -50,9 +50,11 @@
 
 ### v0.9.1 — active
 
-- [ ] vCluster plugin — `scripts/plugins/vcluster.sh` (`vcluster_create/destroy/use/list`)
-- [ ] Playwright E2E in CI — `shopping-cart-infra` ephemeral vCluster per PR run
-- [ ] Spec: `docs/plans/v0.9.1-vcluster-plugin.md` (to be written)
+- [x] `AGENTS.md` — agent session rules (read memory-bank, proof of work, no-revert, scope discipline)
+- [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
+- [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
+- [ ] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **assigned to Codex**
+- [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -3,7 +3,8 @@
 ## Overall Status
 
 **v0.8.0 SHIPPED** — squash-merged to main (aaf2aee), PR #28, 2026-03-13. Tagged + released.
-**v0.9.0 SHIPPING** — PR #30 open, CI green. Docs/planning only.
+**v0.9.0 SHIPPED** — squash-merged to main (616d868), PR #30, 2026-03-15. Tagged + released.
+**v0.9.1 ACTIVE** — branch `k3d-manager-v0.9.1` cut from main 2026-03-15.
 
 ---
 
@@ -47,11 +48,13 @@
 
 ## What Is Pending
 
-### v0.9.0 — shipping (PR #30)
+### v0.9.1 — active
 
-- k3dm-mcp planning, roadmap restructure (vCluster → v1.0.0 plugin, multi-cloud → v1.1.0), agent lessons
+- [ ] vCluster plugin — `scripts/plugins/vcluster.sh` (`vcluster_create/destroy/use/list`)
+- [ ] Playwright E2E in CI — `shopping-cart-infra` ephemeral vCluster per PR run
+- [ ] Spec: `docs/plans/v0.9.1-vcluster-plugin.md` (to be written)
 
-### Next — k3dm-mcp v0.1.0
+### Next after v0.9.1 — k3dm-mcp v1.0.0
 
 - Separate repo `~/src/gitrepo/personal/k3dm-mcp`
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -54,7 +54,8 @@
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
 - [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7`, BATS 8/8, shellcheck clean, audit PASS)
-- [ ] Gemini smoke test — `vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy` on infra cluster — **FAILED** (vcluster CLI missing, Issue `2026-03-15`)
+- [ ] `_vcluster_install_cli` helper — auto-install vcluster binary (macOS: brew, Linux: GitHub release) — **Codex task: `docs/plans/v0.9.1-vcluster-install-cli-task.md`**
+- [ ] Gemini smoke test — retry after `_vcluster_install_cli` ships
 - [ ] Copilot review comments addressed (PR #31 draft)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -54,7 +54,7 @@
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
 - [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7`, BATS 8/8, shellcheck clean, audit PASS)
-- [ ] Gemini smoke test — `vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy` on infra cluster
+- [ ] Gemini smoke test — `vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy` on infra cluster — **FAILED** (vcluster CLI missing, Issue `2026-03-15`)
 - [ ] Copilot review comments addressed (PR #31 draft)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -53,7 +53,7 @@
 - [x] `AGENTS.md` — agent session rules (read memory-bank, proof of work, no-revert, scope discipline)
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
-- [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7e2230d402f6436576f13c7e0ec6c64a97`, PR pending; `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i ... bats` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS)
+- [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `6020fc4c88df520c98d971051a415b1f40fe6edf`, PR pending; `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i ... bats` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -62,7 +62,7 @@
 - [x] Two-tier help — bare shows category summary, `--help` shows full list (commit `0fc68d5`)
 - [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
 - [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
-- [ ] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`
+- [x] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`; commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` pushed (verified via `gh api`); tests: `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`; lint: `shellcheck scripts/k3d-manager`; manual audit: `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`; doc: `docs/issues/2026-03-15-test-function-refactor.md`
 - [ ] Gemini smoke test — `./k3d-manager test all`, `--help`, vcluster_create/destroy/use on M2 Air
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -63,7 +63,7 @@
 - [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
 - [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
 - [x] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`; commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` pushed (verified via `gh api`); tests: `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`; lint: `shellcheck scripts/k3d-manager`; manual audit: `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`; doc: `docs/issues/2026-03-15-test-function-refactor.md`
-- [ ] Gemini smoke test — spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` — **FAILED** (Step 4: selector mismatch, Issue `2026-03-15`)
+- [ ] Gemini smoke test — **RETRY READY** — fixes: commit `45717e8` (selector + plugin help); Gemini to re-run vcluster steps on M2 Air
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -53,7 +53,9 @@
 - [x] `AGENTS.md` — agent session rules (read memory-bank, proof of work, no-revert, scope discipline)
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
-- [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `6020fc4c88df520c98d971051a415b1f40fe6edf`, PR pending; `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i ... bats` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS)
+- [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7`, BATS 8/8, shellcheck clean, audit PASS)
+- [ ] Gemini smoke test — `vcluster_create` → `vcluster_list` → `vcluster_use` → `vcluster_destroy` on infra cluster
+- [ ] Copilot review comments addressed (PR #31 draft)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -53,7 +53,7 @@
 - [x] `AGENTS.md` — agent session rules (read memory-bank, proof of work, no-revert, scope discipline)
 - [x] vCluster plugin spec — `docs/plans/v0.9.1-vcluster-plugin.md` (decisions recorded: v0.32.1, k8s distro, --print kubeconfig, 500m/512Mi limits)
 - [x] Codex task spec — `docs/plans/v0.9.1-vcluster-codex-task.md` (DoD checklist, do-not-do list)
-- [ ] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **assigned to Codex**
+- [x] vCluster plugin implementation — `scripts/plugins/vcluster.sh` + `scripts/etc/vcluster/values.yaml` + `scripts/tests/plugins/vcluster.bats` — **Codex** (commit `9be27b7e2230d402f6436576f13c7e0ec6c64a97`, PR pending; `bats scripts/tests/plugins/vcluster.bats` 8/8, `env -i ... bats` 8/8, `shellcheck scripts/plugins/vcluster.sh` clean, `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` PASS)
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -63,7 +63,7 @@
 - [x] `function test()` moved to dispatcher (unblocks audit; commit `0fc68d5`)
 - [x] Codex refactor spec — `docs/plans/v0.9.1-test-fn-refactor-task.md` (commit `916fa13`)
 - [x] Codex: refactor `function test()` if-count — spec at `docs/plans/v0.9.1-test-fn-refactor-task.md`; commit `79074e58fcc3b1a5410590b94585e8efe2a93a6a` pushed (verified via `gh api`); tests: `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test all`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager test --help`, `PATH="/opt/homebrew/bin:$PATH" ./scripts/k3d-manager --help`; lint: `shellcheck scripts/k3d-manager`; manual audit: `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/k3d-manager`; doc: `docs/issues/2026-03-15-test-function-refactor.md`
-- [ ] Gemini smoke test — `./k3d-manager test all`, `--help`, vcluster_create/destroy/use on M2 Air
+- [ ] Gemini smoke test — spec: `docs/plans/v0.9.1-gemini-smoke-test-task.md` — **READY TO ASSIGN**
 - [ ] Playwright E2E in CI — `shopping-cart-infra` — starts after vCluster plugin ships
 
 ### Next after v0.9.1 — k3dm-mcp v1.0.0

--- a/scripts/etc/vcluster/values.yaml
+++ b/scripts/etc/vcluster/values.yaml
@@ -1,0 +1,9 @@
+controlPlane:
+  statefulSet:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/scripts/k3d-manager
+++ b/scripts/k3d-manager
@@ -64,6 +64,196 @@ function register_shopping_cart_apps() {
     _try_load_plugin register_shopping_cart_apps "$@"
 }
 
+function _test_run_smoke() {
+    local bin_dir="$1"
+    local smoke_namespace="${2:-}"
+    local smoke_rc=0
+    local -a smoke_scripts=(
+        "smoke-test-jenkins.sh"
+        "test-openldap.sh"
+        "test-argocd-cli.sh"
+        "test-directory-auto-load.sh"
+    )
+
+    local script
+    for script in "${smoke_scripts[@]}"; do
+        local script_path="${bin_dir}/${script}"
+        if [[ ! -x "$script_path" ]]; then
+            continue
+        fi
+        printf '\n==> Running %s\n' "$script"
+        if [[ -n "$smoke_namespace" ]]; then
+            "$script_path" "$smoke_namespace" || smoke_rc=$?
+        else
+            "$script_path" || smoke_rc=$?
+        fi
+    done
+
+    return "$smoke_rc"
+}
+
+function _test_select_suite() {
+    local suite_spec="$1"
+    local tests_root="$2"
+    local tests_data="$3"
+    local -a _all_tests=()
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        _all_tests+=("$line")
+    done <<< "$tests_data"$'\n'
+    local -a _selected=()
+
+    case "$suite_spec" in
+        all)
+            _selected=("${_all_tests[@]}")
+            printf '%s\n' "${_selected[@]}"
+            return 0
+            ;;
+        lib|core|plugins)
+            local dir="${tests_root}/${suite_spec}"
+            while IFS= read -r test_file; do
+                _selected+=("$test_file")
+            done < <(find "$dir" -maxdepth 1 -type f -name '*.bats' | sort)
+            if [[ ${#_selected[@]} -eq 0 ]]; then
+                echo "No test suites found in '$suite_spec'." >&2
+                return 1
+            fi
+            printf '%s\n' "${_selected[@]}"
+            return 0
+            ;;
+    esac
+
+    local match_path=""
+    local test_file
+    for test_file in "${_all_tests[@]}"; do
+        local rel_with_ext="${test_file#"${tests_root}"/}"
+        local rel_without_ext="${rel_with_ext%.bats}"
+        local basename_no_ext="${test_file##*/}"
+        basename_no_ext="${basename_no_ext%.bats}"
+        if [[ "$basename_no_ext" == "$suite_spec" \
+           || "$rel_without_ext" == "$suite_spec" \
+           || "$rel_with_ext" == "$suite_spec" \
+           || "$test_file" == "$suite_spec" ]]; then
+            match_path="$test_file"
+            break
+        fi
+    done
+
+    if [[ -n "$match_path" ]]; then
+        _selected=("$match_path")
+        printf '%s\n' "${_selected[@]}"
+        return 0
+    fi
+
+    echo "No test suite matching '$suite_spec'. Available suites:" >&2
+    for test_file in "${_all_tests[@]}"; do
+        printf '  %s\n' "${test_file#"${tests_root}"/}" | sed 's/\.bats$//' >&2
+    done
+    return 1
+}
+
+function _test_execute() {
+    local selected_data="$1"
+    local bats_args_data="$2"
+    local suite_spec="$3"
+    local case_name="$4"
+    local repo_root="$5"
+    local -a _selected=()
+    local -a _bats_args=()
+
+    if [[ -n "$selected_data" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            _selected+=("$line")
+        done <<< "$selected_data"$'\n'
+    fi
+
+    if [[ -n "$bats_args_data" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            _bats_args+=("$line")
+        done <<< "$bats_args_data"$'\n'
+    fi
+
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "No test suites found." >&2
+        return 1
+    fi
+
+    local log_root="${repo_root}/scratch/test-logs"
+    local base_dir=""
+    local artifacts_dir=""
+    local log_file=""
+    local ran_with_logging=0
+    local status=0
+
+    if mkdir -p "$log_root" 2>/dev/null; then
+        local timestamp
+        timestamp="$(date +%Y%m%d-%H%M%S)"
+        local suite_slug
+        suite_slug="$(__slugify "$suite_spec" 12)"
+        base_dir="${log_root}/${suite_slug}"
+        if [[ -n "$case_name" ]]; then
+            local case_slug
+            case_slug="$(__slugify "$case_name" 6)"
+            if [[ -z "$case_slug" ]]; then
+                case_slug='case'
+            fi
+            local case_hash
+            case_hash=$(printf '%s' "$case_name" | sha256sum | cut -c1-4)
+            base_dir+="/${case_slug}-${case_hash}"
+        fi
+
+        if mkdir -p "$base_dir" 2>/dev/null; then
+            artifacts_dir="${base_dir}/${timestamp}"
+            _bats_args+=(--gather-test-outputs-in "$artifacts_dir")
+
+            log_file="${base_dir}/${timestamp}.log"
+            if : > "$log_file" 2>/dev/null; then
+                bats "${_bats_args[@]}" "${_selected[@]}" 2>&1 | tee "$log_file"
+                status=${PIPESTATUS[0]}
+                ran_with_logging=1
+            else
+                log_file=""
+            fi
+        else
+            base_dir=""
+        fi
+    fi
+
+    if (( ran_with_logging == 0 )); then
+        bats "${_bats_args[@]}" "${_selected[@]}"
+        status=$?
+    fi
+
+    if [[ $status -ne 0 ]]; then
+        if [[ -n "$log_file" ]]; then
+            local rel_log_file="${log_file#"${repo_root}"/}"
+            printf 'Test log saved to %s\n' "$rel_log_file" >&2
+        else
+            echo "Test log unavailable (failed to create log file)." >&2
+        fi
+        if [[ -n "$artifacts_dir" ]]; then
+            local rel_artifacts_dir="${artifacts_dir#"${repo_root}"/}"
+            printf 'Collected artifacts in %s\n' "$rel_artifacts_dir" >&2
+        fi
+    else
+        if [[ -n "$log_file" ]]; then
+            rm -f "$log_file" 2>/dev/null || true
+        fi
+        if [[ -n "$artifacts_dir" ]]; then
+            rm -rf "$artifacts_dir" 2>/dev/null || true
+            local prune_dir="$artifacts_dir"
+            while [[ "$prune_dir" != "$log_root" ]]; do
+                prune_dir="$(dirname "$prune_dir")"
+                rmdir "$prune_dir" 2>/dev/null || break
+            done
+        fi
+    fi
+
+    return "$status"
+}
+
 CLUSTER_ROLE="${CLUSTER_ROLE:-infra}"
 CLUSTER_ROLE="$(printf '%s' "$CLUSTER_ROLE" | tr '[:upper:]' '[:lower:]')"
 case "$CLUSTER_ROLE" in
@@ -156,31 +346,14 @@ function test() {
         fi
     fi
 
+    local repo_root
+    repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
     if [[ "$suite_spec" == "smoke" ]]; then
-        local repo_root
-        repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
         local bin_dir="${repo_root}/bin"
         local smoke_namespace="${positional[1]:-}"
-        local smoke_rc=0
-        local -a smoke_scripts=(
-            "smoke-test-jenkins.sh"
-            "test-openldap.sh"
-            "test-argocd-cli.sh"
-            "test-directory-auto-load.sh"
-        )
-        for script in "${smoke_scripts[@]}"; do
-            local script_path="${bin_dir}/${script}"
-            if [[ ! -x "$script_path" ]]; then
-                continue
-            fi
-            printf '\n==> Running %s\n' "$script"
-            if [[ -n "$smoke_namespace" ]]; then
-                "$script_path" "$smoke_namespace" || smoke_rc=$?
-            else
-                "$script_path" || smoke_rc=$?
-            fi
-        done
-        return $smoke_rc
+        _test_run_smoke "$bin_dir" "$smoke_namespace"
+        return $?
     fi
 
     _ensure_bats
@@ -203,129 +376,28 @@ function test() {
         bats_args+=(--filter "^${escaped_case}$")
     fi
 
-    local -a selected_tests=()
-
-    if [[ "$suite_spec" == "all" ]]; then
-        selected_tests=("${tests[@]}")
-    elif [[ "$suite_spec" == "lib" || "$suite_spec" == "core" || "$suite_spec" == "plugins" ]]; then
-        local dir="${tests_root}/${suite_spec}"
-        while IFS= read -r test_file; do
-            selected_tests+=("$test_file")
-        done < <(find "$dir" -maxdepth 1 -type f -name '*.bats' | sort)
-        if [[ ${#selected_tests[@]} -eq 0 ]]; then
-            echo "No test suites found in '$suite_spec'." >&2
-            return 1
-        fi
-    else
-        local match_found=0
-        local test_file
-        for test_file in "${tests[@]}"; do
-            local rel_with_ext
-            rel_with_ext="${test_file#${tests_root}/}"
-            local rel_without_ext
-            rel_without_ext="${rel_with_ext%.bats}"
-            local basename_no_ext
-            basename_no_ext="${test_file##*/}"
-            basename_no_ext="${basename_no_ext%.bats}"
-            if [[ "$basename_no_ext" == "$suite_spec" \
-               || "$rel_without_ext" == "$suite_spec" \
-               || "$rel_with_ext" == "$suite_spec" \
-               || "$test_file" == "$suite_spec" ]]; then
-                selected_tests=("$test_file")
-                match_found=1
-                break
-            fi
-        done
-        if [[ $match_found -eq 0 ]]; then
-            echo "No test suite matching '$suite_spec'. Available suites:" >&2
-            for test_file in "${tests[@]}"; do
-                printf '  %s\n' "${test_file#${tests_root}/}" | sed 's/\.bats$//' >&2
-            done
-            return 1
-        fi
+    local tests_serialized=""
+    if (( ${#tests[@]} )); then
+        tests_serialized="$(printf '%s\n' "${tests[@]}")"
     fi
 
-    if [[ ${#selected_tests[@]} -eq 0 ]]; then
+    local selected_serialized
+    if ! selected_serialized="$(_test_select_suite "$suite_spec" "$tests_root" "$tests_serialized")"; then
+        return 1
+    fi
+
+    if [[ -z "$selected_serialized" ]]; then
         echo "No test suites found." >&2
         return 1
     fi
 
-    local repo_root
-    repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
-    local log_root="${repo_root}/scratch/test-logs"
-    local base_dir=""
-    local artifacts_dir=""
-    local log_file=""
-    local ran_with_logging=0
-    local status
-
-    if mkdir -p "$log_root" 2>/dev/null; then
-        local timestamp
-        timestamp="$(date +%Y%m%d-%H%M%S)"
-        local suite_slug
-        suite_slug="$(__slugify "$suite_spec" 12)"
-        base_dir="${log_root}/${suite_slug}"
-        if [[ -n "$case_name" ]]; then
-            local case_slug
-            case_slug="$(__slugify "$case_name" 6)"
-            if [[ -z "$case_slug" ]]; then
-                case_slug='case'
-            fi
-            local case_hash
-            case_hash=$(printf '%s' "$case_name" | sha256sum | cut -c1-4)
-            base_dir+="/${case_slug}-${case_hash}"
-        fi
-
-        if mkdir -p "$base_dir" 2>/dev/null; then
-            artifacts_dir="${base_dir}/${timestamp}"
-            bats_args+=(--gather-test-outputs-in "$artifacts_dir")
-
-            log_file="${base_dir}/${timestamp}.log"
-            if : > "$log_file" 2>/dev/null; then
-                bats "${bats_args[@]}" "${selected_tests[@]}" 2>&1 | tee "$log_file"
-                status=${PIPESTATUS[0]}
-                ran_with_logging=1
-            else
-                log_file=""
-            fi
-        else
-            base_dir=""
-        fi
+    local bats_serialized=""
+    if (( ${#bats_args[@]} )); then
+        bats_serialized="$(printf '%s\n' "${bats_args[@]}")"
     fi
 
-    if (( ran_with_logging == 0 )); then
-        bats "${bats_args[@]}" "${selected_tests[@]}"
-        status=$?
-    fi
-
-    if [[ $status -ne 0 ]]; then
-        if [[ -n "$log_file" ]]; then
-            local rel_log_file="$log_file"
-            rel_log_file="${rel_log_file#${repo_root}/}"
-            printf 'Test log saved to %s\n' "$rel_log_file" >&2
-        else
-            echo "Test log unavailable (failed to create log file)." >&2
-        fi
-        if [[ -n "$artifacts_dir" ]]; then
-            local rel_artifacts_dir="$artifacts_dir"
-            rel_artifacts_dir="${rel_artifacts_dir#${repo_root}/}"
-            printf 'Collected artifacts in %s\n' "$rel_artifacts_dir" >&2
-        fi
-    else
-        if [[ -n "$log_file" ]]; then
-            rm -f "$log_file" 2>/dev/null || true
-        fi
-        if [[ -n "$artifacts_dir" ]]; then
-            rm -rf "$artifacts_dir" 2>/dev/null || true
-            local prune_dir="$artifacts_dir"
-            while [[ "$prune_dir" != "$log_root" ]]; do
-                prune_dir="$(dirname "$prune_dir")"
-                rmdir "$prune_dir" 2>/dev/null || break
-            done
-        fi
-    fi
-
-    return $status
+    _test_execute "$selected_serialized" "$bats_serialized" "$suite_spec" "$case_name" "$repo_root"
+    return $?
 }
 
 ## -- main --

--- a/scripts/k3d-manager
+++ b/scripts/k3d-manager
@@ -90,11 +90,253 @@ elif [[ -n "${K3D_MANAGER_PROVIDER:-}" ]]; then
     fi
 fi
 
+function test() {
+    local verbose=0
+    local case_name=""
+    local -a positional=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                __print_test_usage
+                return 0
+                ;;
+            -v|--verbose)
+                verbose=1
+                shift
+                continue
+                ;;
+            --case)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    echo "Missing value for --case." >&2
+                    return 1
+                fi
+                case_name="$1"
+                shift
+                continue
+                ;;
+            --)
+                shift
+                positional+=("$@")
+                break
+                ;;
+            -*)
+                echo "Unknown option: $1" >&2
+                return 1
+                ;;
+            *)
+                positional+=("$1")
+                shift
+                continue
+                ;;
+        esac
+    done
+
+    if [[ ${#positional[@]} -eq 0 ]]; then
+        __print_test_usage >&2
+        return 1
+    fi
+
+    if [[ ${#positional[@]} -gt 1 && "${positional[0]}" != "smoke" ]]; then
+        echo "Only one suite or test may be specified." >&2
+        return 1
+    fi
+
+    local suite_spec="${positional[0]}"
+    if [[ "$suite_spec" == *"::"* ]]; then
+        local inline_case="${suite_spec#*::}"
+        suite_spec="${suite_spec%%::*}"
+        if [[ -z "$inline_case" ]]; then
+            echo "Missing test case name in '${positional[0]}'." >&2
+            return 1
+        fi
+        if [[ -z "$case_name" ]]; then
+            case_name="$inline_case"
+        fi
+    fi
+
+    if [[ "$suite_spec" == "smoke" ]]; then
+        local repo_root
+        repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+        local bin_dir="${repo_root}/bin"
+        local smoke_namespace="${positional[1]:-}"
+        local smoke_rc=0
+        local -a smoke_scripts=(
+            "smoke-test-jenkins.sh"
+            "test-openldap.sh"
+            "test-argocd-cli.sh"
+            "test-directory-auto-load.sh"
+        )
+        for script in "${smoke_scripts[@]}"; do
+            local script_path="${bin_dir}/${script}"
+            if [[ ! -x "$script_path" ]]; then
+                continue
+            fi
+            printf '\n==> Running %s\n' "$script"
+            if [[ -n "$smoke_namespace" ]]; then
+                "$script_path" "$smoke_namespace" || smoke_rc=$?
+            else
+                "$script_path" || smoke_rc=$?
+            fi
+        done
+        return $smoke_rc
+    fi
+
+    _ensure_bats
+
+    local tests_root="${SCRIPT_DIR}/tests"
+    local -a search_dirs=("${tests_root}/lib" "${tests_root}/core" "${tests_root}/plugins")
+    local -a tests=()
+    while IFS= read -r test_file; do
+        tests+=("$test_file")
+    done < <(find "${search_dirs[@]}" -maxdepth 1 -type f -name '*.bats' | sort)
+
+    local -a bats_args=()
+    if (( verbose )); then
+        bats_args+=(--show-output-of-passing-tests --print-output-on-failure)
+    fi
+
+    if [[ -n "$case_name" ]]; then
+        local escaped_case
+        escaped_case="$(__escape_regex_literal "$case_name")"
+        bats_args+=(--filter "^${escaped_case}$")
+    fi
+
+    local -a selected_tests=()
+
+    if [[ "$suite_spec" == "all" ]]; then
+        selected_tests=("${tests[@]}")
+    elif [[ "$suite_spec" == "lib" || "$suite_spec" == "core" || "$suite_spec" == "plugins" ]]; then
+        local dir="${tests_root}/${suite_spec}"
+        while IFS= read -r test_file; do
+            selected_tests+=("$test_file")
+        done < <(find "$dir" -maxdepth 1 -type f -name '*.bats' | sort)
+        if [[ ${#selected_tests[@]} -eq 0 ]]; then
+            echo "No test suites found in '$suite_spec'." >&2
+            return 1
+        fi
+    else
+        local match_found=0
+        local test_file
+        for test_file in "${tests[@]}"; do
+            local rel_with_ext
+            rel_with_ext="${test_file#${tests_root}/}"
+            local rel_without_ext
+            rel_without_ext="${rel_with_ext%.bats}"
+            local basename_no_ext
+            basename_no_ext="${test_file##*/}"
+            basename_no_ext="${basename_no_ext%.bats}"
+            if [[ "$basename_no_ext" == "$suite_spec" \
+               || "$rel_without_ext" == "$suite_spec" \
+               || "$rel_with_ext" == "$suite_spec" \
+               || "$test_file" == "$suite_spec" ]]; then
+                selected_tests=("$test_file")
+                match_found=1
+                break
+            fi
+        done
+        if [[ $match_found -eq 0 ]]; then
+            echo "No test suite matching '$suite_spec'. Available suites:" >&2
+            for test_file in "${tests[@]}"; do
+                printf '  %s\n' "${test_file#${tests_root}/}" | sed 's/\.bats$//' >&2
+            done
+            return 1
+        fi
+    fi
+
+    if [[ ${#selected_tests[@]} -eq 0 ]]; then
+        echo "No test suites found." >&2
+        return 1
+    fi
+
+    local repo_root
+    repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+    local log_root="${repo_root}/scratch/test-logs"
+    local base_dir=""
+    local artifacts_dir=""
+    local log_file=""
+    local ran_with_logging=0
+    local status
+
+    if mkdir -p "$log_root" 2>/dev/null; then
+        local timestamp
+        timestamp="$(date +%Y%m%d-%H%M%S)"
+        local suite_slug
+        suite_slug="$(__slugify "$suite_spec" 12)"
+        base_dir="${log_root}/${suite_slug}"
+        if [[ -n "$case_name" ]]; then
+            local case_slug
+            case_slug="$(__slugify "$case_name" 6)"
+            if [[ -z "$case_slug" ]]; then
+                case_slug='case'
+            fi
+            local case_hash
+            case_hash=$(printf '%s' "$case_name" | sha256sum | cut -c1-4)
+            base_dir+="/${case_slug}-${case_hash}"
+        fi
+
+        if mkdir -p "$base_dir" 2>/dev/null; then
+            artifacts_dir="${base_dir}/${timestamp}"
+            bats_args+=(--gather-test-outputs-in "$artifacts_dir")
+
+            log_file="${base_dir}/${timestamp}.log"
+            if : > "$log_file" 2>/dev/null; then
+                bats "${bats_args[@]}" "${selected_tests[@]}" 2>&1 | tee "$log_file"
+                status=${PIPESTATUS[0]}
+                ran_with_logging=1
+            else
+                log_file=""
+            fi
+        else
+            base_dir=""
+        fi
+    fi
+
+    if (( ran_with_logging == 0 )); then
+        bats "${bats_args[@]}" "${selected_tests[@]}"
+        status=$?
+    fi
+
+    if [[ $status -ne 0 ]]; then
+        if [[ -n "$log_file" ]]; then
+            local rel_log_file="$log_file"
+            rel_log_file="${rel_log_file#${repo_root}/}"
+            printf 'Test log saved to %s\n' "$rel_log_file" >&2
+        else
+            echo "Test log unavailable (failed to create log file)." >&2
+        fi
+        if [[ -n "$artifacts_dir" ]]; then
+            local rel_artifacts_dir="$artifacts_dir"
+            rel_artifacts_dir="${rel_artifacts_dir#${repo_root}/}"
+            printf 'Collected artifacts in %s\n' "$rel_artifacts_dir" >&2
+        fi
+    else
+        if [[ -n "$log_file" ]]; then
+            rm -f "$log_file" 2>/dev/null || true
+        fi
+        if [[ -n "$artifacts_dir" ]]; then
+            rm -rf "$artifacts_dir" 2>/dev/null || true
+            local prune_dir="$artifacts_dir"
+            while [[ "$prune_dir" != "$log_root" ]]; do
+                prune_dir="$(dirname "$prune_dir")"
+                rmdir "$prune_dir" 2>/dev/null || break
+            done
+        fi
+    fi
+
+    return $status
+}
+
 ## -- main --
 if [[ $# -eq 0 ]]; then
     _usage
     exit 0
 fi
+
+case "$1" in
+  -h|--help) _usage 1; exit 0 ;;
+esac
 
 function_name=$1
 shift  # Remove the function name from the arguments

--- a/scripts/lib/help/utils.sh
+++ b/scripts/lib/help/utils.sh
@@ -105,7 +105,7 @@ function _usage() {
       "Testing"            "test test_*"
     )
 
-    _match_category() {
+    __usage_match_category() {
       local pats="$1"
       local -a matches=()
       local fn pat
@@ -121,7 +121,7 @@ function _usage() {
       printf '%s\n' "${matches[@]}"
     }
 
-    printf 'Usage: ./k3d-manager <function> [args]\n\n'
+    printf 'Usage: ./scripts/k3d-manager <function> [args]\n\n'
 
     if [[ "$verbose" == "1" ]]; then
       printf 'Available functions:\n'
@@ -132,7 +132,7 @@ function _usage() {
         local -a matches=()
         while IFS= read -r fn; do
           [[ -n "$fn" ]] && matches+=("$fn")
-        done < <(_match_category "$pats")
+        done < <(__usage_match_category "$pats")
         if [[ ${#matches[@]} -gt 0 ]]; then
           printf '  %s:\n' "$label"
           printf '    %s\n' "${matches[@]}"
@@ -163,12 +163,12 @@ EOF
       for (( i=0; i<${#categories[@]}; i+=2 )); do
         label="${categories[$i]}"
         pats="${categories[$i+1]}"
-        count=$(_match_category "$pats" | grep -c .)  || count=0
+        count=$(__usage_match_category "$pats" | grep -c .)  || count=0
         if (( count > 0 )); then
           printf '  %-22s (%d functions)\n' "$label" "$count"
         fi
       done
-      printf '\nRun ./k3d-manager --help for full function list.\n'
+      printf '\nRun ./scripts/k3d-manager --help for full function list.\n'
     fi
 }
 

--- a/scripts/lib/help/utils.sh
+++ b/scripts/lib/help/utils.sh
@@ -78,67 +78,90 @@ function __discover_tests() {
 }
 
 function _usage() {
-    local base_suites="all|lib|core|plugins|smoke"
-    if [[ -n "${test_suites}" ]]; then
-        test_suites="${base_suites}|${test_suites}"
-    else
-        test_suites="${base_suites}"
-    fi
+    local verbose="${1:-0}"
 
-    local provider="${CLUSTER_PROVIDER:-$(_default_cluster_provider)}"
+    local -a all_fns=()
+    while IFS= read -r fn; do
+      all_fns+=("$fn")
+    done < <(declare -F | awk '{print $3}' | grep -v '^_' | sort)
 
-    local -a __tests=()
-    local -a __test_names=()
-    local -a __suite_names=()
-    __discover_tests __tests __test_names __suite_names
+    # Build category lists: label, patterns...
+    local -a categories=(
+      "Cluster lifecycle"  "create_* deploy_cluster deploy_k3d_cluster deploy_k3s_cluster destroy_*"
+      "Infrastructure"     "deploy_vault deploy_eso deploy_ldap deploy_jenkins configure_vault_*"
+      "Secrets"            "secret_backend_*"
+      "Directory service"  "dirservice_*"
+      "Networking"         "*ingress*"
+      "vCluster"           "vcluster_*"
+      "Shopping cart"      "add_ubuntu_k3s_cluster register_shopping_cart_apps"
+      "Testing"            "test test_*"
+    )
 
-    local provider="${CLUSTER_PROVIDER:-$(_default_cluster_provider)}"
+    _match_category() {
+      local pats="$1"
+      local -a matches=()
+      local fn pat
+      for fn in "${all_fns[@]}"; do
+        for pat in $pats; do
+          # shellcheck disable=SC2053
+          if [[ "$fn" == $pat ]]; then
+            matches+=("$fn")
+            break
+          fi
+        done
+      done
+      printf '%s\n' "${matches[@]}"
+    }
 
-    local test_synopsis="suite|test-name"
-    if [[ ${#__suite_names[@]} -gt 0 || ${#__test_names[@]} -gt 0 ]]; then
-        local -a synopsis_tokens=()
-        if [[ ${#__suite_names[@]} -gt 0 ]]; then
-            synopsis_tokens+=("${__suite_names[@]}")
+    printf 'Usage: ./k3d-manager <function> [args]\n\n'
+
+    if [[ "$verbose" == "1" ]]; then
+      printf 'Available functions:\n'
+      local i label pats
+      for (( i=0; i<${#categories[@]}; i+=2 )); do
+        label="${categories[$i]}"
+        pats="${categories[$i+1]}"
+        local -a matches=()
+        while IFS= read -r fn; do
+          [[ -n "$fn" ]] && matches+=("$fn")
+        done < <(_match_category "$pats")
+        if [[ ${#matches[@]} -gt 0 ]]; then
+          printf '  %s:\n' "$label"
+          printf '    %s\n' "${matches[@]}"
         fi
-        if [[ ${#__test_names[@]} -gt 0 ]]; then
-            synopsis_tokens+=("${__test_names[@]}")
-        fi
-        local joined_synopsis="$( ___join_lines '|' "${synopsis_tokens[@]}" )"
-        if [[ -n "$joined_synopsis" ]]; then
-            test_synopsis="$joined_synopsis"
-        fi
-    fi
+      done
 
-    local suites_summary=""
-    if [[ ${#__suite_names[@]} -gt 0 ]]; then
-        suites_summary="$( ___join_lines ', ' "${__suite_names[@]}" )"
-    fi
+      local provider="${CLUSTER_PROVIDER:-$(_default_cluster_provider)}"
+      local base_suites="all|lib|core|plugins|smoke"
+      local -a __suite_names=()
+      local -a __tests=() __test_names=()
+      __discover_tests __tests __test_names __suite_names
 
-    local tests_summary=""
-    if [[ ${#__test_names[@]} -gt 0 ]]; then
-        tests_summary="$( ___join_lines ', ' "${__test_names[@]}" )"
-    fi
-
-    cat <<EOF
-Usage: ./k3d-manager <function> [args]
-
-Available core functions:
-$(declare -F | awk '{print $3}' | grep -v '^_' | sort | sed 's/^/  /')
-
-EOF
-
-    cat <<EOF
+      cat <<EOF
 
 Cluster provider:
   Current: ${provider}
-  Override by exporting CLUSTER_PROVIDER (macOS auto-detects OrbStack when running, otherwise defaults to k3d).
+  Override: export CLUSTER_PROVIDER=k3d|orbstack|k3s
 
 Subcommands:
-  test [options] ${test_suites}   Run BATS tests (see "test --help")
+  test [options] ${base_suites}   Run BATS tests (see "test --help")
 
 Environment variables:
   CLUSTER_ROLE=infra|app   Select deployment profile (default: infra)
 EOF
+    else
+      printf 'Categories:\n'
+      local i label pats count
+      for (( i=0; i<${#categories[@]}; i+=2 )); do
+        label="${categories[$i]}"
+        pats="${categories[$i+1]}"
+        count=$(_match_category "$pats" | grep -c .)  || count=0
+        if (( count > 0 )); then
+          printf '  %-22s (%d functions)\n' "$label" "$count"
+        fi
+      done
+      printf '\nRun ./k3d-manager --help for full function list.\n'
+    fi
 }
 
 function __escape_regex_literal() {
@@ -221,240 +244,6 @@ Available tests: ${tests_summary}
 EOF
 }
 
-function test() {
-    local verbose=0
-    local case_name=""
-    local -a positional=()
-
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            -h|--help)
-                __print_test_usage
-                return 0
-                ;;
-            -v|--verbose)
-                verbose=1
-                shift
-                continue
-                ;;
-            --case)
-                shift
-                if [[ -z "${1:-}" ]]; then
-                    echo "Missing value for --case." >&2
-                    return 1
-                fi
-                case_name="$1"
-                shift
-                continue
-                ;;
-            --)
-                shift
-                positional+=("$@")
-                break
-                ;;
-            -*)
-                echo "Unknown option: $1" >&2
-                return 1
-                ;;
-            *)
-                positional+=("$1")
-                shift
-                continue
-                ;;
-        esac
-    done
-
-    if [[ ${#positional[@]} -eq 0 ]]; then
-        __print_test_usage >&2
-        return 1
-    fi
-
-    if [[ ${#positional[@]} -gt 1 && "${positional[0]}" != "smoke" ]]; then
-        echo "Only one suite or test may be specified." >&2
-        return 1
-    fi
-
-    local suite_spec="${positional[0]}"
-    if [[ "$suite_spec" == *"::"* ]]; then
-        local inline_case="${suite_spec#*::}"
-        suite_spec="${suite_spec%%::*}"
-        if [[ -z "$inline_case" ]]; then
-            echo "Missing test case name in '${positional[0]}'." >&2
-            return 1
-        fi
-        if [[ -z "$case_name" ]]; then
-            case_name="$inline_case"
-        fi
-    fi
-
-    if [[ "$suite_spec" == "smoke" ]]; then
-        local repo_root
-        repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
-        local bin_dir="${repo_root}/bin"
-        local smoke_namespace="${positional[1]:-}"
-        local smoke_rc=0
-        local -a smoke_scripts=(
-            "smoke-test-jenkins.sh"
-            "test-openldap.sh"
-            "test-argocd-cli.sh"
-            "test-directory-auto-load.sh"
-        )
-        for script in "${smoke_scripts[@]}"; do
-            local script_path="${bin_dir}/${script}"
-            if [[ ! -x "$script_path" ]]; then
-                continue
-            fi
-            printf '\n==> Running %s\n' "$script"
-            if [[ -n "$smoke_namespace" ]]; then
-                "$script_path" "$smoke_namespace" || smoke_rc=$?
-            else
-                "$script_path" || smoke_rc=$?
-            fi
-        done
-        return $smoke_rc
-    fi
-
-    _ensure_bats
-
-    local tests_root="${SCRIPT_DIR}/tests"
-    local -a search_dirs=("${tests_root}/lib" "${tests_root}/core" "${tests_root}/plugins")
-    local -a tests=()
-    while IFS= read -r test_file; do
-        tests+=("$test_file")
-    done < <(find "${search_dirs[@]}" -maxdepth 1 -type f -name '*.bats' | sort)
-
-    local -a bats_args=()
-    if (( verbose )); then
-        bats_args+=(--show-output-of-passing-tests --print-output-on-failure)
-    fi
-
-    if [[ -n "$case_name" ]]; then
-        local escaped_case
-        escaped_case="$( __escape_regex_literal "$case_name" )"
-        bats_args+=(--filter "^${escaped_case}$")
-    fi
-
-    local -a selected_tests=()
-
-    if [[ "$suite_spec" == "all" ]]; then
-        selected_tests=("${tests[@]}")
-    elif [[ "$suite_spec" == "lib" || "$suite_spec" == "core" || "$suite_spec" == "plugins" ]]; then
-        local dir="${tests_root}/${suite_spec}"
-        while IFS= read -r test_file; do
-            selected_tests+=("$test_file")
-        done < <(find "$dir" -maxdepth 1 -type f -name '*.bats' | sort)
-        if [[ ${#selected_tests[@]} -eq 0 ]]; then
-            echo "No test suites found in '$suite_spec'." >&2
-            return 1
-        fi
-    else
-        local match_found=0
-        local test_file
-        for test_file in "${tests[@]}"; do
-            local rel_with_ext
-            rel_with_ext="${test_file#${tests_root}/}"
-            local rel_without_ext
-            rel_without_ext="${rel_with_ext%.bats}"
-            local basename_no_ext
-            basename_no_ext="${test_file##*/}"
-            basename_no_ext="${basename_no_ext%.bats}"
-            if [[ "$basename_no_ext" == "$suite_spec" \
-               || "$rel_without_ext" == "$suite_spec" \
-               || "$rel_with_ext" == "$suite_spec" \
-               || "$test_file" == "$suite_spec" ]]; then
-                selected_tests=("$test_file")
-                match_found=1
-                break
-            fi
-        done
-        if [[ $match_found -eq 0 ]]; then
-            echo "No test suite matching '$suite_spec'. Available suites:" >&2
-            for test_file in "${tests[@]}"; do
-                printf '  %s\n' "${test_file#${tests_root}/}" | sed 's/\.bats$//' >&2
-            done
-            return 1
-        fi
-    fi
-
-    if [[ ${#selected_tests[@]} -eq 0 ]]; then
-        echo "No test suites found." >&2
-        return 1
-    fi
-
-    local repo_root
-    repo_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
-    local log_root="${repo_root}/scratch/test-logs"
-    local base_dir=""
-    local artifacts_dir=""
-    local log_file=""
-    local ran_with_logging=0
-    local status
-
-    if mkdir -p "$log_root" 2>/dev/null; then
-        local timestamp
-        timestamp="$(date +%Y%m%d-%H%M%S)"
-        local suite_slug
-        suite_slug="$( __slugify "$suite_spec" 12 )"
-        base_dir="${log_root}/${suite_slug}"
-        if [[ -n "$case_name" ]]; then
-            local case_slug
-            case_slug="$( __slugify "$case_name" 6 )"
-            if [[ -z "$case_slug" ]]; then
-                case_slug='case'
-            fi
-            local case_hash
-            case_hash=$(printf '%s' "$case_name" | sha256sum | cut -c1-4)
-            base_dir+="/${case_slug}-${case_hash}"
-        fi
-
-        if mkdir -p "$base_dir" 2>/dev/null; then
-            artifacts_dir="${base_dir}/${timestamp}"
-            bats_args+=(--gather-test-outputs-in "$artifacts_dir")
-
-            log_file="${base_dir}/${timestamp}.log"
-            if : > "$log_file" 2>/dev/null; then
-                bats "${bats_args[@]}" "${selected_tests[@]}" 2>&1 | tee "$log_file"
-                status=${PIPESTATUS[0]}
-                ran_with_logging=1
-            else
-                log_file=""
-            fi
-        else
-            base_dir=""
-        fi
-    fi
-
-    if (( ran_with_logging == 0 )); then
-        bats "${bats_args[@]}" "${selected_tests[@]}"
-        status=$?
-    fi
-
-    if [[ $status -ne 0 ]]; then
-        if [[ -n "$log_file" ]]; then
-            local rel_log_file="$log_file"
-            rel_log_file="${rel_log_file#${repo_root}/}"
-            printf 'Test log saved to %s\n' "$rel_log_file" >&2
-        else
-            echo "Test log unavailable (failed to create log file)." >&2
-        fi
-        if [[ -n "$artifacts_dir" ]]; then
-            local rel_artifacts_dir="$artifacts_dir"
-            rel_artifacts_dir="${rel_artifacts_dir#${repo_root}/}"
-            printf 'Collected artifacts in %s\n' "$rel_artifacts_dir" >&2
-        fi
-    else
-        if [[ -n "$log_file" ]]; then
-            rm -f "$log_file" 2>/dev/null || true
-        fi
-        if [[ -n "$artifacts_dir" ]]; then
-            rm -rf "$artifacts_dir" 2>/dev/null || true
-            local prune_dir="$artifacts_dir"
-            while [[ "$prune_dir" != "$log_root" ]]; do
-                prune_dir="$(dirname "$prune_dir")"
-                rmdir "$prune_dir" 2>/dev/null || break
-            done
-        fi
-    fi
-
-    return $status
-}
+# function test() has been moved to scripts/k3d-manager (dispatcher)
+# Reason: CLI entrypoint belongs in the dispatcher, not a utility library.
+# Refactor tracking: docs/plans/v0.9.1-test-fn-refactor-task.md

--- a/scripts/lib/help/utils.sh
+++ b/scripts/lib/help/utils.sh
@@ -83,7 +83,15 @@ function _usage() {
     local -a all_fns=()
     while IFS= read -r fn; do
       all_fns+=("$fn")
-    done < <(declare -F | awk '{print $3}' | grep -v '^_' | sort)
+    done < <(
+      {
+        declare -F | awk '{print $3}' | grep -v '^_'
+        if [[ -d "${PLUGINS_DIR:-}" ]]; then
+          grep -h "^function [a-z]" "${PLUGINS_DIR}"/*.sh 2>/dev/null \
+            | awk '{print $2}' | sed 's/().*//'
+        fi
+      } | sort -u
+    )
 
     # Build category lists: label, patterns...
     local -a categories=(

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VCLUSTER_NAMESPACE="${VCLUSTER_NAMESPACE:-vclusters}"
+VCLUSTER_VERSION="${VCLUSTER_VERSION:-0.32.1}"
+VCLUSTER_KUBECONFIG_DIR="${VCLUSTER_KUBECONFIG_DIR:-${HOME}/.kube/vclusters}"
+export VCLUSTER_NAMESPACE
+export VCLUSTER_VERSION
+export VCLUSTER_KUBECONFIG_DIR
+
+function vcluster_create() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "Usage: vcluster_create <name>"
+  fi
+
+  _vcluster_check_prerequisites
+  local values_file
+  values_file="$(_vcluster_values_file)"
+  local target_kubeconfig
+  target_kubeconfig="$(_vcluster_kubeconfig_path "$name")"
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf 'DRY_RUN: vcluster create %s in namespace %s (chart %s)\n' "$name" "$VCLUSTER_NAMESPACE" "$VCLUSTER_VERSION"
+    printf 'DRY_RUN: kubeconfig will be written to %s\n' "$target_kubeconfig"
+    return 0
+  fi
+
+  _run_command -- vcluster create "$name" -n "$VCLUSTER_NAMESPACE" \
+    --chart-version "$VCLUSTER_VERSION" --connect=false -f "$values_file"
+  _vcluster_wait_ready "$name"
+  _vcluster_export_kubeconfig "$name"
+  _info "vCluster '$name' created; run ./scripts/k3d-manager vcluster_use $name to switch context"
+}
+
+function vcluster_destroy() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "Usage: vcluster_destroy <name>"
+  fi
+
+  _vcluster_check_prerequisites
+  _vcluster_ensure_exists "$name"
+  local kubeconfig_path
+  kubeconfig_path="$(_vcluster_kubeconfig_path "$name")"
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf 'DRY_RUN: vcluster delete %s in namespace %s\n' "$name" "$VCLUSTER_NAMESPACE"
+    printf 'DRY_RUN: kubeconfig %s would be removed\n' "$kubeconfig_path"
+    return 0
+  fi
+
+  _run_command -- vcluster delete "$name" -n "$VCLUSTER_NAMESPACE" --delete-namespace --wait
+  if [[ -f "$kubeconfig_path" ]]; then
+    _run_command -- rm -f "$kubeconfig_path"
+  fi
+  _info "Deleted vCluster '$name'"
+}
+
+function vcluster_use() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "Usage: vcluster_use <name>"
+  fi
+
+  _vcluster_check_prerequisites
+
+  local kubeconfig
+  kubeconfig="$(_vcluster_kubeconfig_path "$name")"
+  if [[ ! -f "$kubeconfig" ]]; then
+    _err "kubeconfig for vCluster '$name' not found at $kubeconfig"
+  fi
+
+  local base_config
+  if [[ -n "${KUBECONFIG:-}" ]]; then
+    IFS=':' read -r base_config _ <<< "${KUBECONFIG}"
+  else
+    base_config="${HOME}/.kube/config"
+  fi
+  if [[ -z "$base_config" ]]; then
+    base_config="${HOME}/.kube/config"
+  fi
+
+  local base_dir=""
+  if [[ "$base_config" == */* ]]; then
+    base_dir="${base_config%/*}"
+  else
+    base_dir="."
+  fi
+  if [[ -z "$base_dir" ]]; then
+    base_dir="/"
+  fi
+  _run_command -- mkdir -p "$base_dir"
+
+  local merged=""
+  if [[ -f "$base_config" ]]; then
+    merged="$(
+      _run_command -- env KUBECONFIG="${kubeconfig}:${base_config}" kubectl config view --flatten
+    )"
+  else
+    merged="$(cat "$kubeconfig")"
+  fi
+  printf '%s\n' "$merged" > "$base_config"
+  export KUBECONFIG="$base_config"
+
+  local context
+  context="$(_vcluster_context_from_file "$kubeconfig")"
+  if [[ -n "$context" ]]; then
+    _run_command -- kubectl config use-context "$context"
+    _info "Active context: $context"
+  else
+    _warn "Unable to detect vCluster context from $kubeconfig"
+  fi
+}
+
+function vcluster_list() {
+  _vcluster_check_prerequisites
+  _run_command -- vcluster list -n "$VCLUSTER_NAMESPACE"
+}
+
+function _vcluster_check_prerequisites() {
+  if ! command -v vcluster >/dev/null 2>&1; then
+    _err "vcluster CLI is not installed; see https://github.com/loft-sh/vcluster"
+  fi
+  if ! _kubectl --no-exit --quiet cluster-info >/dev/null 2>&1; then
+    _err "Host cluster context not available; kubectl cluster-info failed"
+  fi
+}
+
+function _vcluster_wait_ready() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "vCluster name required"
+  fi
+  local selector="app.kubernetes.io/name=vcluster,app.kubernetes.io/instance=${name}"
+  _kubectl -n "$VCLUSTER_NAMESPACE" wait --for=condition=Ready --timeout=300s pod -l "$selector"
+}
+
+function _vcluster_export_kubeconfig() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "vCluster name required"
+  fi
+  _run_command -- mkdir -p "$VCLUSTER_KUBECONFIG_DIR"
+  local kubeconfig
+  kubeconfig="$(_vcluster_kubeconfig_path "$name")"
+  local config
+  config="$(_run_command -- vcluster connect "$name" -n "$VCLUSTER_NAMESPACE" --print)"
+  printf '%s\n' "$config" > "$kubeconfig"
+  _run_command -- chmod 600 "$kubeconfig"
+  _info "Kubeconfig written to $kubeconfig"
+}
+
+function _vcluster_values_file() {
+  local file="${SCRIPT_DIR}/etc/vcluster/values.yaml"
+  if [[ ! -f "$file" ]]; then
+    _err "vCluster values file not found at $file"
+  fi
+  printf '%s\n' "$file"
+}
+
+function _vcluster_kubeconfig_path() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "vCluster name required"
+  fi
+  printf '%s/%s.yaml\n' "$VCLUSTER_KUBECONFIG_DIR" "$name"
+}
+
+function _vcluster_ensure_exists() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    _err "vCluster name required"
+  fi
+  local kubeconfig
+  kubeconfig="$(
+    _vcluster_kubeconfig_path "$name"
+  )"
+  if [[ -f "$kubeconfig" ]]; then
+    return 0
+  fi
+  local list_output=""
+  if ! list_output="$(_run_command --no-exit --quiet -- vcluster list -n "$VCLUSTER_NAMESPACE")"; then
+    _err "vCluster '$name' not found in namespace '$VCLUSTER_NAMESPACE'"
+  fi
+  if [[ "$list_output" != *"$name"* ]]; then
+    _err "vCluster '$name' not found in namespace '$VCLUSTER_NAMESPACE'"
+  fi
+}
+
+function _vcluster_context_from_file() {
+  local file="${1:-}"
+  if [[ -z "$file" || ! -f "$file" ]]; then
+    return 1
+  fi
+  local line context=""
+  while IFS= read -r line; do
+    case "$line" in
+      current-context:*)
+        context="${line#current-context:}"
+        while [[ "${context:0:1}" == ' ' || "${context:0:1}" == $'\t' ]]; do
+          context="${context:1}"
+        done
+        break
+        ;;
+    esac
+  done < "$file"
+  printf '%s' "$context"
+}

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -193,8 +193,8 @@ function _vcluster_kubeconfig_path() {
   if [[ -z "$name" ]]; then
     _err "vCluster name required"
   fi
-  if [[ "$name" == */* || "$name" == *..* ]]; then
-    _err "vCluster name must not contain '/' or '..': $name"
+  if [[ ! "$name" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+    _err "vCluster name must be a valid DNS label (lowercase alphanumeric and hyphens, no leading/trailing hyphen): $name"
   fi
   printf '%s/%s.yaml\n' "$VCLUSTER_KUBECONFIG_DIR" "$name"
 }

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -162,7 +162,7 @@ function _vcluster_wait_ready() {
   if [[ -z "$name" ]]; then
     _err "vCluster name required"
   fi
-  local selector="app.kubernetes.io/name=vcluster,app.kubernetes.io/instance=${name}"
+  local selector="app=vcluster,release=${name}"
   _kubectl -n "$VCLUSTER_NAMESPACE" wait --for=condition=Ready --timeout=300s pod -l "$selector"
 }
 

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -4,9 +4,11 @@ set -euo pipefail
 VCLUSTER_NAMESPACE="${VCLUSTER_NAMESPACE:-vclusters}"
 VCLUSTER_VERSION="${VCLUSTER_VERSION:-0.32.1}"
 VCLUSTER_KUBECONFIG_DIR="${VCLUSTER_KUBECONFIG_DIR:-${HOME}/.kube/vclusters}"
+VCLUSTER_INSTALL_DIR="${VCLUSTER_INSTALL_DIR:-/usr/local/bin}"
 export VCLUSTER_NAMESPACE
 export VCLUSTER_VERSION
 export VCLUSTER_KUBECONFIG_DIR
+export VCLUSTER_INSTALL_DIR
 
 function vcluster_create() {
   local name="${1:-}"
@@ -118,9 +120,36 @@ function vcluster_list() {
   _run_command -- vcluster list -n "$VCLUSTER_NAMESPACE"
 }
 
+function _vcluster_install_cli() {
+  if _command_exist vcluster; then
+    _info "vcluster already installed, skipping"
+    return 0
+  fi
+
+  if _is_mac; then
+    _run_command --prefer-sudo -- brew install loft-sh/tap/vcluster
+  else
+    local install_dir="${VCLUSTER_INSTALL_DIR:-/usr/local/bin}"
+    local tmp_file
+    tmp_file="$(mktemp -t vcluster-cli.XXXXXX)"
+    trap '$(_cleanup_trap_command "$tmp_file")' RETURN
+    local url="https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/vcluster-linux-amd64"
+    _run_command -- curl -fsSL -o "$tmp_file" "$url"
+    _run_command -- chmod +x "$tmp_file"
+    _run_command --prefer-sudo -- mkdir -p "$install_dir"
+    _run_command --prefer-sudo -- mv "$tmp_file" "${install_dir%/}/vcluster"
+    trap - RETURN
+  fi
+
+  if ! _command_exist vcluster; then
+    _err "vcluster CLI installation failed"
+  fi
+}
+
 function _vcluster_check_prerequisites() {
-  if ! command -v vcluster >/dev/null 2>&1; then
-    _err "vcluster CLI is not installed; see https://github.com/loft-sh/vcluster"
+  if ! _command_exist vcluster; then
+    _info "vcluster CLI not found — installing automatically"
+    _vcluster_install_cli
   fi
   if ! _kubectl --no-exit --quiet cluster-info >/dev/null 2>&1; then
     _err "Host cluster context not available; kubectl cluster-info failed"

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -52,7 +52,7 @@ function vcluster_destroy() {
     return 0
   fi
 
-  _run_command -- vcluster delete "$name" -n "$VCLUSTER_NAMESPACE" --delete-namespace --wait
+  _run_command -- vcluster delete "$name" -n "$VCLUSTER_NAMESPACE" --wait
   if [[ -f "$kubeconfig_path" ]]; then
     _run_command -- rm -f "$kubeconfig_path"
   fi
@@ -94,15 +94,16 @@ function vcluster_use() {
   fi
   _run_command -- mkdir -p "$base_dir"
 
+  local merge_chain="${KUBECONFIG:-$base_config}"
   local merged=""
   if [[ -f "$base_config" ]]; then
     merged="$(
-      _run_command -- env KUBECONFIG="${kubeconfig}:${base_config}" kubectl config view --flatten
+      _run_command -- env KUBECONFIG="${kubeconfig}:${merge_chain}" kubectl config view --flatten
     )"
   else
     merged="$(cat "$kubeconfig")"
   fi
-  printf '%s\n' "$merged" > "$base_config"
+  _write_sensitive_file "$base_config" "$merged"
   export KUBECONFIG="$base_config"
 
   local context
@@ -175,8 +176,7 @@ function _vcluster_export_kubeconfig() {
   kubeconfig="$(_vcluster_kubeconfig_path "$name")"
   local config
   config="$(_run_command -- vcluster connect "$name" -n "$VCLUSTER_NAMESPACE" --print)"
-  printf '%s\n' "$config" > "$kubeconfig"
-  _run_command -- chmod 600 "$kubeconfig"
+  _write_sensitive_file "$kubeconfig" "$config"
   _info "Kubeconfig written to $kubeconfig"
 }
 
@@ -192,6 +192,9 @@ function _vcluster_kubeconfig_path() {
   local name="${1:-}"
   if [[ -z "$name" ]]; then
     _err "vCluster name required"
+  fi
+  if [[ "$name" == */* || "$name" == *..* ]]; then
+    _err "vCluster name must not contain '/' or '..': $name"
   fi
   printf '%s/%s.yaml\n' "$VCLUSTER_KUBECONFIG_DIR" "$name"
 }
@@ -212,7 +215,16 @@ function _vcluster_ensure_exists() {
   if ! list_output="$(_run_command --no-exit --quiet -- vcluster list -n "$VCLUSTER_NAMESPACE")"; then
     _err "vCluster '$name' not found in namespace '$VCLUSTER_NAMESPACE'"
   fi
-  if [[ "$list_output" != *"$name"* ]]; then
+  local found=0 line cluster_name
+  while IFS= read -r line; do
+    [[ "$line" == NAME* ]] && continue
+    read -r cluster_name _ <<< "$line"
+    if [[ "$cluster_name" == "$name" ]]; then
+      found=1
+      break
+    fi
+  done <<< "$list_output"
+  if [[ $found -eq 0 ]]; then
     _err "vCluster '$name' not found in namespace '$VCLUSTER_NAMESPACE'"
   fi
 }

--- a/scripts/plugins/vcluster.sh
+++ b/scripts/plugins/vcluster.sh
@@ -96,13 +96,9 @@ function vcluster_use() {
 
   local merge_chain="${KUBECONFIG:-$base_config}"
   local merged=""
-  if [[ -f "$base_config" ]]; then
-    merged="$(
-      _run_command -- env KUBECONFIG="${kubeconfig}:${merge_chain}" kubectl config view --flatten
-    )"
-  else
-    merged="$(cat "$kubeconfig")"
-  fi
+  merged="$(
+    _run_command -- env KUBECONFIG="${kubeconfig}:${merge_chain}" kubectl config view --flatten
+  )"
   _write_sensitive_file "$base_config" "$merged"
   export KUBECONFIG="$base_config"
 
@@ -128,13 +124,21 @@ function _vcluster_install_cli() {
   fi
 
   if _is_mac; then
-    _run_command --prefer-sudo -- brew install loft-sh/tap/vcluster
+    _run_command -- brew install loft-sh/tap/vcluster
   else
     local install_dir="${VCLUSTER_INSTALL_DIR:-/usr/local/bin}"
     local tmp_file
     tmp_file="$(mktemp -t vcluster-cli.XXXXXX)"
     trap '$(_cleanup_trap_command "$tmp_file")' RETURN
-    local url="https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/vcluster-linux-amd64"
+    local machine_arch
+    machine_arch="$(uname -m)"
+    local dl_arch
+    case "$machine_arch" in
+      x86_64)          dl_arch="amd64" ;;
+      aarch64|arm64)   dl_arch="arm64" ;;
+      *)               _err "Unsupported architecture for vcluster CLI install: $machine_arch" ;;
+    esac
+    local url="https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/vcluster-linux-${dl_arch}"
     _run_command -- curl -fsSL -o "$tmp_file" "$url"
     _run_command -- chmod +x "$tmp_file"
     _run_command --prefer-sudo -- mkdir -p "$install_dir"

--- a/scripts/tests/plugins/vcluster.bats
+++ b/scripts/tests/plugins/vcluster.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+setup() {
+  source "${BATS_TEST_DIRNAME}/../test_helpers.bash"
+  init_test_env
+  export HOME="${BATS_TEST_TMPDIR}/home"
+  mkdir -p "$HOME"
+  export VCLUSTER_KUBECONFIG_DIR="${BATS_TEST_TMPDIR}/kubeconfigs"
+  mkdir -p "$VCLUSTER_KUBECONFIG_DIR"
+  export PATH="${BATS_TEST_TMPDIR}/bin:$PATH"
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  VCLUSTER_STUB="${BATS_TEST_TMPDIR}/bin/vcluster"
+  cat <<'STUB' > "$VCLUSTER_STUB"
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  list)
+    if [[ -n "${VCLUSTER_LIST_OUTPUT:-}" ]]; then
+      printf '%s\n' "$VCLUSTER_LIST_OUTPUT"
+    else
+      printf 'NAME   NAMESPACE   STATUS   AGE\n'
+    fi
+    ;;
+  *)
+    :
+    ;;
+esac
+STUB
+  chmod +x "$VCLUSTER_STUB"
+  export VCLUSTER_LIST_OUTPUT=""
+  unset KUBECONFIG
+  source "${BATS_TEST_DIRNAME}/../../plugins/vcluster.sh"
+}
+
+@test "vcluster_create: fails without vcluster binary" {
+  rm -f "$VCLUSTER_STUB"
+  run vcluster_create demo
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"vcluster CLI is not installed"* ]]
+}
+
+@test "vcluster_create: fails without active host context" {
+  KUBECTL_EXIT_CODES=(1)
+  run vcluster_create demo
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Host cluster context not available"* ]]
+}
+
+@test "vcluster_create: dry-run prints plan without executing" {
+  DRY_RUN=1 run vcluster_create preview
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY_RUN: vcluster create preview"* ]]
+  [[ "$output" == *"kubeconfig will be written"* ]]
+  [ ! -s "$RUN_LOG" ]
+}
+
+@test "vcluster_destroy: dry-run prints plan without executing" {
+  local kubeconfig="${VCLUSTER_KUBECONFIG_DIR}/demo.yaml"
+  mkdir -p "${VCLUSTER_KUBECONFIG_DIR}"
+  printf 'current-context: vc-demo\n' > "$kubeconfig"
+  DRY_RUN=1 run vcluster_destroy demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"kubeconfig ${kubeconfig} would be removed"* ]]
+  [ ! -s "$RUN_LOG" ]
+}
+
+@test "vcluster_destroy: fails on unknown cluster name" {
+  export VCLUSTER_LIST_OUTPUT=$'NAME   NAMESPACE\nalpha   vclusters'
+  run vcluster_destroy ghost
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"vCluster 'ghost' not found"* ]]
+  local -a run_calls
+  run_calls=()
+  read_lines "$RUN_LOG" run_calls
+  [ "${run_calls[0]}" = "vcluster list -n vclusters" ]
+}
+
+@test "vcluster_use: fails when kubeconfig file missing" {
+  rm -f "${VCLUSTER_KUBECONFIG_DIR}/ghost.yaml"
+  run vcluster_use ghost
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"kubeconfig for vCluster 'ghost' not found"* ]]
+}
+
+@test "VCLUSTER_VERSION defaults to 0.32.1" {
+  [ "$VCLUSTER_VERSION" = "0.32.1" ]
+}
+
+@test "VCLUSTER_NAMESPACE defaults to vclusters" {
+  [ "$VCLUSTER_NAMESPACE" = "vclusters" ]
+}

--- a/scripts/tests/plugins/vcluster.bats
+++ b/scripts/tests/plugins/vcluster.bats
@@ -34,11 +34,25 @@ STUB
   source "${BATS_TEST_DIRNAME}/../../plugins/vcluster.sh"
 }
 
-@test "vcluster_create: fails without vcluster binary" {
+@test "vcluster_create: installs CLI when binary missing" {
   rm -f "$VCLUSTER_STUB"
+  _vcluster_install_cli() {
+    cat <<'BIN' > "$VCLUSTER_STUB"
+#!/usr/bin/env bash
+if [[ "$1" == "list" ]]; then
+  echo "NAME   NAMESPACE"
+else
+  exit 0
+fi
+BIN
+    chmod +x "$VCLUSTER_STUB"
+  }
   run vcluster_create demo
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"vcluster CLI is not installed"* ]]
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"vcluster CLI not found"* ]]
+  local -a run_calls
+  read_lines "$RUN_LOG" run_calls
+  [ "${run_calls[0]}" = "vcluster create demo -n vclusters --chart-version 0.32.1 --connect=false -f ${SCRIPT_DIR}/etc/vcluster/values.yaml" ]
 }
 
 @test "vcluster_create: fails without active host context" {
@@ -90,4 +104,20 @@ STUB
 
 @test "VCLUSTER_NAMESPACE defaults to vclusters" {
   [ "$VCLUSTER_NAMESPACE" = "vclusters" ]
+}
+
+@test "_vcluster_install_cli: skips if binary already exists" {
+  _command_exist() {
+    if [[ "$1" == "vcluster" ]]; then
+      return 0
+    fi
+    command -v "$1" >/dev/null 2>&1
+  }
+  run _vcluster_install_cli
+  [ "$status" -eq 0 ]
+  [ ! -s "$RUN_LOG" ]
+}
+
+@test "VCLUSTER_INSTALL_DIR defaults to /usr/local/bin" {
+  [ "$VCLUSTER_INSTALL_DIR" = "/usr/local/bin" ]
 }


### PR DESCRIPTION
## Summary

Implements the vCluster plugin for k3d-manager — ephemeral tenant clusters inside the host cluster for isolated CI testing.

## Files added

- `scripts/plugins/vcluster.sh` — 4 public functions: `vcluster_create`, `vcluster_destroy`, `vcluster_use`, `vcluster_list`
- `scripts/etc/vcluster/values.yaml` — control plane resource limits (500m CPU / 512Mi RAM)
- `scripts/tests/plugins/vcluster.bats` — 8 tests, `env -i` clean

## Key design decisions

- vCluster CLI `0.32.1` pinned via `VCLUSTER_VERSION` env var
- Kubeconfig export via `vcluster connect --print` — non-blocking, no Docker proxy, CI-safe
- `k8s` distro (default in v0.32.1) — no explicit flag needed
- All external commands routed through `_run_command`
- `DRY_RUN=1` gate on `vcluster_destroy`

## Validation (Codex)

- `bats scripts/tests/plugins/vcluster.bats` — 8/8
- `env -i ... bats scripts/tests/plugins/vcluster.bats` — 8/8
- `shellcheck scripts/plugins/vcluster.sh` — clean
- `AGENT_AUDIT_MAX_IF=8 bash scripts/lib/agent_rigor.sh scripts/plugins/vcluster.sh` — PASS

## Test plan

- [ ] CI green
- [ ] Copilot review — no blocking comments
- [ ] Gemini live smoke test: `vcluster_create` → `vcluster_list` → `vcluster_destroy` on infra cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)