### PR TITLE
docs(v0.9.7): README overhaul — Plugins table, Issue Logs, How-To, Releases

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,20 @@
 # Changes - k3d-manager
 
+## [Unreleased] v0.9.7 — README overhaul + tooling polish
+
+### Changed
+- **`README.md`**: Plugins section — full table of all 13 plugins with key functions and descriptions, replacing single ACG link.
+- **`README.md`**: How-To section — grouped by component (Jenkins / LDAP).
+- **`README.md`**: Issue Logs promoted to top-level section; `docs/issues/` as canonical source; 5 most recent entries in table.
+- **`README.md`**: Releases table — top 3 in main table; older releases in `<details>` collapsible block.
+- **`docs/releases.md`**: Backfilled v0.9.2–v0.9.6 entries (were missing).
+
+### Added
+- **`docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md`**: Frontend nginx CrashLoopBackOff — read-only root filesystem prevents config write; fix: `emptyDir` at `/etc/nginx/conf.d/`.
+- **`docs/retro/2026-03-22-v0.9.6-retrospective.md`**: v0.9.6 retrospective + post-merge v0.9.7 session start (skill updates, README conventions, SSH keychain fix).
+
+---
+
 ## [Unreleased] v0.9.6 — ACG plugin + kops-for-k3s reframe
 
 ### Added

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -3,7 +3,7 @@
 ## [Unreleased] v0.9.7 — README overhaul + tooling polish
 
 ### Changed
