### PR TITLE
fix(acg): migrate ACG sandbox URLs to Pluralsight (app.pluralsight.com)

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,18 @@
 # Changes - k3d-manager
 
+## [v0.9.18] — 2026-03-28 — Pluralsight URL migration (ACG → app.pluralsight.com)
+
+### Fixed
+- `_ACG_SANDBOX_URL` in `scripts/plugins/acg.sh`: updated from retired `learn.acloud.guru/cloud-playground/cloud-sandboxes` to `app.pluralsight.com/cloud-playground/cloud-sandboxes` (`8f857ea`)
+- `_antigravity_ensure_acg_session` in `scripts/plugins/antigravity.sh`: updated navigation URL, login URL (`/id/signin`), and DOM selector hints for Pluralsight; removed "ACG domain migration pending" language from bypass guard (`8f857ea`)
+
+### Docs
+- `docs/api/functions.md`: `_antigravity_ensure_acg_session` — updated domain reference, added `K3DM_ACG_SKIP_SESSION_CHECK` env var table, removed stale redirect note
+- `docs/howto/acg.md`: updated sandbox URL and first-run login note to Pluralsight
+- `docs/howto/antigravity.md`: updated example URL and bypass comment
+
+---
+
 ## [v0.9.17] — 2026-03-27 — Antigravity model fallback + ACG session check + nested agent fix
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -218,6 +218,22 @@ docs/
 
 ### How-To
 
+**Secrets & Identity**
+- **[Vault](docs/howto/vault.md)** — Deploy, init, PKI cert issuance, cross-cluster auth
+- **[ESO](docs/howto/eso.md)** — Deploy, connect a secret store, troubleshoot sync failures
+- **[Keycloak](docs/howto/keycloak.md)** — Deploy, smoke test, LDAP federation
+
+**GitOps & CI/CD**
+- **[ArgoCD](docs/howto/argocd.md)** — Deploy, register app cluster, configure deploy keys
+- **[cert-manager](docs/howto/cert-manager.md)** — Deploy, Vault + ACME issuers, certificate lifecycle
+
+**Cloud Sandbox**
+- **[ACG Sandbox](docs/howto/acg.md)** — Full lifecycle: provision → k3s install → extend TTL → teardown
+- **[Antigravity Browser Automation](docs/howto/antigravity.md)** — First-run setup, ACG extend, Copilot agent trigger
+
+**Networking**
+- **[SSH Tunnel](docs/howto/tunnel.md)** — autossh setup, launchd boot persistence, app cluster access
+
 **Jenkins**
 - **[Configuring SSL Trust for jenkins-cli](docs/howto/jenkins-cli-ssl-trust.md)** — Trust Vault-issued certs for `jenkins-cli.jar`
 - **[Jenkins K8s Agents Testing](docs/howto/jenkins-k8s-agents-testing.md)** — Verify dynamic pod agents in the infra cluster

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ acg_teardown --confirm            # terminate instance; remove ubuntu-k3s kubeco
 ```
 
 > Set `ACG_ALLOWED_CIDR=<your-ip>/32` to restrict SSH/6443 ingress (default: `0.0.0.0/0`).
+>
+> **First run:** `acg_extend` will open the Antigravity browser and prompt for ACG login. Log in manually — the session cookie persists across runs until it expires.
 
 ### 3. Add the Ubuntu k3s app cluster
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
-| v0.9.17 | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
+| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ acg_teardown --confirm            # terminate instance; remove ubuntu-k3s kubeco
 
 > Set `ACG_ALLOWED_CIDR=<your-ip>/32` to restrict SSH/6443 ingress (default: `0.0.0.0/0`).
 >
-> **First run:** `acg_extend` will open the Antigravity browser and prompt for ACG login. Log in manually — the session cookie persists across runs until it expires.
+> **First run:** `antigravity_acg_extend` will open the Antigravity browser and prompt for Pluralsight login as needed. Log in manually — the session cookie persists across runs until it expires. Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the Antigravity session check.
 
 ### 3. Add the Ubuntu k3s app cluster
 
@@ -267,7 +267,7 @@ Recent entries:
 | Version | Date | Highlights |
 |---|---|---|
 | v0.9.18 | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
-| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
+| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 
 <details>

--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
+| v0.9.18 | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
-| [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 
 <details>
 <summary>Older releases</summary>

--- a/docs/api/functions.md
+++ b/docs/api/functions.md
@@ -132,7 +132,7 @@ Checks whether the user is logged into GitHub in the running Antigravity browser
 
 Checks whether the user is logged into Pluralsight's Cloud Playground (`app.pluralsight.com/cloud-playground/cloud-sandboxes`) in the running Antigravity browser (via Playwright CDP). If not logged in, navigates to the sign-in page and waits up to 300s for the user to complete login interactively. Returns 1 on timeout.
 
-**First-run note:** On a brand new environment, the Antigravity browser will open and display the ACG sign-in page. Log in manually — the session cookie is persisted in the Antigravity browser profile and reused on all subsequent runs until it expires.
+**First-run note:** On a brand new environment, the Antigravity browser will open and display the Pluralsight (ACG) sign-in page. Log in manually — the session cookie is persisted in the Antigravity browser profile and reused on all subsequent runs until it expires.
 
 Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the Pluralsight session check (e.g. for CI runs or when Playwright is unavailable).
 

--- a/docs/api/functions.md
+++ b/docs/api/functions.md
@@ -132,4 +132,8 @@ Checks whether the user is logged into GitHub in the running Antigravity browser
 
 Checks whether the user is logged into ACG (`learn.acloud.guru`) in the running Antigravity browser (via Playwright CDP). If not logged in, navigates to the sign-in page and waits up to 300s for the user to complete login interactively. Returns 1 on timeout.
 
+**First-run note:** On a brand new environment, the Antigravity browser will open and display the ACG sign-in page. Log in manually — the session cookie is persisted in the Antigravity browser profile and reused on all subsequent runs until it expires.
+
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass this check (e.g. while the ACG domain migration to Pluralsight is pending).
+
 > **Note:** `learn.acloud.guru` currently redirects to Pluralsight — URL update tracked in v0.9.18 ([issue](../issues/2026-03-28-acg-domain-redirection.md)).

--- a/docs/api/functions.md
+++ b/docs/api/functions.md
@@ -130,10 +130,12 @@ Checks whether the user is logged into GitHub in the running Antigravity browser
 
 ### `_antigravity_ensure_acg_session`
 
-Checks whether the user is logged into ACG (`learn.acloud.guru`) in the running Antigravity browser (via Playwright CDP). If not logged in, navigates to the sign-in page and waits up to 300s for the user to complete login interactively. Returns 1 on timeout.
+Checks whether the user is logged into Pluralsight's Cloud Playground (`app.pluralsight.com/cloud-playground/cloud-sandboxes`) in the running Antigravity browser (via Playwright CDP). If not logged in, navigates to the sign-in page and waits up to 300s for the user to complete login interactively. Returns 1 on timeout.
 
 **First-run note:** On a brand new environment, the Antigravity browser will open and display the ACG sign-in page. Log in manually — the session cookie is persisted in the Antigravity browser profile and reused on all subsequent runs until it expires.
 
-Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass this check (e.g. while the ACG domain migration to Pluralsight is pending).
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the Pluralsight session check (e.g. for CI runs or when Playwright is unavailable).
 
-> **Note:** `learn.acloud.guru` currently redirects to Pluralsight — URL update tracked in v0.9.18 ([issue](../issues/2026-03-28-acg-domain-redirection.md)).
+| Env Var | Default | Description |
+|---|---|---|
+| `K3DM_ACG_SKIP_SESSION_CHECK` | `0` | Set to `1` to bypass the Pluralsight session check (useful for CI or if Playwright cannot launch) |

--- a/docs/gists/install.md
+++ b/docs/gists/install.md
@@ -8,4 +8,22 @@ cd k3d-manager
 
 Requires bash 4+ (auto-detected — macOS ships bash 3.2, Homebrew bash is used automatically if present).
 
+## Pre-commit Hooks (recommended)
+
+Installs the agent rigor pre-commit hook — enforces shellcheck, security rules, and subtree protection on every commit:
+
+```bash
+bash scripts/hooks/install-hooks.sh
+```
+
+## rigor-cli (optional — standalone enforcement)
+
+[rigor-cli](https://github.com/wilddog64/rigor-cli) wraps the same agent rigor framework as a standalone CLI. Useful for running `audit`, `lint`, and `checkpoint` outside of the pre-commit hook (e.g. in CI or on demand in any Bash project):
+
+```bash
+git clone git@github.com:wilddog64/rigor-cli.git
+cd rigor-cli
+./bin/rigor --help
+```
+
 Full docs: https://github.com/wilddog64/k3d-manager

--- a/docs/howto/acg.md
+++ b/docs/howto/acg.md
@@ -16,7 +16,7 @@ The ACG plugin provisions a t3.medium EC2 instance on an ACG (A Cloud Guru) sand
 # Restrict ingress to your IP (recommended)
 export ACG_ALLOWED_CIDR=$(curl -s ifconfig.me)/32
 
-acg_provision --confirm
+./scripts/k3d-manager acg_provision --confirm
 ```
 
 Creates: VPC, subnet, security group, key pair, t3.medium EC2 instance. Updates `~/.ssh/config` with the `ubuntu` host alias.
