### PR TITLE
docs(v0.9.13): v0.9.12 retro + CHANGE.md backfill + releases table

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,28 @@
 # Changes - k3d-manager
 
+## [v0.9.13] — 2026-03-23 — v0.9.12 retro + process: mergeable_state check
+
+### Added
+- v0.9.12 retrospective (`docs/retro/2026-03-23-v0.9.12-retrospective.md`) — documents merge conflict / CI silence root cause, `copilot auth status` vs env var auth decision, `K3DM_COPILOT_LIVE_TESTS` opt-in guard rationale
+
+### Changed
+- `/create-pr` skill — Step 0 added to Post-creation Steps: check `mergeable_state` immediately after PR creation; if `"dirty"`, resolve conflicts before waiting for CI. Added "Dirty PR silently kills CI" to Known Failure Modes.
+
+---
+
+## [v0.9.12] — 2026-03-23 — Copilot CLI auth CI integration + lib-foundation v0.3.6
+
+### Added
+- **`.github/workflows/ci.yml`**: "Install Copilot CLI" step (conditional on `COPILOT_GITHUB_TOKEN`) — installs from `https://gh.io/copilot-install`, adds `$HOME/.local/bin` to `GITHUB_PATH`; "Run lib unit BATS" step now passes `COPILOT_GITHUB_TOKEN`, `K3DM_ENABLE_AI=1`, and `K3DM_COPILOT_LIVE_TESTS=1`
+- **`scripts/tests/lib/ensure_copilot_cli.bats`**: Live binary test (`copilot version`) gated behind `K3DM_COPILOT_LIVE_TESTS=1` + `COPILOT_GITHUB_TOKEN`; install-path tests stubbed for `_copilot_auth_check` to prevent `K3DM_ENABLE_AI` cascade
+- lib-foundation v0.3.6 subtree pull (`9a030bc`) — `doc_hygiene.sh` + hooks now in `scripts/lib/foundation/`
+
+### Fixed
+- `K3DM_ENABLE_AI=1` env cascade — install-path BATS tests now stub `_copilot_auth_check` so live auth check does not fire when copilot binary is present but unstubbed (`fbb9ba4`)
+- `copilot auth status` vs env var auth — live test changed to `copilot version` (which succeeds with `COPILOT_GITHUB_TOKEN` set); `copilot auth status` checks credential store only (`fbb9ba4`)
+
+---
+
 ## [v0.9.11] — 2026-03-22 — dynamic plugin CI
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -247,15 +247,16 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |
 | [v0.9.10](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.10) | 2026-03-22 | if-count allowlist elimination (jenkins) — 8 helpers extracted; allowlist now `system.sh` only |
-| [v0.9.9](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.9) | 2026-03-22 | if-count allowlist elimination — 11 ldap helpers + 6 vault helpers extracted; allowlist down to `system.sh` only |
 
 <details>
 <summary>Older releases</summary>
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.9](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.9) | 2026-03-22 | if-count allowlist elimination — 11 ldap helpers + 6 vault helpers extracted; allowlist down to `system.sh` only |
 | [v0.9.7](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.7) | 2026-03-22 | lib-foundation sync (`--interactive-sudo`, `_run_command_resolve_sudo`), `deploy_cluster` no-args guard, `bin/` `_kubectl` wrapper, BATS stub fixes, Copilot PR #41 findings |
 | [v0.9.6](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.6) | 2026-03-22 | ACG sandbox plugin (`acg_provision/status/extend/teardown`), VPC/SG idempotency, `ACG_ALLOWED_CIDR` security, kops-for-k3s reframe |
 | [v0.9.5](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.5) | 2026-03-21 | `deploy_app_cluster` — EC2 k3sup install + kubeconfig merge + ArgoCD registration; replaces manual rebuild |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |
 | [v0.9.10](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.10) | 2026-03-22 | if-count allowlist elimination (jenkins) — 8 helpers extracted; allowlist now `system.sh` only |
 | [v0.9.9](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.9) | 2026-03-22 | if-count allowlist elimination — 11 ldap helpers + 6 vault helpers extracted; allowlist down to `system.sh` only |