-- **`README.md`**: Plugins section — full table of all 13 plugins with key functions and descriptions, replacing single ACG link.
+- **`README.md`**: Plugins section — full table of all 14 plugins with key functions and descriptions, replacing single ACG link.
 - **`README.md`**: How-To section — grouped by component (Jenkins / LDAP).
 - **`README.md`**: Issue Logs promoted to top-level section; `docs/issues/` as canonical source; 5 most recent entries in table.
 - **`README.md`**: Releases table — top 3 in main table; older releases in `<details>` collapsible block.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ docs/
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.6](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.6) | 2026-03-22 | ACG sandbox plugin (`acg_provision/status/extend/teardown`), VPC/SG idempotency, `ACG_ALLOWED_CIDR` security, kops-for-k3s reframe |
 | [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration next-steps; replaces manual Gemini rebuild |
 | [v0.9.4](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.4) | 2026-03-21 | autossh tunnel plugin, ArgoCD cluster registration, smoke-test gate, `_run_command` TTY fallback, Jenkins optional guard, lib-foundation v0.3.3 subtree |
 | [v0.9.3](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.3) | 2026-03-16 | TTY fix (`_DCRS_PROVIDER` global), lib-foundation v0.3.2 subtree, cluster rebuild smoke test (Gemini-verified) |

--- a/README.md
+++ b/README.md
@@ -213,17 +213,32 @@ docs/
 - **[Two-Cluster Architecture](docs/plans/two-cluster-infra.md)** — Infra + app cluster design
 
 ### How-To
-- **[Configuring SSL Trust for jenkins-cli](docs/howto/jenkins-cli-ssl-trust.md)**
-- **[LDAP Bulk User Import](docs/howto/ldap-bulk-user-import.md)**
-- **[LDAP Password Rotation](docs/howto/ldap-password-rotation.md)**
-- **[Jenkins K8s Agents Testing](docs/howto/jenkins-k8s-agents-testing.md)**
 
-### Issue Logs
-- **[vCluster Copilot Review Findings](docs/issues/2026-03-15-vcluster-copilot-review-findings.md)** — 11 findings across 2 rounds (v0.9.1)
-- **[vCluster Smoke Test Failures](docs/issues/2026-03-15-vcluster-smoke-test-failures.md)** — Pod selector mismatch + missing plugin help (v0.9.1)
-- **[test() Function Refactor](docs/issues/2026-03-15-test-function-refactor.md)** — if-count violation + dispatcher move (v0.9.1)
-- **[Shopping Cart CI Failures](docs/issues/2026-03-11-shopping-cart-ci-failures.md)** — P1/P2 CI fixes (v0.8.0)
-- **[_run_command If-Count Refactor](docs/issues/2026-03-08-run-command-if-count-refactor.md)** — lib-foundation v0.3.0 debt
+**Jenkins**
+- **[Configuring SSL Trust for jenkins-cli](docs/howto/jenkins-cli-ssl-trust.md)** — Trust Vault-issued certs for `jenkins-cli.jar`
+- **[Jenkins K8s Agents Testing](docs/howto/jenkins-k8s-agents-testing.md)** — Verify dynamic pod agents in the infra cluster
+
+**LDAP / Directory**
+- **[LDAP Bulk User Import](docs/howto/ldap-bulk-user-import.md)** — Import users from a CSV into OpenLDAP
+- **[LDAP Password Rotation](docs/howto/ldap-password-rotation.md)** — Rotate user passwords via the rotator CronJob
+
+---
+
+## Issue Logs
+
+All tracked bugs, investigations, and debt are filed in **[docs/issues/](docs/issues/)** — one Markdown file per incident.
+
+Recent entries:
+
+| Date | Issue | Component |
+|---|---|---|
+| 2026-03-22 | [deploy_app_cluster manual gap](docs/issues/2026-03-22-deploy-app-cluster-manual-gap.md) | ACG / k3sup |
+| 2026-03-21 | [Frontend read-only filesystem failure](docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md) | Shopping Cart |
+| 2026-03-21 | [ArgoCD unreachable — mandated SHAs never pushed](docs/issues/2026-03-21-argocd-unreachable-mandated-shas.md) | ArgoCD |
+| 2026-03-21 | [Frontend CrashLoopBackOff misdiagnosis](docs/issues/2026-03-21-frontend-crashloopbackoff-misdiagnosis.md) | Shopping Cart |
+| 2026-03-21 | [order-service RabbitMQ connection refused](docs/issues/2026-03-21-order-service-rabbitmq-connection-refused.md) | Shopping Cart |
+
+[All issues →](docs/issues/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,20 @@ Recent entries:
 | Version | Date | Highlights |
 |---|---|---|
 | [v0.9.6](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.6) | 2026-03-22 | ACG sandbox plugin (`acg_provision/status/extend/teardown`), VPC/SG idempotency, `ACG_ALLOWED_CIDR` security, kops-for-k3s reframe |
-| [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration next-steps; replaces manual Gemini rebuild |
-| [v0.9.4](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.4) | 2026-03-21 | autossh tunnel plugin, ArgoCD cluster registration, smoke-test gate, `_run_command` TTY fallback, Jenkins optional guard, lib-foundation v0.3.3 subtree |
-| [v0.9.3](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.3) | 2026-03-16 | TTY fix (`_DCRS_PROVIDER` global), lib-foundation v0.3.2 subtree, cluster rebuild smoke test (Gemini-verified) |
-| [v0.9.2](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.2) | 2026-03-15 | vCluster E2E composite actions, 11-finding Copilot hardening (curl safety, mktemp, sudo -n, TAG env, input validation) |
+| [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration; replaces manual rebuild |
+| [v0.9.4](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.4) | 2026-03-21 | autossh tunnel plugin, ArgoCD cluster registration, smoke-test gate, `_run_command` TTY fallback, lib-foundation v0.3.3 |
+
+<details>
+<summary>Older releases</summary>
+
+| Version | Date | Highlights |
+|---|---|---|
+| [v0.9.3](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.3) | 2026-03-16 | TTY fix (`_DCRS_PROVIDER` global), lib-foundation v0.3.2 subtree, cluster rebuild smoke test |
+| [v0.9.2](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.2) | 2026-03-15 | vCluster E2E composite actions, 11-finding Copilot hardening (curl safety, mktemp, sudo -n, input validation) |
 | [v0.9.1](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.1) | 2026-03-15 | vCluster plugin (`create/destroy/use/list`), two-tier `--help`, `function test()` refactor, 11 Copilot findings fixed |
+| [v0.9.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.0) | 2026-03-15 | k3dm-mcp planning, agent workflow lessons, roadmap restructure |
 | [v0.8.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.8.0) | 2026-03-13 | Vault-managed ArgoCD deploy keys, `deploy_cert_manager` (ACME/Let's Encrypt), Istio IngressClass |
 
 [Full release history →](docs/releases.md)
+
+</details>

--- a/README.md
+++ b/README.md
@@ -177,7 +177,24 @@ docs/
 ### API Reference
 - **[Public Functions](docs/api/functions.md)** — All callable functions with source locations
 - **[Vault PKI Configuration](docs/api/vault-pki.md)** — PKI variables, example workflow, air-gapped setup
-- **[ACG Plugin](docs/plans/v0.9.6-acg-plugin.md)** — `acg_provision`, `acg_status`, `acg_extend`, `acg_teardown` — ACG sandbox lifecycle
+
+### Plugins
+
+| Plugin | Key Functions | Description |
+|---|---|---|
+| **ACG** | `acg_provision`, `acg_status`, `acg_extend`, `acg_teardown` | AWS ACG sandbox lifecycle — VPC + SG + EC2 provisioning; [spec](docs/plans/v0.9.6-acg-plugin.md) |
+| **ArgoCD** | `deploy_argocd`, `deploy_argocd_bootstrap`, `register_app_cluster`, `configure_vault_argocd_repos` | GitOps engine deployment + app cluster registration + Vault repo auth |
+| **Vault** | `deploy_vault`, `configure_vault_app_auth` | HashiCorp Vault HA + PKI + cross-cluster auth |
+| **ESO** | `deploy_eso` | External Secrets Operator — syncs Vault/AKV secrets into Kubernetes |
+| **Jenkins** | `deploy_jenkins` | Jenkins StatefulSet + Vault sidecar + ESO cert rotation CronJob |
+| **LDAP** | `deploy_ldap`, `deploy_ad`, `ldap_get_user_password` | OpenLDAP or Active Directory directory service |
+| **Keycloak** | `deploy_keycloak`, `test_keycloak` | Keycloak identity provider + smoke test |
+| **cert-manager** | `deploy_cert_manager` | cert-manager + ACME ClusterIssuer (Let's Encrypt) |
+| **vCluster** | `vcluster_create`, `vcluster_destroy`, `vcluster_use`, `vcluster_list` | Virtual cluster lifecycle on top of the infra cluster |
+| **Tunnel** | `tunnel_start`, `tunnel_stop`, `tunnel_status` | autossh persistent tunnel with launchd boot persistence |
+| **Azure** | `create_az_sp`, `deploy_azure_eso`, `eso_akv` | Azure Service Principal + ESO with Azure Key Vault backend |
+| **SMB CSI** | `deploy_smb_csi` | SMB CSI driver for Windows-compatible persistent volumes |
+| **Shopping Cart** | `register_shopping_cart_apps`, `deploy_app_cluster` | Demo app cluster bootstrap — k3sup EC2 install + ArgoCD app registration |
 
 ### Guides
 - **[Jenkins Authentication](docs/guides/jenkins-authentication.md)** — Auth modes (built-in / LDAP / AD), Vault sidecar, password rotation

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ docs/
 | **Azure** | `create_az_sp`, `deploy_azure_eso`, `eso_akv` | Azure Service Principal + ESO with Azure Key Vault backend |
 | **SMB CSI** | `deploy_smb_csi` | SMB CSI driver for Windows-compatible persistent volumes |
 | **Shopping Cart** | `register_shopping_cart_apps`, `deploy_app_cluster` | Demo app cluster bootstrap — k3sup EC2 install + ArgoCD app registration |
+| **Hello** | `hello` | Minimal example plugin — Hello World; reference for new plugin authors |
 
 ### Guides
 - **[Jenkins Authentication](docs/guides/jenkins-authentication.md)** — Auth modes (built-in / LDAP / AD), Vault sidecar, password rotation

--- a/docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md
+++ b/docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md
@@ -1,0 +1,28 @@
+# Issue: Frontend Pod Fails on Start - Read-Only Filesystem (2026-03-21)
+
+## Summary
+
+The `frontend` pod is in a `CrashLoopBackOff` state. Investigation shows this is not a regression of the previously fixed `emptyDir` volume issue, but a new problem related to filesystem permissions.
+
+## Evidence
+
+Logs from the `frontend` container show the NGINX entrypoint script fails when trying to configure the server:
+
+```
+/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+10-listen-on-ipv6-by-default.sh: info: can not modify /etc/nginx/conf.d/default.conf (read-only file system?)
+```
+
+This error indicates that the container's root filesystem is mounted as read-only. The NGINX image's default startup script requires write access to `/etc/nginx/conf.d/` to create the final server configuration.
+
+The pod's graceful shutdown signals suggest this configuration failure leads to a failed readiness/liveness probe, causing Kubernetes to terminate and restart the pod in a loop.
+
+## Next Steps
+
+The `frontend` deployment manifest in the `shopping-cart-infra` repository needs to be reviewed. The `securityContext` for the container likely has `readOnlyRootFilesystem: true` set.
+
+To fix this, one of two approaches can be taken:
+1.  Set `readOnlyRootFilesystem: false`.
+2.  Keep the read-only root and add a writable `emptyDir` volume mounted specifically at `/etc/nginx/conf.d/`.
+
+Approach #2 is generally preferred for better security.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,11 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.6](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.6) | 2026-03-22 | ACG sandbox plugin (`acg_provision/status/extend/teardown`), VPC/SG idempotency, `ACG_ALLOWED_CIDR` security, kops-for-k3s reframe |
+| [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration; replaces manual rebuild |
+| [v0.9.4](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.4) | 2026-03-21 | autossh tunnel plugin, ArgoCD cluster registration, smoke-test gate, `_run_command` TTY fallback, lib-foundation v0.3.3 |
+| [v0.9.3](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.3) | 2026-03-16 | TTY fix (`_DCRS_PROVIDER` global), lib-foundation v0.3.2 subtree, cluster rebuild smoke test |
+| [v0.9.2](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.2) | 2026-03-15 | vCluster E2E composite actions, 11-finding Copilot hardening (curl safety, mktemp, sudo -n, input validation) |
 | [v0.9.1](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.1) | 2026-03-15 | vCluster plugin (`create/destroy/use/list`), two-tier `--help`, `function test()` refactor, 11 Copilot findings fixed |
 | [v0.9.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.0) | 2026-03-15 | k3dm-mcp planning, agent workflow lessons, roadmap restructure |
 | [v0.8.0](https://github.com/wilddog64/k3d-manager/releases/tag/v0.8.0) | 2026-03-13 | Vault-managed ArgoCD deploy keys, `deploy_cert_manager` (ACME/Let's Encrypt), Istio IngressClass, `install-hooks.sh` |

--- a/docs/retro/2026-03-22-v0.9.6-retrospective.md
+++ b/docs/retro/2026-03-22-v0.9.6-retrospective.md
@@ -37,6 +37,34 @@
 - **VPC/SG idempotency via tag lookup** — `_acg_find_vpc` + `_acg_find_sg` find-or-create pattern prevents ACG resource accumulation across provision cycles.
 - **`_err` not used in plugin functions that should return** — `_err` calls `exit 1` which kills interactive sessions. Pattern: `printf 'ERROR: ...' >&2; return 1` for functions where callers use `|| return 1`.
 
+## Post-Merge / v0.9.7 Session Start
+
+Tooling and documentation improvements made immediately after v0.9.6 merged, before any v0.9.7 feature work.
+
+### Skills Updated
+
+| Skill | Change |
+|---|---|
+| `/create-pr` | Added Steps 4+5: reply every Copilot comment via REST (`pulls/<n>/comments/<id>/replies`), resolve all threads via GraphQL `resolveReviewThread`; 3 new Known Failure Modes (404 path, GraphQL-only resolution, thread ID ≠ comment ID) |
+| `/create-pr` | Added pre-flight Step 6: README sections check (Plugins table, How-To, Issue Logs, API Reference, Releases table) |
+| `/post-merge` | Added Step 8: branch cleanup every 5 releases — local `-d`/`-D`, protection removal, remote delete via GitHub API, `git fetch --prune` |
+
+### README Conventions Established
+
+| Section | Change | Why |
+|---|---|---|
+| **Plugins** | New dedicated table listing all 13 plugins, key functions, one-line description | Was a single ACG link; 13 plugins had no discoverability |
+| **How-To** | Grouped by component (Jenkins / LDAP) | Flat list would grow unnavigable; component grouping matches plugin model |
+| **Issue Logs** | Promoted to top-level `## Issue Logs` section; `docs/issues/` as canonical source; 5 most recent in table | Was buried in Documentation with 5 stale v0.9.1 links; 82 docs exist |
+| **Releases** | Top 3 in main table; older in `<details>` collapsible; `docs/releases.md` backfilled | Same convention already applied to shopping-cart repos; consistency |
+
+### Infrastructure Fixes
+
+- **SSH keychain persistence** — added `Host *` block with `UseKeychain yes` + `AddKeysToAgent yes` to `~/.ssh/config`; keys now load from Apple Keychain automatically after reboot without `eval $(ssh-agent -s)`
+- **`lib-foundation` remote** — switched from HTTPS to SSH (`git remote set-url`)
+
+---
+
 ## Theme
 
 v0.9.6 was a focused plugin migration: `bin/acg-sandbox.sh` became a proper k3d-manager plugin with the dispatcher pattern, `--confirm` safety gates, and full BATS coverage. Codex wrote the initial implementation cleanly; Copilot found 9 real defects in the first review, all of which were fixed before merge. The milestone also served as a strategic anchor — the "kops-for-k3s" reframe sharpened the product identity and cleared the roadmap of cloud-managed k8s scope that was never the core value. CI was blocked by a post-reboot cluster wipe (not resource exhaustion), which reminded us that root cause investigation beats retry loops. Next: v0.9.7, with the first items from the code quality backlog.

--- a/docs/retro/2026-03-22-v0.9.6-retrospective.md
+++ b/docs/retro/2026-03-22-v0.9.6-retrospective.md
@@ -1,0 +1,42 @@
+# Retrospective — v0.9.6
+
+**Date:** 2026-03-22
+**Milestone:** ACG sandbox plugin + kops-for-k3s reframe
+**PR:** #39 — merged to main (`8b09d577`)
+**Participants:** Claude, Codex, Copilot
+
+## What Went Well
+
+- **Codex delivered the full plugin in one shot** — `acg_provision`, `acg_status`, `acg_extend`, `acg_teardown` + 12 BATS tests + help category; no iteration needed on functionality.
+- **Copilot caught 9 real bugs** — exit safety (`_run_command --soft`), VPC idempotency, CIDR security, `read -d ''` heredoc non-zero return, and test_helpers.bash alignment. All were genuine defects, not style nits.
+- **CI stage2 green on fixed cluster** — after M2 reboot forced a full k3d redeploy, CI passed cleanly on commit `7987453`. Both lint and stage2 (Vault + ESO + Istio integration tests) green.
+- **Roadmap reframe was the right call** — "kops-for-k3s" is a sharper identity than "k3d + cloud-managed k8s." Dropping EKS/GKE/AKS simplifies the scope and makes the v1.0.0 milestone (3-node ACG) credible without over-engineering.
+- **GraphQL thread resolution** — Copilot threads resolved via `resolveReviewThread` mutation; all 9 conversations closed with specific fix references before merge.
+- **Doc completeness on merge** — README Quick Start, `docs/api/functions.md`, `CHANGE.md` all updated in the same PR cycle.
+
+## What Went Wrong
+
+- **CI failure root cause misdiagnosis** — first diagnosed as M2 resource exhaustion (the prior pattern). Actual cause: k3d cluster containers wiped after OrbStack reboot. Cost: one wasted cycle.
+- **Copilot comment resolution not in default workflow** — had to manually reply to threads and run GraphQL mutations. Should be standard in `/create-pr` post-creation steps.
+- **Codex committed locally but didn't push** — spec required push; Codex did not. Verified via `git log origin/<branch>` before assuming done. Known failure mode — spec pushback required.
+- **ACG plugin had 4 `_run_command` exit-safety bugs** — the `--soft` flag pattern was not documented in `docs/guides/plugin-development.md` or AGENTS.md. Copilot caught what the spec didn't require.
+- **Happy path focus** — during CI debugging, Copilot findings were deprioritized. User explicitly had to redirect: "you are also getting into happy path route." Parallel track (CI fix + Copilot fix) is the right model.
+
+## Process Rules Added
+
+| Rule | File | Trigger |
+|------|------|---------|
+| All Copilot comment threads must be replied to and resolved before merge | `/create-pr` skill | Copilot comments left unresolved in PR #39 |
+| Spec must document `_run_command --soft` for any function using ssh/aws in conditional | `docs/guides/plugin-development.md` | 4 exit-safety bugs in acg.sh |
+| Root cause before retry — CI failure is not always resource exhaustion | CLAUDE.md process notes | Reboot/cluster-wipe misdiagnosed as OrbStack resource pressure |
+
+## Decisions Made
+
+- **kops-for-k3s is the product identity** — no EKS/GKE/AKS in k3d-manager. Cloud-managed k8s has dedicated tooling (eksctl, gcloud, az). k3d-manager's lane: k3s end-to-end at zero managed-service cost.
+- **`ACG_ALLOWED_CIDR` env var** — default `0.0.0.0/0` (ACG sandbox context), user overrides for tighter security. Warning logged when default used.
+- **VPC/SG idempotency via tag lookup** — `_acg_find_vpc` + `_acg_find_sg` find-or-create pattern prevents ACG resource accumulation across provision cycles.
+- **`_err` not used in plugin functions that should return** — `_err` calls `exit 1` which kills interactive sessions. Pattern: `printf 'ERROR: ...' >&2; return 1` for functions where callers use `|| return 1`.
+
+## Theme
+
+v0.9.6 was a focused plugin migration: `bin/acg-sandbox.sh` became a proper k3d-manager plugin with the dispatcher pattern, `--confirm` safety gates, and full BATS coverage. Codex wrote the initial implementation cleanly; Copilot found 9 real defects in the first review, all of which were fixed before merge. The milestone also served as a strategic anchor — the "kops-for-k3s" reframe sharpened the product identity and cleared the roadmap of cloud-managed k8s scope that was never the core value. CI was blocked by a post-reboot cluster wipe (not resource exhaustion), which reminded us that root cause investigation beats retry loops. Next: v0.9.7, with the first items from the code quality backlog.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,10 +1,10 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.6` (as of 2026-03-21)
+## Current Branch: `k3d-manager-v0.9.7` (as of 2026-03-22)
 
-**v0.9.5 SHIPPED** — PR #38 squash-merged (`573c0ac`), tagged v0.9.5, released 2026-03-21.
-**v0.9.6 ACTIVE** — ACG AWS sandbox development focus. M2 Air at resource ceiling; shift CI and smoke testing to EC2.
-**enforce_admins:** restored on main 2026-03-21.
+**v0.9.6 SHIPPED** — PR #39 merged to main (`8b09d577`) 2026-03-22. Tagged v0.9.6, released.
+**v0.9.7 ACTIVE** — branch cut from main 2026-03-22.
+**enforce_admins:** restored on main 2026-03-22.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -27,7 +27,7 @@
 | **Frontend CrashLoopBackOff** | **DEFERRED → v1.0.0** | Root cause: resource exhaustion (FailedScheduling on t3.medium). PR #11 closed — Copilot P1 confirmed original port 8080 + /health was correct. Fix: 3-node k3sup. Doc: `docs/issues/2026-03-21-frontend-crashloopbackoff-misdiagnosis.md` |
 | deploy_app_cluster automation | **MERGED** | commit `13c79b3` — adds k3sup install + kubeconfig merge + follow-up instructions |
 | ACG plugin (aws sandbox) | **MERGED** | commit `37a6629` — acg_provision/status/extend/teardown plugin replaces bin/acg-sandbox.sh |
-| **Copilot fixes (PR #39)** | **PUSHED — PR READY** | commit `7987453` — 9 findings: exit safety (`--soft`), VPC idempotency, CIDR security, heredoc fix, test pattern; `75f3b0f` — memory-bank roadmap; `157d431` — README + functions.md docs; CI green (`23393995884`); all threads resolved |
+| **Copilot fixes (PR #39)** | **MERGED** | commit `7987453` — 9 findings: exit safety (`--soft`), VPC idempotency, CIDR security, heredoc fix, test pattern; `75f3b0f` — memory-bank roadmap; `157d431` — README + functions.md docs; CI green; all threads resolved; squash-merged in `8b09d577` |
 | **product-catalog Degraded** | **OPEN** | Synced to `aa5de3c`; DB env vars correct; RABBITMQ_USER vs RABBITMQ_USERNAME mismatch via ESO |
 | **v1.0.0 (3-node k3sup + Samba AD)** | **NEXT MILESTONE** | Replaces single t3.medium; resolves resource exhaustion structurally; spec: `docs/plans/roadmap-v1.md` |
 | Re-enable e2e-tests schedule | **PENDING** | after all 5 pods Running |
@@ -77,6 +77,17 @@
 - **NetworkPolicy Hardening** — fixed `allow-dns` and added `allow-to-istio` to unblock `payment-service` initialization.
 - **`_run_command` TTY fallback** — interactive sudo fallback when `sudo -n` unavailable.
 - **autossh tunnel plugin** — `tunnel_start|stop|status`.
+
+---
+
+## v0.9.7 Tooling Changes
+
+| Item | Status | Notes |
+|---|---|---|
+| `/create-pr` skill — Copilot reply+resolve flow | **DONE** | Added Steps 4+5: reply each comment via REST, resolve threads via GraphQL `resolveReviewThread`; 3 new Known Failure Modes |
+| `/post-merge` skill — branch cleanup step | **DONE** | Step 8 added: delete stale branches every 5 releases; local `-d`/`-D` + remote protection removal + `git fetch --prune` |
+| SSH config — persistent Keychain | **DONE** | Added `Host *` block with `UseKeychain yes` + `AddKeysToAgent yes` to `~/.ssh/config`; `lib-foundation` remote switched to SSH |
+| Issue doc: frontend read-only filesystem | **COMMITTED** | `docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md` |
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -50,25 +50,37 @@
 
 ---
 
-## v0.9.6 — Active
+## v0.9.6 — Shipped
 
-**Focus: ACG AWS sandbox development — plugin shipped; next up: multi-node k3sup + Samba AD for v1.0.0.**
+**ACG plugin shipped + 9 Copilot findings resolved. PR #39 squash-merged `8b09d577` 2026-03-22. Tagged v0.9.6, released.**
 
-### Primary
-- [x] **ACG plugin** — `scripts/plugins/acg.sh`: `acg_provision`, `acg_status`, `acg_extend`, `acg_teardown`; retire `bin/acg-sandbox.sh`; spec: `docs/plans/v0.9.6-acg-plugin.md`; commit `37a6629`
+- [x] **ACG plugin** — `scripts/plugins/acg.sh`: `acg_provision`, `acg_status`, `acg_extend`, `acg_teardown`; retire `bin/acg-sandbox.sh`; commit `37a6629`
+- [x] **Copilot fixes** — 9 findings: exit safety (`--soft`), VPC idempotency, CIDR security, heredoc fix, test pattern; commits `7987453` + `75f3b0f` + `157d431`
+- [x] **README + functions.md** — ACG plugin documented; v0.9.6 in releases table
+- [x] **CHANGE.md** — v0.9.6 entry with Fixed + Documentation subsections
+- [x] **Retrospective** — `docs/retro/2026-03-22-v0.9.6-retrospective.md`
 
-### Code Quality / Architecture
+---
+
+## v0.9.7 — Active
+
+**Focus: code quality backlog + tooling polish. Branch cut 2026-03-22.**
+
+### Tooling (done this session)
+- [x] `/create-pr` skill — Copilot reply+resolve flow (Steps 4+5, 3 new failure modes)
+- [x] `/post-merge` skill — branch cleanup step (Step 8, every 5 releases)
+- [x] SSH config — persistent Keychain (`Host *` block); `lib-foundation` remote → SSH
+- [x] Issue doc: `docs/issues/2026-03-21-frontend-readonly-filesystem-failure.md`
+
+### Code Quality / Architecture (carried from v0.9.6)
 - [ ] **Upstream local lib edits to lib-foundation** — `scripts/lib/system.sh` (TTY fix + `_run_command_resolve_sudo`) and `scripts/lib/agent_rigor.sh` (allowlist feature) need PRs to lib-foundation `feat/v0.3.4` → subtree pull → remove local divergence
-- [ ] **Reduce if-count allowlist** — refactor 13 allowlisted functions (jenkins x6, ldap x7, vault x5, system x2) to under 8-`if` threshold; remainder needs `docs/issues/` entry; no new entries without linked issue
+- [ ] **Reduce if-count allowlist** — refactor 13 allowlisted functions (jenkins x6, ldap x7, vault x5, system x2) to under 8-`if` threshold; remainder needs `docs/issues/` entry
 - [ ] **`bin/` script consistency** — `bin/smoke-test-cluster-health.sh` needs `_kubectl`/`_run_command`
-- [ ] **Relocate app-layer bug tracking** — file shopping-cart bugs as GitHub Issues in their repos; remove from k3d-manager Known Bugs table
+- [ ] **Relocate app-layer bug tracking** — file shopping-cart bugs as GitHub Issues in their repos
 
-### Secondary (if primary complete)
+### Secondary
 - [ ] **Safety gate audit** — `deploy_*` with no args should print help, NOT trigger deployment
 - [ ] **`--dry-run` / `-n` mode** — all `deploy_*` print every command without executing
-- [ ] **`plan` mode** — prototype with Vault first
-- [ ] **sudo whitelist** — `scripts/etc/sudoers/k3d-manager` template
-- [ ] **Vault backup/restore** — `backup_vault` / `restore_vault`
 - [ ] **GitHub PAT rotation** — expires 2026-04-12
 
 ### Deferred to v1.0.0 (needs multi-node)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -74,7 +74,7 @@
 
 ### Code Quality / Architecture (carried from v0.9.6)
 - [ ] **Upstream local lib edits to lib-foundation** — `scripts/lib/system.sh` (TTY fix + `_run_command_resolve_sudo`) and `scripts/lib/agent_rigor.sh` (allowlist feature) need PRs to lib-foundation `feat/v0.3.4` → subtree pull → remove local divergence
-- [ ] **Reduce if-count allowlist** — refactor 13 allowlisted functions (jenkins x6, ldap x7, vault x5, system x2) to under 8-`if` threshold; remainder needs `docs/issues/` entry
+- [ ] **Reduce if-count allowlist** — refactor 20 allowlisted functions (jenkins x6, ldap x7, vault x5, system x2) to under 8-`if` threshold; remainder needs `docs/issues/` entry
 - [ ] **`bin/` script consistency** — `bin/smoke-test-cluster-health.sh` needs `_kubectl`/`_run_command`
 - [ ] **Relocate app-layer bug tracking** — file shopping-cart bugs as GitHub Issues in their repos
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,7 +5,8 @@
 **v0.9.3 SHIPPED** — squash-merged to main (8046c73), PR #36, 2026-03-16. Tagged + released.
 **v0.9.4 SHIPPED** — merged to main (662878a), PR #37, 2026-03-21.
 **v0.9.5 SHIPPED** — PR #38 squash-merged to main (`573c0ac`) 2026-03-21. Tagged v0.9.5, released.
-**v0.9.6 ACTIVE** — branch cut from main 2026-03-21. Focus: ACG AWS sandbox development.
+**v0.9.6 SHIPPED** — PR #39 merged to main (`8b09d577`) 2026-03-22. Tagged v0.9.6, released.
+**v0.9.7 ACTIVE** — branch cut from main 2026-03-22.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Plugins section**: replace single ACG link with a full table of all 13 plugins, their key public functions, and a one-line description each
- **Issue Logs**: promote from Documentation subsection to top-level `## Issue Logs` section; links to `docs/issues/` as canonical source (82 docs); 5 most recent in table
- **How-To**: group by component (Jenkins / LDAP) instead of flat list
- **Releases**: top 3 in main table, older releases in `<details>` collapsible; `docs/releases.md` backfilled with v0.9.2–v0.9.6
- **Tooling**: `/create-pr` + `/post-merge` skills updated; v0.9.6 retrospective + SSH keychain fix recorded

## Test plan
- [ ] CI green (docs-only — linter may not trigger)
- [ ] Copilot review comments addressed
- [ ] README renders correctly on GitHub (Plugins table, `<details>` block, Issue Logs table)

## Notes
Docs-only PR — no code changes. All conventions established here are captured in `/create-pr` pre-flight Step 6 for future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)