@@ -24,7 +24,7 @@ Creates: VPC, subnet, security group, key pair, t3.medium EC2 instance. Updates 
 ### 2. Verify
 
 ```bash
-acg_status
+./scripts/k3d-manager acg_status
 ```
 
 Shows instance state, public IP, and k3s health. Wait until k3s reports `Running` before proceeding.
@@ -43,9 +43,9 @@ Installs k3s via k3sup and merges the kubeconfig as the `ubuntu-k3s` context.
 ACG sandboxes expire after 4 hours. To extend:
 
 ```bash
-antigravity_acg_extend <sandbox-url>
+./scripts/k3d-manager antigravity_acg_extend <sandbox-url>
 # Example cloud playground URL
-antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
+./scripts/k3d-manager antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
 ```
 
 The Antigravity browser opens and clicks the extend button automatically. **First run:** you will be prompted to log into Pluralsight manually in the browser window — session persists for subsequent runs.
@@ -55,7 +55,7 @@ Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the Pluralsight session check (use
 ### 5. Teardown
 
 ```bash
-acg_teardown --confirm
+./scripts/k3d-manager acg_teardown --confirm
 ```
 
 Terminates the EC2 instance, removes the VPC/SG/key pair, and removes the `ubuntu-k3s` context from `~/.kube/config`.

--- a/docs/howto/acg.md
+++ b/docs/howto/acg.md
@@ -44,11 +44,13 @@ ACG sandboxes expire after 4 hours. To extend:
 
 ```bash
 antigravity_acg_extend <sandbox-url>
+# Example cloud playground URL
+antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
 ```
 
-The Antigravity browser opens and clicks the extend button automatically. **First run:** you will be prompted to log into ACG manually in the browser window — session persists for subsequent runs.
+The Antigravity browser opens and clicks the extend button automatically. **First run:** you will be prompted to log into Pluralsight manually in the browser window — session persists for subsequent runs.
 
-Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the login check while the ACG → Pluralsight domain migration is pending (v0.9.18).
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the Pluralsight session check (useful for CI or troubleshooting Playwright issues).
 
 ### 5. Teardown
 

--- a/docs/howto/acg.md
+++ b/docs/howto/acg.md
@@ -1,0 +1,65 @@
+# How-To: ACG Sandbox (AWS EC2)
+
+The ACG plugin provisions a t3.medium EC2 instance on an ACG (A Cloud Guru) sandbox account, installs k3s via k3sup, and wires it into `~/.kube/config` as the `ubuntu-k3s` context.
+
+## Prerequisites
+
+- Active ACG sandbox with AWS credentials copied to `~/.aws/credentials`
+- `aws`, `k3sup`, and `ssh` in PATH
+- SSH key pair available (generated automatically by `acg_provision`)
+
+## Full Lifecycle
+
+### 1. Provision
+
+```bash
+# Restrict ingress to your IP (recommended)
+export ACG_ALLOWED_CIDR=$(curl -s ifconfig.me)/32
+
+acg_provision --confirm
+```
+
+Creates: VPC, subnet, security group, key pair, t3.medium EC2 instance. Updates `~/.ssh/config` with the `ubuntu` host alias.
+
+### 2. Verify
+
+```bash
+acg_status
+```
+
+Shows instance state, public IP, and k3s health. Wait until k3s reports `Running` before proceeding.
+
+### 3. Install k3s and Merge Kubeconfig
+
+```bash
+UBUNTU_K3S_SSH_HOST=ubuntu \
+  ./scripts/k3d-manager deploy_app_cluster
+```
+
+Installs k3s via k3sup and merges the kubeconfig as the `ubuntu-k3s` context.
+
+### 4. Extend Sandbox TTL
+
+ACG sandboxes expire after 4 hours. To extend:
+
+```bash
+antigravity_acg_extend <sandbox-url>
+```
+
+The Antigravity browser opens and clicks the extend button automatically. **First run:** you will be prompted to log into ACG manually in the browser window — session persists for subsequent runs.
+
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the login check while the ACG → Pluralsight domain migration is pending (v0.9.18).
+
+### 5. Teardown
+
+```bash
+acg_teardown --confirm
+```
+
+Terminates the EC2 instance, removes the VPC/SG/key pair, and removes the `ubuntu-k3s` context from `~/.kube/config`.
+
+## Notes
+
+- `ACG_ALLOWED_CIDR` defaults to `0.0.0.0/0` (open) — always set it to your IP in shared/public environments
+- The sandbox TTL is 4 hours by default; extend before it expires to avoid losing cluster state
+- All AWS resources are tagged with `k3d-manager` for easy identification in the ACG console

--- a/docs/howto/antigravity.md
+++ b/docs/howto/antigravity.md
@@ -37,9 +37,9 @@ Antigravity opens the sandbox page and clicks the extend button (+4 hours). The 
 
 ```bash
 # Example
-antigravity_acg_extend "https://learn.acloud.guru/lab/..."
+antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
 
-# Skip ACG session check (while domain migration to Pluralsight is pending)
+# Skip ACG session check (useful for CI or if Playwright cannot launch)
 K3DM_ACG_SKIP_SESSION_CHECK=1 antigravity_acg_extend "<sandbox-url>"
 ```
 

--- a/docs/howto/antigravity.md
+++ b/docs/howto/antigravity.md
@@ -1,0 +1,93 @@
+# How-To: Antigravity Browser Automation
+
+Antigravity is an agent-first IDE (VS Code fork) with a built-in Chromium browser. k3d-manager uses it for browser automation tasks — extending ACG sandbox TTL and triggering GitHub Copilot coding agent reviews — via the Playwright MCP server over CDP (port 9222).
+
+## Prerequisites
+
+- Node.js 18+ (`_ensure_node` installs it if missing)
+- Antigravity IDE installed (see below)
+- gemini CLI authenticated (`gemini auth login`)
+
+## First-Time Setup
+
+```bash
+./scripts/k3d-manager antigravity_install
+```
+
+This verifies and installs (if missing):
+- Node.js
+- `@google/gemini-cli`
+- Antigravity IDE binary (`agy` or `antigravity`)
+- Playwright MCP entry in Antigravity's `mcp_config.json`
+
+### First-Run Login
+
+On first use, Antigravity will open its browser window and navigate to the target site's login page. **Log in manually** — the session cookie is saved in Antigravity's browser profile and reused on all subsequent runs until it expires.
+
+- **ACG login:** triggered by `antigravity_acg_extend`
+- **GitHub login:** triggered by `antigravity_trigger_copilot_review`
+
+## Extend ACG Sandbox TTL
+
+```bash
+antigravity_acg_extend <sandbox-url>
+```
+
+Antigravity opens the sandbox page and clicks the extend button (+4 hours). The new expiry time is printed on completion.
+
+```bash
+# Example
+antigravity_acg_extend "https://learn.acloud.guru/lab/..."
+
+# Skip ACG session check (while domain migration to Pluralsight is pending)
+K3DM_ACG_SKIP_SESSION_CHECK=1 antigravity_acg_extend "<sandbox-url>"
+```
+
+## Trigger a GitHub Copilot Coding Agent Review
+
+```bash
+antigravity_trigger_copilot_review <owner> <repo> [prompt]
+```
+
+Navigates to `github.com/<owner>/<repo>/agents`, creates a new Copilot coding agent task with the given prompt, and returns the task UUID.
+
+```bash
+# Default prompt: "Review this codebase for code quality, security, and architecture."
+antigravity_trigger_copilot_review wilddog64 k3d-manager
+
+# Custom prompt
+antigravity_trigger_copilot_review wilddog64 k3d-manager "Focus on shell injection risks."
+```
+
+## Poll a Copilot Task
+
+```bash
+antigravity_poll_task <owner> <repo> <task-uuid> [timeout-seconds]
+```
+
+Polls the task URL every 30 seconds until complete (default timeout: 300s). Prints the full review output verbatim.
+
+## How It Works
+
+```
+k3d-manager function
+    → gemini CLI (--model gemini-2.5-flash, fallback to 2.0/1.5)
+        → Playwright MCP over CDP → Antigravity browser (port 9222)
+```
+
+gemini generates a Playwright Node.js script, writes it to `${HOME}/.gemini/tmp/k3d-manager/`, and executes it. The script connects to the running Antigravity browser via CDP — it does not launch a new headless browser.
+
+## Troubleshoot
+
+```bash
+# Verify Antigravity is running and CDP is exposed
+curl -sf http://localhost:9222/json | jq '.[0].title'
+
+# Manually launch Antigravity with CDP
+open -a "Antigravity" --args --remote-debugging-port=9222   # macOS
+antigravity --remote-debugging-port=9222 &                  # Linux
+
+# Check gemini CLI
+gemini --version
+gemini --model gemini-2.5-flash --prompt "say hello"
+```

--- a/docs/howto/antigravity.md
+++ b/docs/howto/antigravity.md
@@ -30,17 +30,17 @@ On first use, Antigravity will open its browser window and navigate to the targe
 ## Extend ACG Sandbox TTL
 
 ```bash
-antigravity_acg_extend <sandbox-url>
+./scripts/k3d-manager antigravity_acg_extend <sandbox-url>
 ```
 
 Antigravity opens the sandbox page and clicks the extend button (+4 hours). The new expiry time is printed on completion.
 
 ```bash
 # Example
-antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
+./scripts/k3d-manager antigravity_acg_extend "https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
 
 # Skip ACG session check (useful for CI or if Playwright cannot launch)
-K3DM_ACG_SKIP_SESSION_CHECK=1 antigravity_acg_extend "<sandbox-url>"
+K3DM_ACG_SKIP_SESSION_CHECK=1 ./scripts/k3d-manager antigravity_acg_extend "<sandbox-url>"
 ```
 
 ## Trigger a GitHub Copilot Coding Agent Review
@@ -53,16 +53,16 @@ Navigates to `github.com/<owner>/<repo>/agents`, creates a new Copilot coding ag
 
 ```bash
 # Default prompt: "Review this codebase for code quality, security, and architecture."
-antigravity_trigger_copilot_review wilddog64 k3d-manager
+./scripts/k3d-manager antigravity_trigger_copilot_review wilddog64 k3d-manager
 
 # Custom prompt
-antigravity_trigger_copilot_review wilddog64 k3d-manager "Focus on shell injection risks."
+./scripts/k3d-manager antigravity_trigger_copilot_review wilddog64 k3d-manager "Focus on shell injection risks."
 ```
 
 ## Poll a Copilot Task
 
 ```bash
-antigravity_poll_task <owner> <repo> <task-uuid> [timeout-seconds]
+./scripts/k3d-manager antigravity_poll_task <owner> <repo> <task-uuid> [timeout-seconds]
 ```
 
 Polls the task URL every 30 seconds until complete (default timeout: 300s). Prints the full review output verbatim.

--- a/docs/howto/argocd.md
+++ b/docs/howto/argocd.md
@@ -1,0 +1,65 @@
+# How-To: ArgoCD
+
+ArgoCD is the GitOps engine. It runs on the infra cluster and manages application deployments on the app cluster (Ubuntu k3s) via hub-and-spoke.
+
+## Prerequisites
+
+- Infra cluster running (`deploy_cluster`)
+- Vault and ESO deployed (for Vault-managed deploy keys)
+
+## Deploy ArgoCD
+
+```bash
+./scripts/k3d-manager deploy_argocd --confirm
+```
+
+Installs ArgoCD via Helm into the `cicd` namespace. Vault-managed deploy keys are configured automatically so ArgoCD can pull from private GitHub repos.
+
+## Bootstrap Initial Apps
+
+```bash
+./scripts/k3d-manager deploy_argocd_bootstrap
+```
+
+Applies the root App-of-Apps manifest — ArgoCD self-manages its own app definitions from that point forward.
+
+## Register the App Cluster (Ubuntu k3s)
+
+After `deploy_app_cluster` completes and the kubeconfig is merged:
+
+```bash
+./scripts/k3d-manager register_shopping_cart_apps
+```
+
+This registers the `ubuntu-k3s` context as a target cluster in ArgoCD and creates Application CRs for the shopping-cart services.
+
+## Configure Vault Deploy Keys
+
+```bash
+./scripts/k3d-manager configure_vault_argocd_repos
+```
+
+Rotates the deploy keys stored in Vault and updates ArgoCD's repository credentials. Run this after any Vault PKI rotation.
+
+## Common Operations
+
+```bash
+# Check all application sync status
+kubectl get applications -n cicd
+
+# Force sync a specific app
+argocd app sync <app-name>
+
+# View sync history
+argocd app history <app-name>
+
+# Access ArgoCD UI (port-forward)
+kubectl port-forward svc/argocd-server -n cicd 8080:443
+# then open https://localhost:8080
+```
+
+## Notes
+
+- ArgoCD runs on the **infra cluster** (`k3d-k3d-cluster` context) and deploys to the **app cluster** (`ubuntu-k3s` context)
+- All Application CRs live in the `cicd` namespace on the infra cluster
+- Deploy keys are rotated via `configure_vault_argocd_repos` — never commit SSH keys to git

--- a/docs/howto/cert-manager.md
+++ b/docs/howto/cert-manager.md
@@ -1,0 +1,65 @@
+# How-To: cert-manager
+
+cert-manager handles TLS certificate issuance and renewal. k3d-manager deploys cert-manager and configures two ClusterIssuers: one backed by Vault PKI (internal cluster TLS) and one backed by Let's Encrypt ACME (public-facing endpoints).
+
+## Prerequisites
+
+- Infra cluster running (`deploy_cluster`)
+- Vault deployed and PKI configured (`deploy_vault`) — required for the Vault issuer
+- A valid email address for Let's Encrypt registration
+
+## Deploy cert-manager
+
+```bash
+ACME_EMAIL=you@example.com \
+  ./scripts/k3d-manager deploy_cert_manager --confirm
+```
+
+Installs cert-manager via Helm and creates:
+- `vault-issuer` ClusterIssuer — signs certs via Vault PKI intermediate CA
+- `letsencrypt-prod` ClusterIssuer — signs certs via Let's Encrypt ACME HTTP-01 challenge
+
+## Issue a Certificate
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: myservice-tls
+  namespace: myservice
+spec:
+  secretName: myservice-tls
+  issuerRef:
+    name: vault-issuer        # or letsencrypt-prod for public endpoints
+    kind: ClusterIssuer
+  dnsNames:
+    - myservice.example.com
+```
+
+```bash
+kubectl apply -f myservice-cert.yaml
+kubectl describe certificate myservice-tls -n myservice
+```
+
+## Common Operations
+
+```bash
+# List all certificates and their status
+kubectl get certificates -A
+
+# Check a certificate's renewal schedule
+kubectl describe certificate <name> -n <namespace>
+
+# Force renewal
+kubectl delete secret <tls-secret-name> -n <namespace>
+# cert-manager re-issues automatically within ~1 minute
+
+# Check cert-manager logs
+kubectl logs -n cert-manager deploy/cert-manager -f
+```
+
+## Notes
+
+- Vault issuer cert TTL is capped at 720h (`VAULT_PKI_ROLE_TTL`) — cert-manager renews at 2/3 of TTL
+- Let's Encrypt rate limits apply in production — use `letsencrypt-staging` for testing
+- `--insecure` and `insecureSkipVerify: true` are dev-only flags — never use against production endpoints

--- a/docs/howto/eso.md
+++ b/docs/howto/eso.md
@@ -1,0 +1,73 @@
+# How-To: External Secrets Operator
+
+ESO syncs secrets from Vault (or Azure Key Vault) into Kubernetes `Secret` objects. k3d-manager deploys ESO and configures it to pull from the infra cluster's Vault instance.
+
+## Prerequisites
+
+- Vault deployed and healthy (`deploy_vault`)
+- Infra cluster running
+
+## Deploy ESO
+
+```bash
+./scripts/k3d-manager deploy_eso
+```
+
+This installs ESO via Helm and creates a `ClusterSecretStore` backed by the Vault KV engine.
+
+## How It Works
+
+```
+Vault KV (secret/k3d-manager/...)
+        ↓  ESO ClusterSecretStore
+Kubernetes Secret (in target namespace)
+```
+
+ESO polls Vault on a configurable interval. When a Vault secret changes, ESO updates the Kubernetes `Secret` automatically — no manual `kubectl create secret` needed.
+
+## Add a New Secret
+
+1. Write the secret to Vault:
+   ```bash
+   vault kv put secret/k3d-manager/myapp password=s3cr3t
+   ```
+
+2. Create an `ExternalSecret` CR in your namespace:
+   ```yaml
+   apiVersion: external-secrets.io/v1beta1
+   kind: ExternalSecret
+   metadata:
+     name: myapp-secret
+     namespace: myapp
+   spec:
+     refreshInterval: 1h
+     secretStoreRef:
+       name: vault-backend
+       kind: ClusterSecretStore
+     target:
+       name: myapp-secret
+     data:
+       - secretKey: password
+         remoteRef:
+           key: secret/data/k3d-manager/myapp
+           property: password
+   ```
+
+## Troubleshoot Sync Failures
+
+```bash
+# Check ESO controller logs
+kubectl logs -n external-secrets deploy/external-secrets -f
+
+# Check ExternalSecret status
+kubectl describe externalsecret myapp-secret -n myapp
+
+# Force a resync
+kubectl annotate externalsecret myapp-secret -n myapp \
+  force-sync=$(date +%s) --overwrite
+```
+
+## Notes
+
+- Secrets are never stored in git — ESO pulls from Vault at runtime
+- Use `ClusterSecretStore` for cross-namespace access; `SecretStore` for namespace-scoped stores

--- a/docs/howto/eso.md
+++ b/docs/howto/eso.md
@@ -29,7 +29,7 @@ ESO polls Vault on a configurable interval. When a Vault secret changes, ESO upd
 
 1. Write the secret to Vault:
    ```bash
-   vault kv put secret/k3d-manager/myapp password=s3cr3t
+   vault kv put secret/k3d-manager/myapp password=<your-password>
    ```
 
 2. Create an `ExternalSecret` CR in your namespace:

--- a/docs/howto/keycloak.md
+++ b/docs/howto/keycloak.md
@@ -1,0 +1,49 @@
+# How-To: Keycloak
+
+Keycloak provides identity federation for the infra cluster — SSO for Jenkins, ArgoCD, and other services. k3d-manager deploys Keycloak and can connect it to the OpenLDAP or Active Directory directory service.
+
+## Prerequisites
+
+- Infra cluster running (`deploy_cluster`)
+- LDAP/AD deployed (`deploy_ldap` or `deploy_ad`) if using directory federation
+
+## Deploy Keycloak
+
+```bash
+./scripts/k3d-manager deploy_keycloak --confirm
+```
+
+Installs Keycloak via Helm into its own namespace. Admin credentials are stored in Vault.
+
+## Smoke Test
+
+```bash
+./scripts/k3d-manager test_keycloak
+```
+
+Verifies the Keycloak pod is healthy and the admin API responds.
+
+## Common Operations
+
+```bash
+# Access Keycloak admin UI (port-forward)
+kubectl port-forward svc/keycloak -n keycloak 8443:443
+# then open https://localhost:8443/auth/admin
+
+# Get admin password from Vault
+vault kv get secret/k3d-manager/keycloak
+```
+
+## LDAP Federation
+
+To connect Keycloak to the OpenLDAP instance deployed by `deploy_ldap`:
+
+1. Open the admin UI → User Federation → Add provider → LDAP
+2. Connection URL: `ldap://openldap.ldap.svc.cluster.local:389`
+3. Bind DN and credentials: retrieve from Vault (`secret/k3d-manager/ldap`)
+4. User DN: `ou=users,dc=example,dc=com` (adjust to your `LDAP_BASE_DN`)
+
+## Notes
+
+- Keycloak uses `AD_TLS_CONFIG=TRUST_ALL_CERTIFICATES` in dev — never use in production
+- Admin credentials are managed via Vault/ESO — do not hardcode in manifests

--- a/docs/howto/tunnel.md
+++ b/docs/howto/tunnel.md
@@ -1,0 +1,48 @@
+# How-To: SSH Tunnel (autossh)
+
+The tunnel plugin creates a persistent SSH tunnel from the M2/M4 Air to the Ubuntu k3s node, forwarding port 6443 so `kubectl` can reach the app cluster API server without a VPN.
+
+## Prerequisites
+
+- `autossh` installed (`brew install autossh` on macOS)
+- SSH access to the Ubuntu k3s node (configured in `~/.ssh/config` as `ubuntu`)
+- launchd (macOS) for boot persistence
+
+## Start the Tunnel
+
+```bash
+./scripts/k3d-manager tunnel_start
+```
+
+Starts an autossh process forwarding `localhost:6443 → ubuntu:6443`. Registers a launchd job so the tunnel restarts automatically on reboot and reconnects on network interruption.
+
+## Check Status
+
+```bash
+./scripts/k3d-manager tunnel_status
+```
+
+Shows the autossh process state and launchd job status.
+
+## Stop the Tunnel
+
+```bash
+./scripts/k3d-manager tunnel_stop
+```
+
+Kills the autossh process and unloads the launchd job.
+
+## Use the App Cluster
+
+Once the tunnel is active:
+
+```bash
+kubectl config use-context ubuntu-k3s
+kubectl get nodes
+```
+
+## Notes
+
+- The tunnel must be active before any `kubectl` commands targeting `ubuntu-k3s`
+- autossh handles reconnection automatically — no manual restart needed after network drops
+- Port 6443 is the Kubernetes API server port; ensure it is not in use locally

--- a/docs/howto/vault.md
+++ b/docs/howto/vault.md
@@ -1,0 +1,62 @@
+# How-To: HashiCorp Vault
+
+Vault provides secrets management and PKI for the infra cluster. k3d-manager deploys Vault in HA mode with a Raft storage backend and configures a PKI engine for TLS certificate issuance.
+
+## Prerequisites
+
+- Infra cluster running (`deploy_cluster`)
+- `helm` and `kubectl` in PATH
+
+## Deploy Vault
+
+```bash
+./scripts/k3d-manager deploy_vault --confirm
+```
+
+This installs Vault via Helm, initializes the Raft cluster, unseals automatically, and configures:
+- KV v2 secret store at `secret/`
+- PKI engine with a root CA and an intermediate issuer
+- Kubernetes auth mount for the infra cluster
+
+To review what will be applied without executing:
+```bash
+./scripts/k3d-manager deploy_vault --plan
+```
+
+## Cross-Cluster Auth (app cluster)
+
+After the app cluster (Ubuntu k3s) is registered:
+
+```bash
+./scripts/k3d-manager configure_vault_app_auth
+```
+
+This registers a second Kubernetes auth mount for the app cluster, allowing pods on Ubuntu k3s to authenticate to Vault using their ServiceAccount tokens.
+
+## PKI — Issue a Certificate
+
+```bash
+vault write pki_int/issue/k3d-manager \
+  common_name="myservice.svc.cluster.local" \
+  ttl="720h"
+```
+
+See **[Vault PKI Configuration](../api/vault-pki.md)** for full PKI variable reference, air-gapped setup, and example workflows.
+
+## Common Operations
+
+```bash
+# Check Vault status
+kubectl exec -n secrets vault-0 -- vault status
+
+# Re-unseal after restart
+./scripts/k3d-manager deploy_vault --confirm   # idempotent — safe to re-run
+
+# Rotate root token (manual — store securely)
+vault token create -policy=root -period=0
+```
+
+## Notes
+
+- Vault tokens must never appear in script arguments or CI logs — use env vars or stdin
+- Leaf cert TTL is capped at 720h by default (`VAULT_PKI_ROLE_TTL`) — do not increase without justification

--- a/docs/plans/v0.9.18-pluralsight-url-fix.md
+++ b/docs/plans/v0.9.18-pluralsight-url-fix.md
@@ -2,7 +2,7 @@
 
 **Branch:** `k3d-manager-v0.9.18`
 **Assigned to:** Codex (implementation) + Gemini (e2e verification)
-**Status:** Ready for implementation
+**Status:** Implemented
 
 ## Background
 

--- a/docs/plans/v0.9.18-pluralsight-url-fix.md
+++ b/docs/plans/v0.9.18-pluralsight-url-fix.md
@@ -1,0 +1,224 @@
+# Spec: v0.9.18 — Pluralsight URL Fix
+
+**Branch:** `k3d-manager-v0.9.18`
+**Assigned to:** Codex (implementation) + Gemini (e2e verification)
+**Status:** Ready for implementation
+
+## Background
+
+ACG (A Cloud Guru) migrated its platform to Pluralsight. `learn.acloud.guru` now 301-redirects
+to `acg-notice.pluralsight.com` and eventually to `app.pluralsight.com`. The correct new URL for
+cloud sandboxes is `https://app.pluralsight.com/cloud-playground/cloud-sandboxes`.
+
+A temporary bypass (`K3DM_ACG_SKIP_SESSION_CHECK=1`) was added in v0.9.17 to prevent
+`_antigravity_ensure_acg_session` from hanging 300 seconds on the broken URL. This spec
+replaces that bypass with the correct Pluralsight URLs and updated DOM selectors.
+
+---
+
+## Before You Start
+
+1. Read `memory-bank/activeContext.md` and `memory-bank/progress.md`
+2. `git pull origin k3d-manager-v0.9.18`
+3. Read the exact target files before editing:
+   - `scripts/plugins/acg.sh` — lines 17 and 276–282
+   - `scripts/plugins/antigravity.sh` — lines 105–131
+   - `docs/api/functions.md` — `_antigravity_ensure_acg_session` entry
+   - `docs/howto/acg.md`
+   - `docs/howto/antigravity.md`
+
+**Branch (all work):** `k3d-manager-v0.9.18`
+
+---
+
+## Target Files
+
+| File | Change |
+|------|--------|
+| `scripts/plugins/acg.sh` | Update `_ACG_SANDBOX_URL` constant |
+| `scripts/plugins/antigravity.sh` | Update `_antigravity_ensure_acg_session` URLs + selectors; update bypass guard message |
+| `docs/api/functions.md` | Update `_antigravity_ensure_acg_session` docs: remove "pending" language, update env var description |
+| `docs/howto/acg.md` | Update sandbox URL |
+| `docs/howto/antigravity.md` | Update ACG session note |
+
+---
+
+## Changes
+
+### 1. `scripts/plugins/acg.sh` — line 17
+
+**Old:**
+```bash
+_ACG_SANDBOX_URL="https://learn.acloud.guru/cloud-playground/cloud-sandboxes"
+```
+
+**New:**
+```bash
+_ACG_SANDBOX_URL="https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
+```
+
+---
+
+### 2. `scripts/plugins/antigravity.sh` — `_antigravity_ensure_acg_session` function (lines 105–131)
+
+**Old:**
+```bash
+function _antigravity_ensure_acg_session() {
+  if [[ "${K3DM_ACG_SKIP_SESSION_CHECK:-0}" == "1" ]]; then
+    _info "K3DM_ACG_SKIP_SESSION_CHECK=1 — skipping ACG session check (ACG domain migration pending)"
+    return 0
+  fi
+  _info "Checking ACG session in Antigravity browser..."
+
+  local gemini_prompt
+  gemini_prompt="You are a browser automation agent. Use Playwright (Node.js) to do the following:
+
+1. Connect to the running Antigravity browser via CDP: const browser = await chromium.connectOverCDP('http://localhost:9222');
+2. Use the first browser context and page (do NOT launch a new browser).
+3. Navigate to https://learn.acloud.guru and wait for the page to load.
+4. Check if the user is logged in by looking for user avatar, account menu, or dashboard elements.
+5. If logged in: print ACG_SESSION_OK and exit with code 0.
+6. If NOT logged in:
+   a. Navigate to https://learn.acloud.guru/sign-in
+   b. Print: ACTION REQUIRED: Please log into ACG in the Antigravity browser window, then press Enter to continue.
+   c. Wait for the page URL to no longer contain '/sign-in' — poll every 5 seconds, timeout after 300 seconds.
+   d. Once URL is no longer '/sign-in', print ACG_SESSION_OK and exit with code 0.
+   e. If 300 seconds pass without login, print ERROR: ACG login timeout and exit with code 1.
+
+Write the Playwright script to ${HOME}/.gemini/tmp/k3d-manager/ag_acg_session.js, execute with node, print the result.
+Exit code 1 if session cannot be confirmed."
+
+  _antigravity_gemini_prompt "$gemini_prompt" --yolo
+}
+```
+
+**New:**
+```bash
+function _antigravity_ensure_acg_session() {
+  if [[ "${K3DM_ACG_SKIP_SESSION_CHECK:-0}" == "1" ]]; then
+    _info "K3DM_ACG_SKIP_SESSION_CHECK=1 — skipping ACG/Pluralsight session check"
+    return 0
+  fi
+  _info "Checking Pluralsight (ACG) session in Antigravity browser..."
+
+  local gemini_prompt
+  gemini_prompt="You are a browser automation agent. Use Playwright (Node.js) to do the following:
+
+1. Connect to the running Antigravity browser via CDP: const browser = await chromium.connectOverCDP('http://localhost:9222');
+2. Use the first browser context and page (do NOT launch a new browser).
+3. Navigate to https://app.pluralsight.com/cloud-playground/cloud-sandboxes and wait for the page to load.
+4. Check if the user is logged in by looking for user avatar, account menu, or sandbox list elements (e.g. [data-testid='user-menu'], [aria-label='User menu'], or a heading containing 'Cloud Sandboxes').
+5. If logged in: print ACG_SESSION_OK and exit with code 0.
+6. If NOT logged in:
+   a. Navigate to https://app.pluralsight.com/id/signin
+   b. Print: ACTION REQUIRED: Please log into Pluralsight in the Antigravity browser window, then press Enter to continue.
+   c. Wait for the page URL to no longer contain '/signin' — poll every 5 seconds, timeout after 300 seconds.
+   d. Once URL is no longer '/signin', print ACG_SESSION_OK and exit with code 0.
+   e. If 300 seconds pass without login, print ERROR: Pluralsight login timeout and exit with code 1.
+
+Write the Playwright script to ${HOME}/.gemini/tmp/k3d-manager/ag_acg_session.js, execute with node, print the result.
+Exit code 1 if session cannot be confirmed."
+
+  _antigravity_gemini_prompt "$gemini_prompt" --yolo
+}
+```
+
+---
+
+### 3. `docs/api/functions.md` — `_antigravity_ensure_acg_session` entry
+
+Find the entry for `_antigravity_ensure_acg_session` and update:
+
+**Old text** (in the description):
+```
+Navigates to `learn.acloud.guru` and verifies an active session...
+...
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass while ACG domain migration is pending.
+```
+
+**New text**:
+```
+Navigates to `app.pluralsight.com/cloud-playground/cloud-sandboxes` and verifies an active session...
+...
+Set `K3DM_ACG_SKIP_SESSION_CHECK=1` to bypass the session check (e.g. in CI or when Playwright is unavailable).
+```
+
+Update the env var description table row for `K3DM_ACG_SKIP_SESSION_CHECK`:
+
+**Old:**
+```
+| `K3DM_ACG_SKIP_SESSION_CHECK` | `0` | Set to `1` to bypass the ACG session check while `learn.acloud.guru` redirects to Pluralsight (ACG domain migration pending) |
+```
+
+**New:**
+```
+| `K3DM_ACG_SKIP_SESSION_CHECK` | `0` | Set to `1` to bypass the Pluralsight session check (e.g. in CI or when Playwright is unavailable) |
+```
+
+---
+
+### 4. `docs/howto/acg.md` — sandbox URL reference
+
+Find any occurrence of `learn.acloud.guru/cloud-playground/cloud-sandboxes` and replace with
+`app.pluralsight.com/cloud-playground/cloud-sandboxes`.
+
+---
+
+### 5. `docs/howto/antigravity.md` — ACG session note
+
+Find any reference to `learn.acloud.guru` and update to `app.pluralsight.com`. Update any
+note about domain migration being "pending" — remove the "pending" language since it is fixed.
+
+---
+
+## Definition of Done
+
+- [ ] `scripts/plugins/acg.sh` line 17: `_ACG_SANDBOX_URL` points to `app.pluralsight.com`
+- [ ] `scripts/plugins/antigravity.sh`: `_antigravity_ensure_acg_session` uses Pluralsight URLs and updated selector hints; bypass message no longer says "migration pending"
+- [ ] `docs/api/functions.md`: `K3DM_ACG_SKIP_SESSION_CHECK` description updated (no "pending" language)
+- [ ] `docs/howto/acg.md`: sandbox URL updated
+- [ ] `docs/howto/antigravity.md`: ACG/Pluralsight references updated
+- [ ] `shellcheck scripts/plugins/acg.sh scripts/plugins/antigravity.sh` — zero new warnings
+- [ ] `bash scripts/tests/run_tests.sh` — all tests pass (no regressions)
+- [ ] Committed on `k3d-manager-v0.9.18` with message: `fix(acg): update ACG sandbox URL to Pluralsight — app.pluralsight.com migration`
+- [ ] Pushed: `git push origin k3d-manager-v0.9.18`
+- [ ] `memory-bank/activeContext.md` and `memory-bank/progress.md` updated with commit SHA
+
+**Exact commit message:**
+```
+fix(acg): update ACG sandbox URL to Pluralsight — app.pluralsight.com migration
+```
+
+---
+
+## What NOT to Do
+
+- Do NOT create a PR
+- Do NOT skip pre-commit hooks (`--no-verify`)
+- Do NOT modify files outside the listed targets
+- Do NOT commit to `main` — work on `k3d-manager-v0.9.18` only
+- Do NOT change `K3DM_ACG_SKIP_SESSION_CHECK` logic — only update the bypass message and the env var docs
+- Do NOT change Playwright selector logic beyond what is specified — the DOM selector hints are intentionally general to handle Pluralsight's actual page structure at runtime
+
+---
+
+## Verification (Gemini — after Codex commits)
+
+After Codex pushes the commit:
+
+1. `git pull origin k3d-manager-v0.9.18`
+2. Confirm `_ACG_SANDBOX_URL` in `acg.sh` points to `app.pluralsight.com`
+3. Confirm `_antigravity_ensure_acg_session` in `antigravity.sh` navigates to `app.pluralsight.com`
+4. Start antigravity: `./scripts/k3d-manager antigravity_install`
+5. Run: `K3DM_ACG_SKIP_SESSION_CHECK=0 ./scripts/k3d-manager antigravity_acg_extend <sandbox_url> 4`
+   - Expected: Playwright script navigates to `app.pluralsight.com/cloud-playground/cloud-sandboxes`
+   - Expected: Session check either prints `ACG_SESSION_OK` (logged in) or prompts for login
+6. Report: actual URL navigated to, session check result, any errors
+
+---
+
+## Rules
+
+- shellcheck must pass with zero new warnings before commit
+- BATS tests must pass: `bash scripts/tests/run_tests.sh`
+- Pre-commit hooks must not be skipped

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,7 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
-| v0.9.17 | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
+| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| v0.9.18 | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,7 +3,7 @@
 | Version | Date | Highlights |
 |---|---|---|
 | v0.9.18 | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
-| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-28 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
+| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.13](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.13) | 2026-03-23 | v0.9.12 retro, `/create-pr` `mergeable_state` check, CHANGE.md backfill for v0.9.12 |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |

--- a/docs/retro/2026-03-28-v0.9.17-retrospective.md
+++ b/docs/retro/2026-03-28-v0.9.17-retrospective.md
@@ -1,0 +1,44 @@
+# Retrospective — v0.9.17
+
+**Date:** 2026-03-28
+**Milestone:** Antigravity model fallback + ACG session check + nested agent fix
+**PR:** #52 — merged to main (`c88ca7a`)
+**Participants:** Claude, Codex, Gemini, Copilot
+
+## What Went Well
+
+- **Model fallback worked on first real run** — `gemini-2.5-flash` succeeded immediately once correctly placed first in the array; no model exhaustion during the final e2e retest
+- **Copilot caught meaningful issues** — yolo always-on (safety rule violation), broken tag links, sleep not stubbed, tmpdir not isolated; all 10 findings across 2 review rounds were valid and worth fixing
+- **`--yolo` opt-in design** — cleaner than the original always-on; `antigravity_poll_task` correctly excluded; pattern is reusable for future helpers that mix Playwright and non-Playwright prompts
+- **`K3DM_ACG_SKIP_SESSION_CHECK` guard** — minimal, reversible, doesn't break existing callers while the Pluralsight migration is pending
+- **BATS isolation improvement** — `BATS_TEST_TMPDIR` for tmpdir + `sleep` stub in `setup()` are good patterns to carry forward
+
+## What Went Wrong
+
+- **BATS mocks hardcoded old model order** — tests 13/14 were written before the array order was flipped; CI caught it immediately but it was avoidable. Root cause: Codex wrote tests against the original spec order, not the implemented order.
+- **Model array written in wrong order initially** — spec said ascending (`1.5 → 2.0 → 2.5`), implemented ascending, then had to flip. Spec should have said descending from the start.
+- **Model order inconsistency in 3 places** — `activeContext.md`, `docs/plans/v0.9.17-antigravity-model-fallback.md`, and BATS mocks all had stale order after the flip. A single flip should cascade to all dependents.
+- **`--approval-mode yolo` added globally** — when fixing nested agent restrictions, the flag was added to the shared helper without checking all callers. Should audit all call sites when adding a mode flag.
+- **Gemini made unauthorized `cluster_var.sh` change** — scope creep during an e2e test task. Reverted with `git revert`. Rule added to GEMINI.md Known Failure Modes.
+- **Pre-released tag links in PR** — README and docs/releases.md included `[v0.9.17](releases/tag/v0.9.17)` before the tag existed; Copilot caught both. Convention: use plain text for the current version until post-merge creates the tag.
+
+## Process Rules Added
+
+| Rule | File | Added |
+|------|------|-------|
+| `--approval-mode yolo` only for tightly scoped prompts writing to workspace temp dir | `AGENTS.md` rule #13 | v0.9.17 |
+| `--approval-mode yolo` safety rule + known failure mode for scope creep | `GEMINI.md` | v0.9.17 |
+| Don't add tag hyperlinks to releases tables in the PR — add them in post-merge | Process (this retro) | v0.9.17 |
+| When adding a mode flag to a shared helper, audit every call site | Process (this retro) | v0.9.17 |
+| BATS tests for model arrays must match the implemented order, not the spec order | Process (this retro) | v0.9.17 |
+
+## Decisions Made
+
+- **`--yolo` opt-in via second parameter** — `_antigravity_gemini_prompt "prompt" --yolo`; Playwright callers pass it, web_fetch callers do not. Pattern is final.
+- **`K3DM_ACG_SKIP_SESSION_CHECK=1`** — env guard to bypass `_antigravity_ensure_acg_session` while `learn.acloud.guru` redirects to Pluralsight. URL fix is v0.9.18 scope.
+- **`gemini-2.5-flash` first** — model array order is descending by capability: best model first, degrade only on 429/exhaustion. This is the permanent order.
+- **v0.9.17 is the last version before considering v0.9.x series length** — noted by user that v0.9.x is unusually long (18 versions). Agreed to continue to v1.0.0 without artificial version bump, but acknowledged the series is longer than v0.7.x (3) or v0.8.x (1).
+
+## Theme
+
+v0.9.17 was a hardening sprint for the Antigravity plugin. The core work — model fallback, ACG session check, nested agent restrictions — took multiple iterations because each fix exposed the next issue: model capacity → model order → nested agent path restrictions → yolo safety. Copilot caught two rounds of findings (10 total), with the most impactful being the always-on yolo flag and the pre-released tag links. The sprint ended with a cleaner helper design (`--yolo` opt-in) and two new BATS best practices (sleep stub in setup, tmpdir isolation) that apply to any future test suite touching filesystem or time.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,9 +7,10 @@
 **v0.9.14 SHIPPED** — PR #50 merged to main (`d317429b`) 2026-03-24. No version tag. if-count allowlist fully cleared.
 **v0.9.15 SHIPPED** — PR #51 merged (`484354da`) 2026-03-27. Tagged v0.9.15, released.
 **v0.9.16 SHIPPED** — PR #51 merged (`484354da`) 2026-03-27. Tagged v0.9.16, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-27-v0.9.16-retrospective.md`.