--- a/docs/retro/2026-03-23-v0.9.12-retrospective.md
+++ b/docs/retro/2026-03-23-v0.9.12-retrospective.md
@@ -30,7 +30,7 @@
 
 - **`copilot auth status` not suitable for CI** — env var auth (`COPILOT_GITHUB_TOKEN`) bypasses the credential store; `copilot version` is the correct liveness check; `_copilot_auth_check` in production is correct (it gates on `K3DM_ENABLE_AI=1` which requires a live cluster context)
 - **`K3DM_COPILOT_LIVE_TESTS=1` opt-in guard** — live binary tests in BATS must be gated behind this env var in addition to `COPILOT_GITHUB_TOKEN`; keeps unit suite clean when token is present but live test is undesired
-- **COPILOT_TOKEN expires 2026-04-22** — must rotate before then; see `memory/project_copilot_token.md`
+- **COPILOT_TOKEN expires 2026-04-22** — must rotate before then; tracked in `memory-bank/progress.md` GitHub PAT rotation item
 
 ## Theme
 

--- a/docs/retro/2026-03-23-v0.9.12-retrospective.md
+++ b/docs/retro/2026-03-23-v0.9.12-retrospective.md
@@ -1,0 +1,37 @@
+# Retrospective — v0.9.12
+
+**Date:** 2026-03-23
+**Milestone:** Copilot CLI auth CI integration + lib-foundation v0.3.6 subtree pull
+**PR:** #47 — merged to main (`f8014bc`)
+**Participants:** Claude, Codex, Copilot
+
+## What Went Well
+
+- **Spec quality** — tight 3-file spec kept Codex focused; no scope creep in the diff
+- **Copilot findings were valid** — both findings (live test opt-in, curl retry) improved real-world reliability and caught gaps the spec missed
+- **COPILOT_TOKEN PAT investigation** — correctly identified that fine-grained PAT v2 with "Copilot Requests" permission is required; classic PATs (`ghp_`) are not supported
+- **lib-foundation v0.3.6 subtree pull** — pulled cleanly with no conflicts; `doc_hygiene.sh` + hooks now in `scripts/lib/foundation/`
+
+## What Went Wrong
+
+- **CI merge conflict blocked workflow trigger** — PR had a dirty merge state (memory-bank conflicts between branch and main) which silently prevented the GitHub Actions CI workflow from triggering entirely; spent significant time diagnosing before discovering `mergeable_state: "dirty"` via API
+- **`K3DM_ENABLE_AI=1` env cascade** — setting the env var globally in the BATS step caused tests 55 + 57 to call real `_copilot_auth_check` (no stubs), breaking tests that were previously pure unit tests; should have been caught in the spec
+- **`copilot auth status` vs env var auth** — `copilot auth status` checks the credential store, not `COPILOT_GITHUB_TOKEN`; initial integration test design was wrong; `copilot version` is the correct live check for CI env var auth
+- **yamllint line-length** — Codex added an 85-char curl line which would have failed the yamllint CI step; caught post-push and fixed before CI ran
+- **Merge conflict root cause** — Codex's memory-bank commit + Claude's local memory-bank commit both diverged from main; should be caught earlier by checking `gh pr view --json mergeable` after PR creation
+
+## Process Rules Added
+
+| Rule | File | Description |
+|---|---|---|
+| Check mergeable_state after PR creation | `/create-pr` skill | Run `gh api .../pulls/<n> --jq .mergeable_state` after creating PR; if `dirty`, resolve conflicts and push before waiting for CI |
+
+## Decisions Made
+
+- **`copilot auth status` not suitable for CI** — env var auth (`COPILOT_GITHUB_TOKEN`) bypasses the credential store; `copilot version` is the correct liveness check; `_copilot_auth_check` in production is correct (it gates on `K3DM_ENABLE_AI=1` which requires a live cluster context)
+- **`K3DM_COPILOT_LIVE_TESTS=1` opt-in guard** — live binary tests in BATS must be gated behind this env var in addition to `COPILOT_GITHUB_TOKEN`; keeps unit suite clean when token is present but live test is undesired
+- **COPILOT_TOKEN expires 2026-04-22** — must rotate before then; see `memory/project_copilot_token.md`
+
+## Theme
+
+v0.9.12 closed the gap between `_ensure_copilot_cli`/`_k3d_manager_copilot` being implemented and them actually being exercised in CI with a live token. The main story was discovering that GitHub Copilot CLI's auth model has two separate layers — env var auth (for runtime commands) and credential store auth (for `auth status`) — and adapting the test strategy accordingly. A merge conflict that silently killed CI took the most debugging time; diagnosing via `mergeable_state` API is now a `/create-pr` checklist item.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,7 +7,8 @@
 **v0.9.9 SHIPPED** — PR #43 merged to main (`c1043175`) 2026-03-22. Tagged v0.9.9, released.
 **v0.9.10 SHIPPED** — PR #44 merged to main (`877ec970`) 2026-03-22. Tagged v0.9.10, released.
 **v0.9.11 SHIPPED** — PR #45 merged to main (`1a0c913`) 2026-03-22. Tagged v0.9.11, released.
