### PR TITLE
feat(ci): dynamic plugin detection — skip docs-only, map plugins to smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,60 @@ jobs:
           set -euo pipefail
           bats scripts/tests/lib
 
-  stage2:
+  detect:
     needs: lint
     if: >-
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      skip_cluster: ${{ steps.changes.outputs.skip_cluster }}
+      run_jenkins: ${{ steps.changes.outputs.run_jenkins }}
+      run_vault: ${{ steps.changes.outputs.run_vault }}
+      run_eso: ${{ steps.changes.outputs.run_eso }}
+      run_keycloak: ${{ steps.changes.outputs.run_keycloak }}
+      run_cert_manager: ${{ steps.changes.outputs.run_cert_manager }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed plugins
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "origin/main...HEAD")
+          NON_DOCS=$(printf '%s\n' "$CHANGED" |
+            grep -vE '^(docs/|memory-bank/|README\.md|CHANGE\.md)' || true)
+          if [[ -z "$NON_DOCS" ]]; then
+            echo "skip_cluster=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_cluster=false" >> "$GITHUB_OUTPUT"
+          fi
+          PLUGINS=$(printf '%s\n' "$CHANGED" |
+            grep 'scripts/plugins/' |
+            sed 's|scripts/plugins/||; s|\.sh$||' || true)
+          for flag in jenkins vault eso keycloak; do
+            if printf '%s\n' "$PLUGINS" | grep -q "^${flag}$"; then
+              echo "run_${flag}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_${flag}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+          if printf '%s\n' "$PLUGINS" | grep -q '^cert-manager$'; then
+            echo "run_cert_manager=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_cert_manager=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  stage2:
+    needs: [lint, detect]
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          needs.detect.outputs.skip_cluster == 'false' }}
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
@@ -74,9 +123,27 @@ jobs:
       - name: Run integration tests
         env:
           CLUSTER_PROVIDER: orbstack