-**v0.9.17 ACTIVE** — branch `k3d-manager-v0.9.17` cut from `484354da` 2026-03-27. lib-foundation v0.3.14 subtree-pulled (`583b0d0`). Unblocked.
-**Current task:** Model fallback helper — **COMPLETE**. Implemented `_antigravity_gemini_prompt` in `scripts/plugins/antigravity.sh` (tries gemini-2.5-flash → 2.0-flash → 1.5-flash); verified via mock fallback test. Commit: `d004bb3`.
-**enforce_admins:** restored on main 2026-03-24.
+**v0.9.17 SHIPPED** — PR #52 merged (`c88ca7a`) 2026-03-28. Tagged v0.9.17. Released.
+**v0.9.18 ACTIVE** — branch `k3d-manager-v0.9.18` cut from `c88ca7a` 2026-03-28.
+**enforce_admins:** restored on main 2026-03-28.
+**Branch cleanup:** v0.9.7–v0.9.17 deleted (local + remote) 2026-03-28.
 **v0.9.15 scope:** Antigravity × GitHub Copilot coding agent validation — 3 runs, determinism verdict; spec `docs/plans/v0.9.15-antigravity-copilot-agent.md`. Antigravity plugin rewritten in `b2ba187` per `docs/plans/v0.9.15-antigravity-plugin-impl.md`. Also: ldap-password-rotator `vault kv put` stdin hardening — spec `docs/plans/v0.9.15-ensure-copilot-cli.md` (closes v0.6.2 security debt; `_ensure_copilot_cli`/`_k3d_manager_copilot`/`_ensure_node` already shipped in v0.9.12).
 
 ---

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,7 +19,7 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| **Pluralsight URL fix** | **SPEC READY** | Spec: `docs/plans/v0.9.18-pluralsight-url-fix.md`; assigned to Codex; Gemini verifies e2e |
+| **Pluralsight URL fix** | **COMPLETE** | `8f857ea` updates ACG + Antigravity plugins and docs to use `app.pluralsight.com` per `docs/plans/v0.9.18-pluralsight-url-fix.md`; Gemini to verify e2e |
 | **Nested agent fix** | **COMPLETE** | Implemented `--approval-mode yolo` + workspace temp path in `scripts/plugins/antigravity.sh`; commit `978b215`. |
 | **E2E live test: ACG session** | **COMPLETE** | Verified `gemini-2.5-flash` is used as the first attempt (no fallback needed). Nested agent fix verified. Platform redirection issue remains but session check logic passed via manual login. |
 | Reduce replicas + remove HPAs | **MERGED** | 5 repos squash-merged to main 2026-03-20 |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.17` (as of 2026-03-27)
+## Current Branch: `k3d-manager-v0.9.18` (as of 2026-03-28)
 
 **v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. Copilot CLI CI integration.
 **v0.9.13 SHIPPED** — PR #48 merged to main (`c54fbe6`) 2026-03-23. Tagged v0.9.13, released.
@@ -15,10 +15,11 @@
 
 ---
 
-## Current Focus
+## Current Focus (v0.9.18)
 
 | Item | Status | Notes |
 |---|---|---|
+| **Pluralsight URL fix** | **SPEC READY** | Spec: `docs/plans/v0.9.18-pluralsight-url-fix.md`; assigned to Codex; Gemini verifies e2e |
 | **Nested agent fix** | **COMPLETE** | Implemented `--approval-mode yolo` + workspace temp path in `scripts/plugins/antigravity.sh`; commit `978b215`. |
 | **E2E live test: ACG session** | **COMPLETE** | Verified `gemini-2.5-flash` is used as the first attempt (no fallback needed). Nested agent fix verified. Platform redirection issue remains but session check logic passed via manual login. |
 | Reduce replicas + remove HPAs | **MERGED** | 5 repos squash-merged to main 2026-03-20 |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -50,7 +50,7 @@
 
 ## v0.9.18 — Active
 
-- [ ] **Pluralsight URL fix** — update `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` URLs/selectors; spec: `docs/plans/v0.9.18-pluralsight-url-fix.md`; **Codex** implements, **Gemini** verifies e2e
+- [x] **Pluralsight URL fix** — commit `8f857ea` updates `_ACG_SANDBOX_URL`, `_antigravity_ensure_acg_session`, and docs per `docs/plans/v0.9.18-pluralsight-url-fix.md`; Gemini to run e2e verification
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -16,9 +16,10 @@
 **v0.9.14 SHIPPED** — PR #50 merged to main (`d317429b`) 2026-03-24. No version tag (CHANGE.md [Unreleased]). if-count allowlist fully cleared: _run_command + _ensure_node helpers extracted via lib-foundation PR #13.
 **v0.9.15 SHIPPED** — PR #51 squash-merged to main (`484354da`) 2026-03-27. Tagged v0.9.15, released.
 **v0.9.16 SHIPPED** — PR #51 squash-merged to main (`484354da`) 2026-03-27. Tagged v0.9.16, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-27-v0.9.16-retrospective.md`.