-**v0.9.12 ACTIVE** — branch cut from main 2026-03-22. PR #46 merged (`2b27028`) — roadmap Currently Shipped table updated to v0.9.11. lib-foundation v0.3.6 subtree pull (`9a030bc`) — `doc_hygiene.sh` + `doc_hygiene.bats` + hooks now in `scripts/lib/foundation/`. Copilot CLI auth CI integration shipped in `fd97705` — installs Copilot CLI in lint job, passes `COPILOT_GITHUB_TOKEN`/`K3DM_ENABLE_AI` into BATS, adds live `_copilot_auth_check` test per `docs/plans/v0.9.12-copilot-auth-ci-integration.md`.
+**v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. Copilot CLI CI integration: lint job installs CLI, wires `COPILOT_GITHUB_TOKEN`/`K3DM_ENABLE_AI`/`K3DM_COPILOT_LIVE_TESTS` into BATS, live binary check; 2 Copilot findings fixed (`fbb9ba4`).
+**v0.9.13 ACTIVE** — branch cut from main 2026-03-23.
 **enforce_admins:** restored on main 2026-03-23.
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.12` (as of 2026-03-22)
+## Current Branch: `k3d-manager-v0.9.13` (as of 2026-03-23)
 
 **v0.9.7 SHIPPED** — PR #41 merged to main (`97249a6f`) 2026-03-22. Tagged v0.9.7, released.
 **v0.9.8 SHIPPED** — PR #42 merged to main (`64525e3f`) 2026-03-22. No version tag (CHANGELOG [Unreleased]).

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -23,7 +23,10 @@
 
 ## v0.9.13 — In Progress
 
-- [ ] TBD
+- [x] v0.9.12 retrospective — `docs/retro/2026-03-23-v0.9.12-retrospective.md` (`3f19383`)
+- [x] `/create-pr` skill — `mergeable_state` check in Post-creation Steps + "Dirty PR silently kills CI" failure mode
+- [x] CHANGE.md — backfill `[v0.9.12]` entry; add `[v0.9.13]` section
+- [x] README + docs/releases.md — add v0.9.13 release row; v0.9.9 moved to collapsible
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,16 +11,19 @@
 **v0.9.9 SHIPPED** — PR #43 merged to main (`c1043175`) 2026-03-22. Tagged v0.9.9, released. if-count allowlist: ldap (7) + vault (5) entries removed.
 **v0.9.10 SHIPPED** — PR #44 merged to main (`877ec970`) 2026-03-22. Tagged v0.9.10, released. if-count allowlist: jenkins (4) entries removed; allowlist now system.sh only.
 **v0.9.11 SHIPPED** — PR #45 merged to main (`1a0c913`) 2026-03-22. Tagged v0.9.11, released. Dynamic plugin CI: detect job + conditional stage2.
-**v0.9.12 ACTIVE** — branch cut from main 2026-03-22. lib-foundation v0.3.6 subtree pull (`9a030bc`).
+**v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. No version tag (CHANGELOG [Unreleased]). Copilot CLI CI integration + lib-foundation v0.3.6 subtree.
+**v0.9.13 ACTIVE** — branch cut from main 2026-03-23.
 
-## v0.9.12 — In Progress
+## v0.9.12 — Completed
 
 - [x] lib-foundation v0.3.6 subtree pull — `9a030bc` — `doc_hygiene.sh` + hooks now in subtree
 - [x] `_ensure_copilot_cli` / `_ensure_node` / `_k3d_manager_copilot` — already implemented (pre-compaction); BATS tests present in `scripts/tests/lib/`
-- [ ] Roadmap update — `docs/plans/roadmap-v1.md` revised sequencing (k3dm-mcp v1.2.0, GKE v1.3.0, AKS v1.4.0, vCluster v1.5.0; AD plugin in v1.1.0) — **STALE**: current roadmap already correct; no changes needed
-- [x] **Copilot CLI auth CI integration** — commit `fd97705` installs Copilot CLI in CI lint job, wires secrets into BATS, and adds live `_copilot_auth_check` test per `docs/plans/v0.9.12-copilot-auth-ci-integration.md`.
-- [x] **Agent Experience: gemini-skills repo** — Created private Git repo for custom agent skills; configured all Gemini config remotes to use SSH.
-- [x] **Agent Experience: task-reporter skill** — Implemented standardized, copyable task completion report with dynamically generated metrics status bar.
+- [x] Roadmap update — **STALE**: current roadmap already correct; no changes needed
+- [x] **Copilot CLI auth CI integration** — PR #47 (`f8014bc`): installs Copilot CLI in lint job, wires `COPILOT_GITHUB_TOKEN`/`K3DM_ENABLE_AI`/`K3DM_COPILOT_LIVE_TESTS` into BATS, adds live binary check; 2 Copilot findings fixed (`fbb9ba4`)
+
+## v0.9.13 — In Progress
+
+- [ ] TBD
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,7 +11,7 @@
 **v0.9.9 SHIPPED** — PR #43 merged to main (`c1043175`) 2026-03-22. Tagged v0.9.9, released. if-count allowlist: ldap (7) + vault (5) entries removed.
 **v0.9.10 SHIPPED** — PR #44 merged to main (`877ec970`) 2026-03-22. Tagged v0.9.10, released. if-count allowlist: jenkins (4) entries removed; allowlist now system.sh only.
 **v0.9.11 SHIPPED** — PR #45 merged to main (`1a0c913`) 2026-03-22. Tagged v0.9.11, released. Dynamic plugin CI: detect job + conditional stage2.
-**v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. No version tag (CHANGELOG [Unreleased]). Copilot CLI CI integration + lib-foundation v0.3.6 subtree.
+**v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. No version tag (CHANGE.md [Unreleased]). Copilot CLI CI integration + lib-foundation v0.3.6 subtree.
 **v0.9.13 ACTIVE** — branch cut from main 2026-03-23.
 
 ## v0.9.12 — Completed


### PR DESCRIPTION
## Summary
- Add v0.9.12 retrospective documenting merge conflict / CI silence root cause, \`copilot auth status\` vs env var auth decision, and \`K3DM_COPILOT_LIVE_TESTS\` guard rationale
- Backfill \`CHANGE.md\` with \`[v0.9.12]\` entry (Copilot CLI CI integration + lib-foundation v0.3.6); add \`[v0.9.13]\` section documenting process improvement
- Update README releases table (add v0.9.13, move v0.9.9 to collapsible) and \`docs/releases.md\`

## Test plan
- [ ] CI green
- [ ] Copilot review comments addressed
- [ ] Docs-only change — no functional impact to verify

## Notes
Process improvement: \`/create-pr\` skill now checks \`mergeable_state\` immediately after PR creation. This was root-caused from v0.9.12 where a dirty PR silently prevented GitHub Actions from triggering CI at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)