+          RUN_JENKINS: ${{ needs.detect.outputs.run_jenkins }}
+          RUN_VAULT: ${{ needs.detect.outputs.run_vault }}
+          RUN_ESO: ${{ needs.detect.outputs.run_eso }}
+          RUN_KEYCLOAK: ${{ needs.detect.outputs.run_keycloak }}
+          RUN_CERT_MANAGER: ${{ needs.detect.outputs.run_cert_manager }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:$PATH"
-          ./scripts/k3d-manager test_vault
-          ./scripts/k3d-manager test_eso
           ./scripts/k3d-manager test_istio
+          if [[ "$RUN_VAULT" == "true" ]]; then
+            ./scripts/k3d-manager test_vault
+          fi
+          if [[ "$RUN_ESO" == "true" ]]; then
+            ./scripts/k3d-manager test_eso
+          fi
+          if [[ "$RUN_JENKINS" == "true" ]]; then
+            ./scripts/k3d-manager test_jenkins
+          fi
+          if [[ "$RUN_KEYCLOAK" == "true" ]]; then
+            ./scripts/k3d-manager test_keycloak
+          fi
+          if [[ "$RUN_CERT_MANAGER" == "true" ]]; then
+            ./scripts/k3d-manager test_cert_rotation
+          fi

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,15 @@
 # Changes - k3d-manager
 
+## [v0.9.11] — 2026-03-22 — dynamic plugin CI
+
+### Added
+- **`.github/workflows/ci.yml`**: New `detect` job (ubuntu-latest) runs after `lint` — computes changed files via `git diff --name-only origin/main...HEAD`, emits `skip_cluster=true` for docs-only PRs, and emits per-plugin flags (`run_jenkins`, `run_vault`, `run_eso`, `run_keycloak`, `run_cert_manager`) when the corresponding plugin file is modified (`e2241d6`).
+
+### Changed
+- **`.github/workflows/ci.yml`**: `stage2` job now depends on `detect`; skips entirely when `skip_cluster=true`; always runs `test_istio` as structural baseline; conditionally runs `test_jenkins`, `test_vault`, `test_eso`, `test_keycloak`, or `test_cert_rotation` only when the matched plugin changed (`e2241d6`).
+
+---
+
 ## [v0.9.10] — 2026-03-22 — if-count allowlist elimination (jenkins)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -233,11 +233,11 @@ Recent entries:
 
 | Date | Issue | Component |
 |---|---|---|
+| 2026-03-22 | [Copilot PR #45 review findings](docs/issues/2026-03-22-copilot-pr45-review-findings.md) | spec doc — plugin paths, Rules vs DoD contradiction |
 | 2026-03-22 | [Copilot PR #44 review findings](docs/issues/2026-03-22-copilot-pr44-review-findings.md) | jenkins — duplicate PKI vars, help text mismatch |
 | 2026-03-22 | [Copilot PR #43 review findings](docs/issues/2026-03-22-copilot-pr43-review-findings.md) | ldap / vault — newlines, local scope, jq bool, printf |
 | 2026-03-22 | [Copilot PR #42 review findings](docs/issues/2026-03-22-copilot-pr42-review-findings.md) | dry-run tests / memory-bank |
 | 2026-03-22 | [if-count allowlist deferred refactors](docs/issues/2026-03-22-if-count-allowlist-deferred.md) | jenkins / ldap / vault / system |
-| 2026-03-22 | [Copilot PR #41 review findings](docs/issues/2026-03-22-copilot-pr41-review-findings.md) | lib / agent_rigor / core |
 
 [All issues →](docs/issues/)
 

--- a/README.md
+++ b/README.md
@@ -247,15 +247,16 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |
 | [v0.9.10](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.10) | 2026-03-22 | if-count allowlist elimination (jenkins) — 8 helpers extracted; allowlist now `system.sh` only |
 | [v0.9.9](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.9) | 2026-03-22 | if-count allowlist elimination — 11 ldap helpers + 6 vault helpers extracted; allowlist down to `system.sh` only |
-| [v0.9.7](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.7) | 2026-03-22 | lib-foundation sync (`--interactive-sudo`, `_run_command_resolve_sudo`), `deploy_cluster` no-args guard, `bin/` `_kubectl` wrapper, BATS stub fixes, Copilot PR #41 findings |
 
 <details>
 <summary>Older releases</summary>
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.7](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.7) | 2026-03-22 | lib-foundation sync (`--interactive-sudo`, `_run_command_resolve_sudo`), `deploy_cluster` no-args guard, `bin/` `_kubectl` wrapper, BATS stub fixes, Copilot PR #41 findings |
 | [v0.9.6](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.6) | 2026-03-22 | ACG sandbox plugin (`acg_provision/status/extend/teardown`), VPC/SG idempotency, `ACG_ALLOWED_CIDR` security, kops-for-k3s reframe |
 | [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration; replaces manual rebuild |
 | [v0.9.4](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.4) | 2026-03-21 | autossh tunnel plugin, ArgoCD cluster registration, smoke-test gate, `_run_command` TTY fallback, lib-foundation v0.3.3 |

--- a/docs/issues/2026-03-22-copilot-pr45-review-findings.md
+++ b/docs/issues/2026-03-22-copilot-pr45-review-findings.md
@@ -1,0 +1,52 @@
+# Copilot PR #45 Review Findings
+
+**PR:** #45 — feat(ci): dynamic plugin detection — skip docs-only, map plugins to smoke tests
+**Date:** 2026-03-22
+**Files reviewed:** `docs/plans/v0.9.11-dynamic-plugin-ci.md`
+**Findings:** 2 (both doc accuracy)
+
+---
+
+## Finding 1 — Plugin path prefix missing in mapping table
+
+**File:** `docs/plans/v0.9.11-dynamic-plugin-ci.md:45`
+**Copilot flagged:** Plugin file paths listed as `plugins/<name>.sh` but the repo layout and workflow grep both use `scripts/plugins/`. Misleading for anyone cross-referencing the spec with the workflow.
+
+**Before:**
+```
+| `plugins/jenkins.sh` | `test_jenkins` | Full suite |
+| `plugins/vault.sh` | `test_vault` | ... |
+...
+```
+
+**After:**
+```
+| `scripts/plugins/jenkins.sh` | `test_jenkins` | Full suite |
+| `scripts/plugins/vault.sh` | `test_vault` | ... |
+...
+```
+
+**Fix commit:** `85e0063`
+**Root cause:** Spec written with abbreviated paths for readability; actual layout not double-checked.
+**Process note:** Spec tables referencing file paths must use paths relative to repo root, matching what `git diff --name-only` would output.
+
+---
+
+## Finding 2 — Rules vs Definition of Done contradiction
+
+**File:** `docs/plans/v0.9.11-dynamic-plugin-ci.md:193`
+**Copilot flagged:** `## Rules` said "Do NOT modify any file other than `.github/workflows/ci.yml`" but `## Definition of Done` required updating `memory-bank/activeContext.md` — contradictory.
+
+**Before:**
+```
+- Do NOT modify any file other than `.github/workflows/ci.yml`
+```
+
+**After:**
+```
+- Do NOT modify any file other than `.github/workflows/ci.yml` (and `memory-bank/activeContext.md` after the commit — required by Definition of Done)
+```
+
+**Fix commit:** `85e0063`
+**Root cause:** Rules section copied from a previous spec without updating the file list; memory-bank update requirement is standard DoD boilerplate but wasn't reflected in Rules.
+**Process note:** When writing Rules, always cross-check against Definition of Done — any file listed in DoD must be explicitly allowed in Rules.

--- a/docs/plans/v0.9.11-dynamic-plugin-ci.md
+++ b/docs/plans/v0.9.11-dynamic-plugin-ci.md
@@ -37,12 +37,12 @@ Modify `stage2` to:
 
 | Plugin file | Test function | Notes |
 |---|---|---|
-| `plugins/jenkins.sh` | `test_jenkins` | Full suite |
-| `plugins/vault.sh` | `test_vault` | Already in baseline — now explicit |
-| `plugins/eso.sh` | `test_eso` | Already in baseline — now explicit |
-| `plugins/keycloak.sh` | `test_keycloak` | Added; was never in CI |
-| `plugins/cert-manager.sh` | `test_cert_rotation` | Added; was never in CI |
-| `plugins/ldap.sh` | _(none)_ | No `test_ldap` exists; falls back to baseline |
+| `scripts/plugins/jenkins.sh` | `test_jenkins` | Full suite |
+| `scripts/plugins/vault.sh` | `test_vault` | Already in baseline — now explicit |
+| `scripts/plugins/eso.sh` | `test_eso` | Already in baseline — now explicit |
+| `scripts/plugins/keycloak.sh` | `test_keycloak` | Added; was never in CI |
+| `scripts/plugins/cert-manager.sh` | `test_cert_rotation` | Added; was never in CI |
+| `scripts/plugins/ldap.sh` | _(none)_ | No `test_ldap` exists; falls back to baseline |
 | all others | _(baseline only)_ | `test_istio` structural check |
 
 **Baseline rule:** `test_istio` always runs when `skip_cluster=false`.
@@ -186,7 +186,7 @@ Insert the `detect` job block **between** the `lint` job and the `stage2` job.
 ## Rules
 
 - Do NOT use `|| true` to mask test failures — use `if [[ ... ]]; then ... fi` (already done above)
-- Do NOT modify any file other than `.github/workflows/ci.yml`
+- Do NOT modify any file other than `.github/workflows/ci.yml` (and `memory-bank/activeContext.md` after the commit — required by Definition of Done)
 - Do NOT create a PR
 - Do NOT skip pre-commit hooks (`--no-verify`)
 - Do NOT commit to `main` — work on `k3d-manager-v0.9.11`

--- a/docs/plans/v0.9.11-dynamic-plugin-ci.md
+++ b/docs/plans/v0.9.11-dynamic-plugin-ci.md
@@ -1,0 +1,214 @@
+# Spec: v0.9.11 — Dynamic Plugin CI
+
+**Branch:** `k3d-manager-v0.9.11`
+**Target file:** `.github/workflows/ci.yml`
+
+---
+
+## Problem
+
+The current `stage2` CI job always runs `test_vault`, `test_eso`, and `test_istio` on every
+PR regardless of what changed. When `jenkins.sh` was refactored in v0.9.10, CI ran the Istio
+smoke test — not the Jenkins smoke test. Bugs introduced in `deploy_jenkins` helpers would
+not be caught until a manual Gemini run.
+
+Two gaps:
+1. Plugin-specific tests are not triggered when a plugin file changes.
+2. Docs-only PRs (changes only in `docs/`, `memory-bank/`, `README.md`, `CHANGE.md`) still
+   spin up the self-hosted macOS runner — wasting resource and time.
+
+---
+
+## Solution
+
+Add a `detect` job (ubuntu-latest, fast) that:
+- Computes the set of changed files via `git diff --name-only origin/main...HEAD`
+- Outputs `skip_cluster=true` if ALL changed files are docs-only paths
+- Outputs per-plugin flags (`run_jenkins`, `run_vault`, `run_eso`, `run_keycloak`,
+  `run_cert_manager`) when the corresponding plugin file was modified
+
+Modify `stage2` to:
+- Depend on `detect`
+- Skip entirely when `skip_cluster=true`
+- Run `test_istio` as the structural baseline when any non-docs file changed
+- Run the mapped plugin test only when its flag is `true`
+
+**Plugin → test mapping:**
+
+| Plugin file | Test function | Notes |
+|---|---|---|
+| `plugins/jenkins.sh` | `test_jenkins` | Full suite |
+| `plugins/vault.sh` | `test_vault` | Already in baseline — now explicit |
+| `plugins/eso.sh` | `test_eso` | Already in baseline — now explicit |
+| `plugins/keycloak.sh` | `test_keycloak` | Added; was never in CI |
+| `plugins/cert-manager.sh` | `test_cert_rotation` | Added; was never in CI |
+| `plugins/ldap.sh` | _(none)_ | No `test_ldap` exists; falls back to baseline |
+| all others | _(baseline only)_ | `test_istio` structural check |
+
+**Baseline rule:** `test_istio` always runs when `skip_cluster=false`.
+
+---
+
+## Before You Start
+
+1. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+2. `git pull origin k3d-manager-v0.9.11`
+3. Read `.github/workflows/ci.yml` in full
+
+---
+
+## Change 1 — Add `detect` job
+
+Insert the `detect` job block **between** the `lint` job and the `stage2` job.
+
+### Old (the blank line before `  stage2:`)
+
+```yaml
+  stage2:
+    needs: lint
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cluster health check
+        run: bash scripts/ci/check_cluster_health.sh
+
+      - name: Run integration tests
+        env:
+          CLUSTER_PROVIDER: orbstack
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:$PATH"
+          ./scripts/k3d-manager test_vault
+          ./scripts/k3d-manager test_eso
+          ./scripts/k3d-manager test_istio
+```
+
+### New (replace the entire `stage2` block with `detect` + `stage2`)
+
+```yaml
+  detect:
+    needs: lint
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      skip_cluster: ${{ steps.changes.outputs.skip_cluster }}
+      run_jenkins: ${{ steps.changes.outputs.run_jenkins }}
+      run_vault: ${{ steps.changes.outputs.run_vault }}
+      run_eso: ${{ steps.changes.outputs.run_eso }}
+      run_keycloak: ${{ steps.changes.outputs.run_keycloak }}
+      run_cert_manager: ${{ steps.changes.outputs.run_cert_manager }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed plugins
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "origin/main...HEAD")
+          NON_DOCS=$(printf '%s\n' "$CHANGED" | \
+            grep -vE '^(docs/|memory-bank/|README\.md|CHANGE\.md)' || true)
+          if [[ -z "$NON_DOCS" ]]; then
+            echo "skip_cluster=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_cluster=false" >> "$GITHUB_OUTPUT"
+          fi
+          PLUGINS=$(printf '%s\n' "$CHANGED" | \
+            grep 'scripts/plugins/' | sed 's|scripts/plugins/||; s|\.sh$||' || true)
+          for flag in jenkins vault eso keycloak; do
+            if printf '%s\n' "$PLUGINS" | grep -q "^${flag}$"; then
+              echo "run_${flag}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_${flag}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+          if printf '%s\n' "$PLUGINS" | grep -q '^cert-manager$'; then
+            echo "run_cert_manager=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_cert_manager=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  stage2:
+    needs: [lint, detect]
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          needs.detect.outputs.skip_cluster == 'false' }}
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cluster health check
+        run: bash scripts/ci/check_cluster_health.sh
+
+      - name: Run integration tests
+        env:
+          CLUSTER_PROVIDER: orbstack
+          RUN_JENKINS: ${{ needs.detect.outputs.run_jenkins }}
+          RUN_VAULT: ${{ needs.detect.outputs.run_vault }}
+          RUN_ESO: ${{ needs.detect.outputs.run_eso }}
+          RUN_KEYCLOAK: ${{ needs.detect.outputs.run_keycloak }}
+          RUN_CERT_MANAGER: ${{ needs.detect.outputs.run_cert_manager }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:$PATH"
+          ./scripts/k3d-manager test_istio
+          if [[ "$RUN_VAULT" == "true" ]]; then
+            ./scripts/k3d-manager test_vault
+          fi
+          if [[ "$RUN_ESO" == "true" ]]; then
+            ./scripts/k3d-manager test_eso
+          fi
+          if [[ "$RUN_JENKINS" == "true" ]]; then
+            ./scripts/k3d-manager test_jenkins
+          fi
+          if [[ "$RUN_KEYCLOAK" == "true" ]]; then
+            ./scripts/k3d-manager test_keycloak
+          fi
+          if [[ "$RUN_CERT_MANAGER" == "true" ]]; then
+            ./scripts/k3d-manager test_cert_rotation
+          fi
+```
+
+---
+
+## Rules
+
+- Do NOT use `|| true` to mask test failures — use `if [[ ... ]]; then ... fi` (already done above)
+- Do NOT modify any file other than `.github/workflows/ci.yml`
+- Do NOT create a PR
+- Do NOT skip pre-commit hooks (`--no-verify`)
+- Do NOT commit to `main` — work on `k3d-manager-v0.9.11`
+- Run `yamllint .github/workflows/ci.yml` before committing — must produce zero warnings
+
+---
+
+## Definition of Done
+
+- [ ] `.github/workflows/ci.yml` updated with `detect` job and modified `stage2`
+- [ ] `yamllint .github/workflows/ci.yml` passes with zero warnings
+- [ ] `git diff origin/main...HEAD -- .github/workflows/ci.yml` shows only the expected changes
+- [ ] Committed on `k3d-manager-v0.9.11` with exact message:
+      `feat(ci): dynamic plugin detection — skip cluster tests for docs-only PRs, map plugin changes to smoke tests`
+- [ ] Pushed to `origin/k3d-manager-v0.9.11`
+- [ ] Update `memory-bank/activeContext.md`: change `v0.9.11: dynamic plugin CI` status from `PLANNED` to `MERGED` with the commit SHA
+- [ ] Report back: commit SHA + paste the memory-bank line you updated
+
+## What NOT to Do
+
+- Do NOT create a PR
+- Do NOT skip pre-commit hooks (`--no-verify`)
+- Do NOT modify files outside `.github/workflows/ci.yml` (and memory-bank after commit)
+- Do NOT commit to `main` — always work on `k3d-manager-v0.9.11`
+- Do NOT use `|| true` to suppress test exit codes

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |
 | [v0.9.10](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.10) | 2026-03-22 | if-count allowlist elimination (jenkins) — 8 helpers extracted; allowlist now `system.sh` only |
 | [v0.9.9](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.9) | 2026-03-22 | if-count allowlist elimination — 11 ldap helpers + 6 vault helpers extracted; allowlist down to `system.sh` only |
 | [v0.9.7](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.7) | 2026-03-22 | lib-foundation sync (`--interactive-sudo`, `_run_command_resolve_sudo`), `deploy_cluster` no-args guard, `bin/` `_kubectl` wrapper, BATS stub fixes, Copilot PR #41 findings |

--- a/docs/retro/2026-03-22-v0.9.10-retrospective.md
+++ b/docs/retro/2026-03-22-v0.9.10-retrospective.md
@@ -1,0 +1,36 @@
+# Retrospective — v0.9.10
+
+**Date:** 2026-03-22
+**Milestone:** if-count allowlist elimination (jenkins)
+**PR:** #44 — merged to main (`877ec970`)
+**Participants:** Claude, Codex, Copilot
+
+## What Went Well
+
+- **Codex delivered cleanly on first attempt** — `733123a` extracted 8+ helpers from `_deploy_jenkins` (560 lines → delegating helpers), all 4 jenkins functions dropped to ≤ 8 ifs, 4 allowlist entries removed
+- **CI ran and passed** — unlike v0.9.9 (no CI), v0.9.10 had a live CI pipeline run; Istio smoke test + lint both green
+- **Pre-commit hook caught partial working tree correctly** — from previous session, Codex's abandoned partial work left an inconsistent state; hook blocked the commit as expected
+- **Copilot findings were lightweight** — only 2 real issues (4 comment threads): duplicate PKI var block and help text mismatch; both straightforward fixes
+
+## What Went Wrong
+
+- **Duplicate PKI var block** — Codex copy-pasted `local vault_pki_secret_name` + `export` block twice during `_deploy_jenkins` extraction; easy to miss in a 2300-line file
+- **Help text default mismatch** — `--enable-vault` help said "default: disabled" but code defaulted to `JENKINS_VAULT_ENABLED:-1`; two separate heredocs both wrong; not caught before PR
+- **CI only runs Istio test regardless of changed plugin** — jenkins refactor PR ran Istio smoke test, not jenkins smoke test; gap identified and queued as v0.9.11
+
+## Process Rules Added
+
+| Rule | Where |
+|------|--------|
+| After helper extraction, scan for back-to-back identical `local`/`export` patterns — sign of copy-paste duplication | Spec template / verification checklist |
+| After any refactor, verify all help text defaults match the actual `:-N` fallback values in code | Spec template |
+
+## Decisions Made
+
+- **v0.9.11 = dynamic plugin CI** — detect changed plugins via `git diff --name-only origin/main...HEAD | grep scripts/plugins/`; map plugin → smoke test; PRs touching only docs/memory-bank skip cluster tests entirely
+- **Allowlist elimination complete** — all plugin entries cleared (ldap 7, vault 5, jenkins 4); only `system.sh:_run_command` and `system.sh:_ensure_node` remain, blocked on lib-foundation `feat/v0.3.4`
+- **Post-refactor smoke tests needed** — Gemini to run `deploy_vault` + `deploy_jenkins` on M2 Air infra cluster after merge to verify helper extraction didn't break live flows
+
+## Theme
+
+v0.9.10 finished what v0.9.9 started: the jenkins plugin got the same helper-extraction treatment as ldap and vault, clearing the last plugin entries from the if-count allowlist. The milestone was clean — Codex delivered on spec, Copilot caught two copy-paste artifacts from the extraction, CI passed. The session also surfaced a genuine CI design gap: running a fixed Istio smoke test on every PR regardless of what changed. That gap is now v0.9.11. The allowlist is down to two entries that can only be fixed upstream — a natural stopping point for this refactor arc.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -45,7 +45,7 @@
 | **Gemini: smoke test vault refactor** | **COMPLETE** | Ran `deploy_vault` and `deploy_vault --re-unseal` successfully. ESO integration confirmed working. |
 | **Gemini: smoke test jenkins refactor** | **COMPLETE** | Ran `deploy_jenkins --enable-ldap --enable-vault` successfully. Helm, Istio, and CronJob resources created as expected. |
 | **CI gap: no live cluster smoke tests** | **ROADMAP** | CI only runs pre-commit hooks; no automated deploy_vault/deploy_jenkins in CI — manual Gemini smoke tests are the only gate; track for v1.1.0 `provision_full_stack` work |
-| **v0.9.11: dynamic plugin CI** | **PLANNED** | Detect changed plugins via `git diff --name-only origin/main...HEAD | grep scripts/plugins/`; map plugin→smoke test (jenkins→jenkins smoke, vault→unseal+policy, ldap→OpenLDAP connectivity, istio→IngressGateway); PRs touching only docs/memory-bank skip cluster tests entirely; spec: `docs/plans/v0.9.11-dynamic-plugin-ci.md` |
+| **v0.9.11: dynamic plugin CI** | **SPEC WRITTEN** | Spec: `docs/plans/v0.9.11-dynamic-plugin-ci.md`; adds `detect` job (ubuntu-latest) + conditional stage2; plugin→test map: jenkins→test_jenkins, vault→test_vault, eso→test_eso, keycloak→test_keycloak, cert-manager→test_cert_rotation; docs-only PRs skip stage2; Codex handoff next |
 | **Dry-run docs/tests** | **MERGED** | commit `f1b4ca7` — README Safety Gates doc + `scripts/tests/lib/dry_run.bats` coverage |
 | **v1.0.0 (3-node k3sup + Samba AD)** | **NEXT MILESTONE** | Replaces single t3.medium; resolves resource exhaustion structurally; spec: `docs/plans/roadmap-v1.md` |
 | Re-enable e2e-tests schedule | **PENDING** | after all 5 pods Running |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -42,8 +42,8 @@
 | **if-count jenkins refactor** | **MERGED** | commit `733123a` on k3d-manager-v0.9.10 — new helpers drop 4 `jenkins.sh` functions ≤8 ifs; allowlist entries removed |
 | **v0.9.10 PR #44** | **MERGED** | `877ec970` — jenkins allowlist elimination; 4 Copilot findings fixed in `25e2b2a`; tagged v0.9.10; branch v0.9.11 cut |
 | **v0.9.9 PR #43** | **MERGED** | `c1043175` — ldap+vault allowlist elimination; 9 Copilot findings fixed in `bbfc12e`; tagged v0.9.9; branch v0.9.10 cut |
-| **Gemini: smoke test vault refactor** | **PENDING** | After v0.9.10 merges — run `deploy_vault` on infra cluster (M2 Air) to verify unseal flow works end-to-end after helper extraction |
-| **Gemini: smoke test jenkins refactor** | **PENDING** | After v0.9.10 merges — run `deploy_jenkins` on infra cluster (M2 Air) to verify Helm install + Istio resources + cert rotator path after helper extraction |
+| **Gemini: smoke test vault refactor** | **COMPLETE** | Ran `deploy_vault` and `deploy_vault --re-unseal` successfully. ESO integration confirmed working. |
+| **Gemini: smoke test jenkins refactor** | **COMPLETE** | Ran `deploy_jenkins --enable-ldap --enable-vault` successfully. Helm, Istio, and CronJob resources created as expected. |
 | **CI gap: no live cluster smoke tests** | **ROADMAP** | CI only runs pre-commit hooks; no automated deploy_vault/deploy_jenkins in CI — manual Gemini smoke tests are the only gate; track for v1.1.0 `provision_full_stack` work |
 | **v0.9.11: dynamic plugin CI** | **PLANNED** | Detect changed plugins via `git diff --name-only origin/main...HEAD | grep scripts/plugins/`; map plugin→smoke test (jenkins→jenkins smoke, vault→unseal+policy, ldap→OpenLDAP connectivity, istio→IngressGateway); PRs touching only docs/memory-bank skip cluster tests entirely; spec: `docs/plans/v0.9.11-dynamic-plugin-ci.md` |
 | **Dry-run docs/tests** | **MERGED** | commit `f1b4ca7` — README Safety Gates doc + `scripts/tests/lib/dry_run.bats` coverage |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -45,7 +45,7 @@
 | **Gemini: smoke test vault refactor** | **COMPLETE** | Ran `deploy_vault` and `deploy_vault --re-unseal` successfully. ESO integration confirmed working. |
 | **Gemini: smoke test jenkins refactor** | **COMPLETE** | Ran `deploy_jenkins --enable-ldap --enable-vault` successfully. Helm, Istio, and CronJob resources created as expected. |
 | **CI gap: no live cluster smoke tests** | **ROADMAP** | CI only runs pre-commit hooks; no automated deploy_vault/deploy_jenkins in CI — manual Gemini smoke tests are the only gate; track for v1.1.0 `provision_full_stack` work |
-| **v0.9.11: dynamic plugin CI** | **SPEC WRITTEN** | Spec: `docs/plans/v0.9.11-dynamic-plugin-ci.md`; adds `detect` job (ubuntu-latest) + conditional stage2; plugin→test map: jenkins→test_jenkins, vault→test_vault, eso→test_eso, keycloak→test_keycloak, cert-manager→test_cert_rotation; docs-only PRs skip stage2; Codex handoff next |
+| **v0.9.11: dynamic plugin CI** | **MERGED** | commit `e2241d6` — implements detect job + conditional stage2 per doc-only / plugin change spec (`docs/plans/v0.9.11-dynamic-plugin-ci.md`) |
 | **Dry-run docs/tests** | **MERGED** | commit `f1b4ca7` — README Safety Gates doc + `scripts/tests/lib/dry_run.bats` coverage |
 | **v1.0.0 (3-node k3sup + Samba AD)** | **NEXT MILESTONE** | Replaces single t3.medium; resolves resource exhaustion structurally; spec: `docs/plans/roadmap-v1.md` |
 | Re-enable e2e-tests schedule | **PENDING** | after all 5 pods Running |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,12 +1,12 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.10` (as of 2026-03-22)
+## Current Branch: `k3d-manager-v0.9.11` (as of 2026-03-22)
 
-**v0.9.6 SHIPPED** — PR #39 merged to main (`8b09d577`) 2026-03-22. Tagged v0.9.6, released.
 **v0.9.7 SHIPPED** — PR #41 merged to main (`97249a6f`) 2026-03-22. Tagged v0.9.7, released.
 **v0.9.8 SHIPPED** — PR #42 merged to main (`64525e3f`) 2026-03-22. No version tag (CHANGELOG [Unreleased]).
 **v0.9.9 SHIPPED** — PR #43 merged to main (`c1043175`) 2026-03-22. Tagged v0.9.9, released.
-**v0.9.10 ACTIVE** — branch cut from main 2026-03-22.
+**v0.9.10 SHIPPED** — PR #44 merged to main (`877ec970`) 2026-03-22. Tagged v0.9.10, released.
+**v0.9.11 ACTIVE** — branch cut from main 2026-03-22.
 **enforce_admins:** restored on main 2026-03-22.
 
 ---
@@ -40,6 +40,7 @@
 | **if-count ldap refactor** | **MERGED** | commit `ba6f3a9` — extracted helpers so 7 `ldap.sh` functions drop ≤8 ifs; allowlist trimmed |
 | **if-count vault refactor** | **MERGED** | commit `365846c` — extracted helpers + guard clauses so 5 `vault.sh` functions drop ≤8 ifs; allowlist cleared |
 | **if-count jenkins refactor** | **MERGED** | commit `733123a` on k3d-manager-v0.9.10 — new helpers drop 4 `jenkins.sh` functions ≤8 ifs; allowlist entries removed |
+| **v0.9.10 PR #44** | **MERGED** | `877ec970` — jenkins allowlist elimination; 4 Copilot findings fixed in `25e2b2a`; tagged v0.9.10; branch v0.9.11 cut |
 | **v0.9.9 PR #43** | **MERGED** | `c1043175` — ldap+vault allowlist elimination; 9 Copilot findings fixed in `bbfc12e`; tagged v0.9.9; branch v0.9.10 cut |
 | **Gemini: smoke test vault refactor** | **PENDING** | After v0.9.10 merges — run `deploy_vault` on infra cluster (M2 Air) to verify unseal flow works end-to-end after helper extraction |
 | **Gemini: smoke test jenkins refactor** | **PENDING** | After v0.9.10 merges — run `deploy_jenkins` on infra cluster (M2 Air) to verify Helm install + Istio resources + cert rotator path after helper extraction |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,7 +9,8 @@
 **v0.9.7 SHIPPED** — PR #41 merged to main (`97249a6f`) 2026-03-22. Tagged v0.9.7, released.
 **v0.9.8 SHIPPED** — PR #42 merged to main (`64525e3f`) 2026-03-22. if-count easy wins + dry-run doc/tests. No version tag (CHANGELOG [Unreleased]).
 **v0.9.9 SHIPPED** — PR #43 merged to main (`c1043175`) 2026-03-22. Tagged v0.9.9, released. if-count allowlist: ldap (7) + vault (5) entries removed.
-**v0.9.10 ACTIVE** — branch cut from main 2026-03-22.
+**v0.9.10 SHIPPED** — PR #44 merged to main (`877ec970`) 2026-03-22. Tagged v0.9.10, released. if-count allowlist: jenkins (4) entries removed; allowlist now system.sh only.
+**v0.9.11 ACTIVE** — branch cut from main 2026-03-22.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a `detect` job (ubuntu-latest) that computes changed files and emits `skip_cluster=true` for docs/memory-bank-only PRs and per-plugin flags (`run_jenkins`, `run_vault`, `run_eso`, `run_keycloak`, `run_cert_manager`) when a plugin file changes
- Rewires `stage2` to depend on `detect`: skips entirely for docs-only PRs, always runs `test_istio` as a structural baseline, and conditionally runs the matched plugin smoke test
- Fixes the v0.9.10 gap where a `jenkins.sh` refactor PR triggered the Istio smoke test instead of the Jenkins smoke test

## Test plan
- [ ] CI green (lint + detect + stage2 with dynamic test selection)
- [ ] Copilot review comments addressed
- [ ] Docs-only PR skips `stage2` runner (verify via detect job output `skip_cluster=true`)
- [ ] Plugin PR triggers correct smoke test (verify via detect job outputs)

## Notes
- `ldap.sh` has no `test_ldap` function — ldap changes fall back to `test_istio` baseline only; tracked as future gap
- Spec: `docs/plans/v0.9.11-dynamic-plugin-ci.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)