-**v0.9.17 ACTIVE** — branch `k3d-manager-v0.9.17`; PR #52 open 2026-03-28; CI in progress; Copilot tagged.
+**v0.9.17 SHIPPED** — PR #52 merged to main (`c88ca7a`) 2026-03-28. Tagged v0.9.17, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.17-retrospective.md`. Branches v0.9.7–v0.9.17 deleted.
+**v0.9.18 ACTIVE** — branch `k3d-manager-v0.9.18` cut from `c88ca7a` 2026-03-28.
 
-## v0.9.17 — In Progress
+## v0.9.17 — Shipped
 
 - [x] **`_antigravity_ensure_acg_session`** — Implemented in `scripts/plugins/antigravity.sh`; BATS coverage in `scripts/tests/lib/antigravity.bats`; verified via `env -i` BATS run.
 - [x] **E2E live test: `_antigravity_ensure_acg_session`** — **COMPLETE**. Verified `gemini-2.5-flash` is used as first attempt. Fallback helper and nested agent fix (YOLO + workspace temp) verified working. ACG login logic verified via manual prompt. Spec: `docs/plans/v0.9.17-acg-session-e2e-test.md`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -51,10 +51,11 @@
 ## v0.9.18 — Active
 
 - [x] **Pluralsight URL fix** — commit `8f857ea` updates `_ACG_SANDBOX_URL`, `_antigravity_ensure_acg_session`, and docs per `docs/plans/v0.9.18-pluralsight-url-fix.md`; Gemini to run e2e verification
+- [ ] **scratch/ cleanup** — delete all stale Playwright artifacts and debug scripts from `scratch/` (already gitignored); policy: wipe at each release cut in `/post-merge` Step 8 alongside branch pruning
 
 ---
 
-## v0.9.17 — Planned
+## v0.9.17 — Completed
 
 - [x] **`_antigravity_ensure_acg_session`** — Implemented in `scripts/plugins/antigravity.sh`; BATS coverage in `scripts/tests/lib/antigravity.bats`; verified via `env -i` BATS run.
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -48,6 +48,12 @@
 
 ---
 
+## v0.9.18 — Active
+
+- [ ] **Pluralsight URL fix** — update `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` URLs/selectors; spec: `docs/plans/v0.9.18-pluralsight-url-fix.md`; **Codex** implements, **Gemini** verifies e2e
+
+---
+
 ## v0.9.17 — Planned
 
 - [x] **`_antigravity_ensure_acg_session`** — Implemented in `scripts/plugins/antigravity.sh`; BATS coverage in `scripts/tests/lib/antigravity.bats`; verified via `env -i` BATS run.

--- a/scripts/plugins/acg.sh
+++ b/scripts/plugins/acg.sh
@@ -14,7 +14,7 @@ _ACG_AMI_OWNER="099720109477"
 _ACG_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
 _ACG_VPC_CIDR="10.0.0.0/16"
 _ACG_SUBNET_CIDR="10.0.1.0/24"
-_ACG_SANDBOX_URL="https://learn.acloud.guru/cloud-playground/cloud-sandboxes"
+_ACG_SANDBOX_URL="https://app.pluralsight.com/cloud-playground/cloud-sandboxes"
 
 _acg_check_credentials() {
   _info "[acg] Checking AWS credentials..."

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -104,25 +104,25 @@ Exit code 1 if session cannot be confirmed."
 
 function _antigravity_ensure_acg_session() {
   if [[ "${K3DM_ACG_SKIP_SESSION_CHECK:-0}" == "1" ]]; then
-    _info "K3DM_ACG_SKIP_SESSION_CHECK=1 — skipping ACG session check (ACG domain migration pending)"
+    _info "K3DM_ACG_SKIP_SESSION_CHECK=1 — skipping ACG/Pluralsight session check"
     return 0
   fi
-  _info "Checking ACG session in Antigravity browser..."
+  _info "Checking Pluralsight (ACG) session in Antigravity browser..."
 
   local gemini_prompt
   gemini_prompt="You are a browser automation agent. Use Playwright (Node.js) to do the following:
 
 1. Connect to the running Antigravity browser via CDP: const browser = await chromium.connectOverCDP('http://localhost:9222');
 2. Use the first browser context and page (do NOT launch a new browser).
-3. Navigate to https://learn.acloud.guru and wait for the page to load.
-4. Check if the user is logged in by looking for user avatar, account menu, or dashboard elements.
+3. Navigate to https://app.pluralsight.com/cloud-playground/cloud-sandboxes and wait for the page to load.
+4. Check if the user is logged in by looking for user avatar, account menu, or sandbox list elements (e.g. [data-testid='user-menu'], [aria-label='User menu'], or a heading containing 'Cloud Sandboxes').
 5. If logged in: print ACG_SESSION_OK and exit with code 0.
 6. If NOT logged in:
-   a. Navigate to https://learn.acloud.guru/sign-in
-   b. Print: ACTION REQUIRED: Please log into ACG in the Antigravity browser window, then press Enter to continue.
-   c. Wait for the page URL to no longer contain '/sign-in' — poll every 5 seconds, timeout after 300 seconds.
-   d. Once URL is no longer '/sign-in', print ACG_SESSION_OK and exit with code 0.
-   e. If 300 seconds pass without login, print ERROR: ACG login timeout and exit with code 1.
+   a. Navigate to https://app.pluralsight.com/id/signin
+   b. Print: ACTION REQUIRED: Please log into Pluralsight in the Antigravity browser window, then press Enter to continue.
+   c. Wait for the page URL to no longer contain '/signin' — poll every 5 seconds, timeout after 300 seconds.
+   d. Once URL is no longer '/signin', print ACG_SESSION_OK and exit with code 0.
+   e. If 300 seconds pass without login, print ERROR: Pluralsight login timeout and exit with code 1.
 
 Write the Playwright script to ${HOME}/.gemini/tmp/k3d-manager/ag_acg_session.js, execute with node, print the result.
 Exit code 1 if session cannot be confirmed."


### PR DESCRIPTION
## Summary

- `learn.acloud.guru` has retired; ACG platform now lives at `app.pluralsight.com`. This PR updates all hardcoded URLs and browser automation selectors to the new domain.
- `_ACG_SANDBOX_URL` in `acg.sh` and all three URL strings in `_antigravity_ensure_acg_session` updated to `app.pluralsight.com`; DOM selector hints updated for Pluralsight's page structure
- `K3DM_ACG_SKIP_SESSION_CHECK` bypass guard message and all docs cleaned of "ACG domain migration pending" language — fix is now complete

## Test plan

- [x] shellcheck clean — zero new warnings (`scripts/plugins/acg.sh`, `scripts/plugins/antigravity.sh`)
- [x] 244 BATS tests passing (`./scripts/k3d-manager test all`)
- [x] Gemini e2e verification — Playwright navigated to `app.pluralsight.com/cloud-playground/cloud-sandboxes`, session check correctly detected logged-out state, redirected to `app.pluralsight.com/id/signin`
- [ ] CI green
- [ ] Copilot review comments addressed

## Notes

- `K3DM_ACG_SKIP_SESSION_CHECK=1` bypass is retained for CI/Playwright-unavailable scenarios — it no longer carries the "pending" qualifier since the migration is complete
- Tag link for v0.9.18 in README/releases.md is plain text — will be converted to hyperlink in post-merge once tag exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)