### PR TITLE
fix(acg): launch Chrome not Antigravity; SPA nav guard in acg_credentials.js

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,13 @@
 # Changes - k3d-manager
 
+## [v0.9.20] — 2026-03-29 — ACG Chrome launch + SPA navigation fix
+
+### Fixed
+- `_antigravity_launch` in `scripts/plugins/antigravity.sh`: now launches Google Chrome (not Antigravity IDE) with `--remote-debugging-port=9222 --password-store=basic --user-data-dir=~/.config/acg-chrome-profile`; fixes macOS Keychain `errSecInteractionNotAllowed` blocking CDP port bind on cold start (`8dd9cbb`, `653896e`)
+- `scripts/playwright/acg_credentials.js`: no longer calls `page.goto()` when already on `app.pluralsight.com` — hard navigation was destroying SPA auth state causing permanent skeleton-loading; now finds Pluralsight page by URL, SPA-navigates via nav link click when needed, waits for `aria-busy` to clear; credential selector timeout 30s → 60s (`8dd9cbb`)
+
+---
+
 ## [v0.9.19] — 2026-03-28 — ACG automated credential extraction
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
-| v0.9.19 | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP), `acg_import_credentials` (stdin), static `acg_credentials.js`; live-verified against Pluralsight sandbox |
+| [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP), `acg_import_credentials` (stdin), static `acg_credentials.js`; live-verified against Pluralsight sandbox |
 | [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 

--- a/README.md
+++ b/README.md
@@ -269,15 +269,16 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.20](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.20) | 2026-03-29 | ACG Chrome launch fix — `_antigravity_launch` now opens Chrome (not Antigravity IDE) with `--password-store=basic`; `acg_credentials.js` SPA nav guard avoids hard reload |
 | [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP), `acg_import_credentials` (stdin), static `acg_credentials.js`; live-verified against Pluralsight sandbox |
 | [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
-| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 
 <details>
 <summary>Older releases</summary>
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |
 | [v0.9.10](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.10) | 2026-03-22 | if-count allowlist elimination (jenkins) — 8 helpers extracted; allowlist now `system.sh` only |

--- a/docs/plans/v0.9.20-acg-automation-fixes.md
+++ b/docs/plans/v0.9.20-acg-automation-fixes.md
@@ -1,8 +1,10 @@
 # Plan: v0.9.20 — ACG Automation Fixes
 
+> **Note:** Fix 3 (`_ensure_k3sup`) was implemented then reverted as out-of-scope for v0.9.20. It is deferred to v0.9.21. Only Fix 1 and Fix 2 shipped in this release.
+
 ## Summary
 
-Three bugs blocked the ACG automated credential extraction flow during v0.9.19 live testing:
+Two bugs blocked the ACG automated credential extraction flow during v0.9.19 live testing:
 
 1. **`_antigravity_launch` launches wrong app** — `open -a "Antigravity"` starts the code editor (VS Code fork), not a browser. The CDP probe on port 9222 only passes if Chrome is already running manually.
 

--- a/docs/plans/v0.9.20-acg-automation-fixes.md
+++ b/docs/plans/v0.9.20-acg-automation-fixes.md
@@ -1,0 +1,222 @@
+# Plan: v0.9.20 — ACG Automation Fixes
+
+## Summary
+
+Three bugs blocked the ACG automated credential extraction flow during v0.9.19 live testing:
+
+1. **`_antigravity_launch` launches wrong app** — `open -a "Antigravity"` starts the code editor (VS Code fork), not a browser. The CDP probe on port 9222 only passes if Chrome is already running manually.
+
+2. **`acg_credentials.js` uses `page.goto()`** — Hard navigation destroys Pluralsight SPA auth state. The `labs.pluralsight.com/graphql` API returns 403 and `prism/api/current-user` returns 401 after any hard reload. Page gets stuck in permanent skeleton-loading state.
+
+3. **`deploy_app_cluster` uses raw `command -v k3sup`** — fails with a manual install instruction instead of auto-installing, inconsistent with `_ensure_node`/`_ensure_copilot_cli` pattern.
+
+---
+
+## Before You Start
+
+```
+Branch: k3d-manager-v0.9.20
+First: git pull origin k3d-manager-v0.9.20
+Read this spec in full before touching any file.
+```
+
+Target files:
+- `scripts/plugins/antigravity.sh` — `_antigravity_launch` function
+- `scripts/playwright/acg_credentials.js` — navigation + page selection
+- `scripts/plugins/shopping_cart.sh` — new `_ensure_k3sup` + `deploy_app_cluster` guard
+
+Do NOT touch `scripts/lib/system.sh` or lib-foundation — k3sup is shopping_cart-specific.
+
+---
+
+## Fix 1 — `scripts/plugins/antigravity.sh` (`_antigravity_launch`)
+
+**Root cause:** `open -a "Antigravity"` starts the Antigravity IDE (VS Code/Electron code editor), not a browser. The IDE does not serve Chrome DevTools Protocol on port 9222.
+
+**Change:** Replace Antigravity with Google Chrome, add `--password-store=basic` to prevent macOS Keychain from blocking CDP port bind, add `--user-data-dir` for session persistence.
+
+### Before (lines 73–77):
+
+```bash
+  if _is_mac; then
+    open -a "Antigravity" --args --remote-debugging-port=9222
+  else
+    antigravity --remote-debugging-port=9222 &
+  fi
+```
+
+### After:
+
+```bash
+  if _is_mac; then
+    open -a "Google Chrome" --args \
+      --remote-debugging-port=9222 \
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile"
+  else
+    google-chrome \
+      --remote-debugging-port=9222 \
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile" &
+  fi
+```
+
+---
+
+## Fix 2 — `scripts/playwright/acg_credentials.js`
+
+**Root cause:** `page.goto(url)` forces a hard page reload on every invocation. Pluralsight's SPA stores auth state in memory; reload causes `labs.pluralsight.com/graphql` to return 403 (subdomain cookie scope) and `prism/api/current-user` to return 401. The page gets stuck with `aria-busy: true` skeleton loaders permanently.
+
+**Changes:**
+1. Find the Pluralsight page by URL (`find()`) instead of taking `pages()[0]` (which may be the Antigravity editor page)
+2. Skip `page.goto()` if the page URL already matches the target — no hard reload needed
+3. When navigation IS needed, use `page.evaluate()` to trigger SPA routing via `window.location.assign()` (React Router will handle it without a full page reload IF called within the SPA context; if that fails, click the nav link)
+4. Wait for skeleton loaders to clear (`aria-busy: false`) before looking for buttons
+5. Increase waitForSelector timeout from 30s to 60s to account for slow sandbox provisioning
+
+### Before (lines 22–32):
+
+```javascript
+    // 2. Use the first browser context and page
+    const context = browser.contexts()[0];
+    if (!context) throw new Error('No browser context found');
+    const page = context.pages()[0];
+    if (!page) throw new Error('No page found in the first browser context');
+
+    console.error(`INFO: Navigating to ${targetUrl}...`);
+    await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    // Give it time to render the SPA content
+    await page.waitForTimeout(5000);
+```
+
+### After:
+
+```javascript
+    // 2. Find the Pluralsight page by URL (do not assume pages()[0])
+    const context = browser.contexts()[0];
+    if (!context) throw new Error('No browser context found');
+    const allPages = context.pages();
+    let page = allPages.find(p => p.url().includes('pluralsight.com'));
+    if (!page) {
+      // No Pluralsight page found — navigate the first available page
+      page = allPages[0];
+      if (!page) throw new Error('No page found in the browser context');
+    }
+
+    // Navigate only if not already on the target URL (hard goto destroys SPA auth state)
+    const currentUrl = page.url();
+    if (!currentUrl.startsWith('https://app.pluralsight.com')) {
+      console.error(`INFO: Navigating to ${targetUrl}...`);
+      await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    } else if (!currentUrl.includes('cloud-sandboxes')) {
+      console.error(`INFO: SPA-navigating to cloud-sandboxes from ${currentUrl}...`);
+      // Click nav link for SPA routing — avoids hard reload
+      const navLink = page.locator('a[href*="cloud-sandboxes"]').first();
+      if (await navLink.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await navLink.click();
+      } else {
+        // Fallback: client-side assign (still SPA-friendly on Pluralsight)
+        await page.evaluate(url => window.location.assign(url), targetUrl);
+      }
+    } else {
+      console.error(`INFO: Already on ${currentUrl} — skipping navigation`);
+    }
+
+    // Wait for skeleton loaders to clear before looking for buttons
+    console.error('INFO: Waiting for page content to load...');
+    await page.waitForFunction(
+      () => !document.querySelector('[aria-busy="true"]'),
+      { timeout: 30000 }
+    ).catch(() => console.error('WARN: Skeleton loaders did not clear within 30s — proceeding anyway'));
+```
+
+### Before (line 73 — waitForSelector timeout):
+
+```javascript
+    await page.waitForSelector('input[aria-label="Copyable input"]', { timeout: 30000 });
+```
+
+### After:
+
+```javascript
+    await page.waitForSelector('input[aria-label="Copyable input"]', { timeout: 60000 });
+```
+
+---
+
+## Fix 3 — `scripts/plugins/shopping_cart.sh` (`_ensure_k3sup` + `deploy_app_cluster`)
+
+**Root cause:** `command -v k3sup` check hard-fails with a manual install message. Should auto-install following the `_ensure_node`/`_ensure_copilot_cli` pattern.
+
+### Add new private helper before `deploy_app_cluster` (insert before line 95 approximately — find `function deploy_app_cluster`):
+
+```bash
+function _ensure_k3sup() {
+  if _command_exist k3sup; then
+    return 0
+  fi
+  if _command_exist brew; then
+    _run_command -- brew install k3sup
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  if _is_debian_family && _command_exist curl && _sudo_available; then
+    _run_command -- curl -sLS https://get.k3sup.dev | _run_command --prefer-sudo -- sh
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  _err "[shopping_cart] k3sup not found and automatic installation failed — install manually: brew install k3sup"
+}
+```
+
+### Replace in `deploy_app_cluster` (lines 135–138):
+
+```bash
+# Before
+  if ! command -v k3sup >/dev/null 2>&1; then
+    _err "[shopping_cart] k3sup not found — install with: brew install k3sup"
+    return 1
+  fi
+```
+
+```bash
+# After
+  _ensure_k3sup || return 1
+```
+
+---
+
+## Rules
+
+- `shellcheck -S warning scripts/plugins/antigravity.sh scripts/plugins/shopping_cart.sh` must pass with zero new warnings
+- `bats scripts/tests/plugins/antigravity.bats` must pass (run if file exists; skip if no antigravity bats file)
+- `bats scripts/tests/plugins/shopping_cart.bats` must pass (run if file exists)
+- Do NOT run BATS suites that require a live cluster
+
+---
+
+## Definition of Done
+
+- [ ] `_antigravity_launch` launches `Google Chrome` (not `Antigravity`) with `--password-store=basic` and `--user-data-dir`
+- [ ] `acg_credentials.js` does not call `page.goto()` if already on a `pluralsight.com` page
+- [ ] `acg_credentials.js` finds Pluralsight page by URL, not by `pages()[0]`
+- [ ] `acg_credentials.js` waits for `aria-busy` to clear before looking for buttons
+- [ ] `_ensure_k3sup` helper added to `shopping_cart.sh` before `deploy_app_cluster`
+- [ ] `deploy_app_cluster` uses `_ensure_k3sup || return 1` instead of raw `command -v` check
+- [ ] shellcheck passes with zero new warnings on changed files
+- [ ] Committed on `k3d-manager-v0.9.20` with message:
+  `fix(acg): launch Chrome not Antigravity; skip goto on SPA; add _ensure_k3sup`
+- [ ] Pushed to `origin k3d-manager-v0.9.20`
+- [ ] `memory-bank/activeContext.md` and `memory-bank/progress.md` updated with commit SHA
+
+## What NOT to Do
+
+- Do NOT create a PR
+- Do NOT skip pre-commit hooks (`--no-verify`)
+- Do NOT modify `scripts/lib/system.sh` or lib-foundation
+- Do NOT modify any other plugin files
+- Do NOT commit to `main`
+- Do NOT add the `_ensure_k3sup` Debian curl pipe to a chain without `_run_command` wrapper on each stage

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.20](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.20) | 2026-03-29 | ACG Chrome launch fix — `_antigravity_launch` now opens Chrome (not Antigravity IDE) with `--password-store=basic`; `acg_credentials.js` SPA nav guard avoids hard reload |
 | [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP auto-start), `acg_import_credentials` (stdin fallback), static `acg_credentials.js`; live-verified |
 | [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,7 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
-| v0.9.19 | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP auto-start), `acg_import_credentials` (stdin fallback), static `acg_credentials.js`; live-verified |
+| [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP auto-start), `acg_import_credentials` (stdin fallback), static `acg_credentials.js`; live-verified |
 | [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |

--- a/docs/retro/2026-03-28-v0.9.19-retrospective.md
+++ b/docs/retro/2026-03-28-v0.9.19-retrospective.md
@@ -1,0 +1,42 @@
+# Retrospective — v0.9.19
+
+**Date:** 2026-03-28
+**Milestone:** ACG automated credential extraction
+**PR:** #54 — merged to main (`0f13be1`)
+**Participants:** Claude, Codex, Gemini, Copilot
+
+## What Went Well
+
+- **Three-agent handoff executed cleanly** — Codex implemented the Bash helpers and BATS tests; Gemini wrote and live-verified the Playwright script against a real Pluralsight sandbox; Claude integrated and fixed regressions. Each agent did exactly what it was suited for.
+- **Live DOM verification was the right call** — Reassigning the Playwright script to Gemini (from Codex) meant the selectors were verified against real page structure before shipping. The fallback positional index logic was confirmed correct.
+- **Copilot caught 9 real issues** — session token optional, playwright guard, null parent handle, chmod trace leak, stale docs, missing BATS case. All fixed in a single focused commit.
+- **Chrome `--password-store=basic` root cause found** — The CDP port 9222 binding failure (Keychain `errSecInteractionNotAllowed`) was diagnosed correctly and resolved without code changes to the script itself.
+- **`_vault_replay_cached_unseal` worked over SSH** — The M2 Air k3d cluster recovered from sleep with a single command invoked remotely.
+
+## What Went Wrong
+
+- **Gemini introduced NODE_PATH hardcode twice** — `/opt/homebrew/lib/node_modules` was hardcoded into `acg_get_credentials`, breaking Linux compatibility. Fixed twice (first by Gemini reverting on Claude's request, second by Claude directly). Should be caught by shellcheck or a portability rule.
+- **Gemini added inline `source antigravity.sh`** — dispatcher handles plugin loading; sourcing inside a function is wrong. Caught and removed.
+- **GitGuardian false positive on `AKIAIOSFODNN7EXAMPLE`** — Canonical AWS docs example keys in BATS tests triggered the scanner. Resolution: `.gitguardian.yaml` with `ignore-paths: scripts/tests/`. Should have been anticipated when writing the test.
+- **CI stage2 blocked on cluster sleep** — M2 Air going to sleep kills k3d + seals Vault. CI run queued indefinitely until cluster restarted and Vault unsealed. No automation for this — acceptable for a dev cluster but cost ~30 min of wait time.
+- **`# pragma: allowlist secret` applied incorrectly inside string literal** — First attempt put the pragma inside a multi-line bash string, which would have corrupted test input. Caught and reverted before commit.
+- **`{ set +x; } 2>/dev/null` pattern vs `_args_have_sensitive_flag`** — The chmod trace fix uses a different suppression pattern than the rest of the codebase. Acceptable but inconsistent.
+
+## Process Rules Added
+
+| Rule | File | Detail |
+|------|------|--------|
+| NODE_PATH must never be hardcoded | CLAUDE.md (implicit) | Use `node` from PATH; never reference `/opt/homebrew` or OS-specific paths in scripts |
+| `.gitguardian.yaml` required for test files with example credentials | CLAUDE.md (implicit) | Add `ignore-paths: scripts/tests/` at repo root when BATS tests use AKIA-format example keys |
+| `# pragma: allowlist secret` goes on shell lines, not inside string literals | Process | Can only suppress scanner on the line containing the secret in shell code, not in string content |
+
+## Decisions Made
+
+- **Static Playwright script over Gemini-generated-per-call** — `scripts/playwright/acg_credentials.js` is version-controlled, testable, and reproducible. Eliminates LLM round-trip cost on every credential extraction.
+- **Session token is optional** — AKIA keys (long-lived) don't have session tokens. Both `acg_import_credentials` and `_acg_write_credentials` now treat session token as optional. Aligns with AWS IAM reality.
+- **Playwright node/module guard added to `acg_get_credentials`** — Fail fast with a clear message if `node` or `playwright` module is missing rather than getting a cryptic node error at runtime.
+- **`.gitguardian.yaml` created** — Repo-level suppression for test files. Permanent fix, no per-line annotation noise.
+
+## Theme
+
+v0.9.19 was the credential automation sprint — turning a manual "copy credentials from the Pluralsight UI" step into a single command. The three-agent pattern worked well: Codex for Bash scaffolding, Gemini for live browser verification, Claude for integration and regression fixing. The main friction was environmental: Chrome needing `--password-store=basic`, k3d cluster sleeping mid-CI, and a GitGuardian scanner that can't tell AWS documentation examples from real keys. All three were resolved. The pipeline is clean.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.19` (as of 2026-03-28)
+## Current Branch: `k3d-manager-v0.9.20` (as of 2026-03-28)
 
 **v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. Copilot CLI CI integration.
 **v0.9.13 SHIPPED** — PR #48 merged to main (`c54fbe6`) 2026-03-23. Tagged v0.9.13, released.
@@ -9,7 +9,8 @@
 **v0.9.16 SHIPPED** — PR #51 merged (`484354da`) 2026-03-27. Tagged v0.9.16, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-27-v0.9.16-retrospective.md`.
 **v0.9.17 SHIPPED** — PR #52 merged (`c88ca7a`) 2026-03-28. Tagged v0.9.17. Released.
 **v0.9.18 SHIPPED** — PR #53 merged (`7567a5c`) 2026-03-28. Tagged v0.9.18. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.18-retrospective.md`.
-**v0.9.19 ACTIVE** — branch `k3d-manager-v0.9.19` cut from `7567a5c` 2026-03-28.
+**v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
+**v0.9.20 ACTIVE** — branch `k3d-manager-v0.9.20` cut from `0f13be1` 2026-03-28.
 **enforce_admins:** restored on main 2026-03-28.
 **Branch cleanup:** v0.9.7–v0.9.17 deleted (local + remote) 2026-03-28.
 **v0.9.15 scope:** Antigravity × GitHub Copilot coding agent validation — 3 runs, determinism verdict; spec `docs/plans/v0.9.15-antigravity-copilot-agent.md`. Antigravity plugin rewritten in `b2ba187` per `docs/plans/v0.9.15-antigravity-plugin-impl.md`. Also: ldap-password-rotator `vault kv put` stdin hardening — spec `docs/plans/v0.9.15-ensure-copilot-cli.md` (closes v0.6.2 security debt; `_ensure_copilot_cli`/`_k3d_manager_copilot`/`_ensure_node` already shipped in v0.9.12).

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -30,9 +30,9 @@ Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
 | Item | Status | Notes |
 |---|---|---|
 | **v0.9.20 spec written** | **COMPLETE** | 3 fixes: Chrome launch, SPA nav, _ensure_k3sup. `b579043`. |
-| **`_antigravity_launch` Chrome fix** | **ASSIGNED → Codex** | Change `open -a "Antigravity"` to `open -a "Google Chrome"` + `--password-store=basic` + `--user-data-dir` |
-| **`acg_credentials.js` SPA nav fix** | **ASSIGNED → Codex** | Skip `page.goto()` if on pluralsight.com; find page by URL; wait for aria-busy clear |
-| **`_ensure_k3sup`** | **ASSIGNED → Codex** | Add to `shopping_cart.sh`; replace raw `command -v k3sup` check |
+| **`_antigravity_launch` Chrome fix** | **COMPLETE** | Chrome + `--password-store=basic` + dedicated profile added per spec; commit `8dd9cbb`. |
+| **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Finds Pluralsight page, SPA-nav, waits for `aria-busy` clear, 60s selector; commit `8dd9cbb`. |
+| **`_ensure_k3sup`** | **COMPLETE** | Helper installs via brew/curl; `deploy_app_cluster` uses `_ensure_k3sup`; commit `8dd9cbb`. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -23,10 +23,16 @@
 
 ---
 
-## Current Focus (v0.9.19)
+## Current Focus (v0.9.20)
+
+Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
 
 | Item | Status | Notes |
 |---|---|---|
+| **v0.9.20 spec written** | **COMPLETE** | 3 fixes: Chrome launch, SPA nav, _ensure_k3sup. `b579043`. |
+| **`_antigravity_launch` Chrome fix** | **ASSIGNED → Codex** | Change `open -a "Antigravity"` to `open -a "Google Chrome"` + `--password-store=basic` + `--user-data-dir` |
+| **`acg_credentials.js` SPA nav fix** | **ASSIGNED → Codex** | Skip `page.goto()` if on pluralsight.com; find page by URL; wait for aria-busy clear |
+| **`_ensure_k3sup`** | **ASSIGNED → Codex** | Add to `shopping_cart.sh`; replace raw `command -v k3sup` check |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -32,7 +32,7 @@ Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
 | **v0.9.20 spec written** | **COMPLETE** | 3 fixes: Chrome launch, SPA nav, _ensure_k3sup. `b579043`. |
 | **`_antigravity_launch` Chrome fix** | **COMPLETE** | Verified Chrome cold-start with `--password-store=basic` and dedicated profile. |
 | **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
-| **`_ensure_k3sup`** | **COMPLETE** | Helper installs via brew/curl; `deploy_app_cluster` uses `_ensure_k3sup`; commit `8dd9cbb`. |
+| **`_ensure_k3sup`** | **DEFERRED → v0.9.21** | Reverted from v0.9.20 (scope creep); not in repo; planned for next release |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -30,8 +30,8 @@ Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
 | Item | Status | Notes |
 |---|---|---|
 | **v0.9.20 spec written** | **COMPLETE** | 3 fixes: Chrome launch, SPA nav, _ensure_k3sup. `b579043`. |
-| **`_antigravity_launch` Chrome fix** | **COMPLETE** | Chrome + `--password-store=basic` + dedicated profile added per spec; commit `8dd9cbb`. |
-| **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Finds Pluralsight page, SPA-nav, waits for `aria-busy` clear, 60s selector; commit `8dd9cbb`. |
+| **`_antigravity_launch` Chrome fix** | **COMPLETE** | Verified Chrome cold-start with `--password-store=basic` and dedicated profile. |
+| **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
 | **`_ensure_k3sup`** | **COMPLETE** | Helper installs via brew/curl; `deploy_app_cluster` uses `_ensure_k3sup`; commit `8dd9cbb`. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -21,6 +21,12 @@
 **v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
 **v0.9.20 ACTIVE** — branch `k3d-manager-v0.9.20` cut from `0f13be1` 2026-03-28.
 
+## v0.9.20 — Active
+
+- [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
+- [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.
+- [x] **`_ensure_k3sup` helper** — Added auto-install helper in `shopping_cart.sh` (brew or curl | sudo sh) and wired `deploy_app_cluster` to `_ensure_k3sup || return 1`. Commit `8dd9cbb`.
+
 ## v0.9.19 — Shipped
 
 - [x] **`acg_get_credentials` + `acg_import_credentials`** — commit `3970623` adds `_acg_write_credentials`, both public functions, docs updates, and 8 BATS tests per `docs/plans/v0.9.19-acg-get-credentials.md`

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -18,13 +18,16 @@
 **v0.9.16 SHIPPED** — PR #51 squash-merged to main (`484354da`) 2026-03-27. Tagged v0.9.16, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-27-v0.9.16-retrospective.md`.
 **v0.9.17 SHIPPED** — PR #52 merged to main (`c88ca7a`) 2026-03-28. Tagged v0.9.17, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.17-retrospective.md`. Branches v0.9.7–v0.9.17 deleted.
 **v0.9.18 SHIPPED** — PR #53 merged (`7567a5c`) 2026-03-28. Tagged v0.9.18. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.18-retrospective.md`.
-**v0.9.19 ACTIVE** — branch `k3d-manager-v0.9.19` cut from `7567a5c` 2026-03-28.
+**v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
+**v0.9.20 ACTIVE** — branch `k3d-manager-v0.9.20` cut from `0f13be1` 2026-03-28.
 
-## v0.9.19 — In Progress
+## v0.9.19 — Shipped
 
 - [x] **`acg_get_credentials` + `acg_import_credentials`** — commit `3970623` adds `_acg_write_credentials`, both public functions, docs updates, and 8 BATS tests per `docs/plans/v0.9.19-acg-get-credentials.md`
-- [ ] **Static Playwright script** — Codex assigned. Spec: `docs/plans/v0.9.19-acg-playwright-script.md`. Creates `scripts/playwright/acg_credentials.js`; replaces Gemini-prompt block in `acg_get_credentials` with direct `node` call. Commit message: `feat(acg): replace Gemini-generated Playwright with static acg_credentials.js`
-- [ ] **Gemini: verify Playwright selectors** — after Codex, spin up live sandbox and run `acg_get_credentials <url>` to verify/update DOM selectors in `acg_credentials.js`
+- [x] **Static Playwright script** — `scripts/playwright/acg_credentials.js` implemented + live-verified by Gemini against Pluralsight sandbox. `acg_get_credentials` updated to call static script. Spec: `docs/plans/v0.9.19-acg-playwright-script.md`.
+- [x] **Gemini: verify Playwright selectors** — `aws sts get-caller-identity` confirmed valid account ID; credentials written to `~/.aws/credentials`. Live-verified.
+- [x] **Copilot PR #54 findings** — 9 findings addressed in `392dae5`: session token optional, playwright guard, null parent, chmod trace suppression, docs fixes, spec status, issue doc resolution, BATS AKIA test.
+- [x] **GitGuardian false positive** — `.gitguardian.yaml` added to exclude `scripts/tests/` from scanning.
 - [ ] **scratch/ cleanup** — `rm -rf scratch/*` — wipe stale Playwright artifacts at release cut
 
 ## v0.9.17 — Shipped

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -26,6 +26,7 @@
 - [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
 - [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.
 - [x] **`_ensure_k3sup` helper** — Added auto-install helper in `shopping_cart.sh` (brew or curl | sudo sh) and wired `deploy_app_cluster` to `_ensure_k3sup || return 1`. Commit `8dd9cbb`.
+- [x] **Automation Verification** — Verified Chrome cold-start (flags/profile) and SPA navigation guard in `acg_credentials.js`. Logic confirmed via live verification.
 
 ## v0.9.19 — Shipped
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -25,7 +25,7 @@
 
 - [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
 - [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.
-- [x] **`_ensure_k3sup` helper** — Added auto-install helper in `shopping_cart.sh` (brew or curl | sudo sh) and wired `deploy_app_cluster` to `_ensure_k3sup || return 1`. Commit `8dd9cbb`.
+- [ ] **`_ensure_k3sup` helper** — DEFERRED to v0.9.21; reverted from v0.9.20 (scope creep); not in repo.
 - [x] **Automation Verification** — Verified Chrome cold-start (flags/profile) and SPA navigation guard in `acg_credentials.js`. Logic confirmed via live verification.
 
 ## v0.9.19 — Shipped

--- a/scripts/playwright/acg_credentials.js
+++ b/scripts/playwright/acg_credentials.js
@@ -35,10 +35,17 @@ async function extractCredentials() {
     const currentUrl = page.url();
     let currentHostname = '';
     try { currentHostname = new URL(currentUrl).hostname; } catch { /* non-URL, will navigate */ }
+    let targetPathname = '';
+    try { targetPathname = new URL(targetUrl).pathname; } catch { /* invalid targetUrl */ }
+    let currentPathname = '';
+    try { currentPathname = new URL(currentUrl).pathname; } catch { /* non-URL */ }
+
     if (currentHostname !== 'app.pluralsight.com') {
       console.error(`INFO: Navigating to ${targetUrl}...`);
       await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
-    } else if (!currentUrl.includes('cloud-sandboxes')) {
+    } else if (currentPathname === targetPathname) {
+      console.error(`INFO: Already on ${currentUrl} — skipping navigation`);
+    } else if (targetPathname.includes('cloud-sandboxes')) {
       console.error(`INFO: SPA-navigating to cloud-sandboxes from ${currentUrl}...`);
       const navLink = page.locator('a[href*="cloud-sandboxes"]').first();
       const navVisible = await navLink.isVisible({ timeout: 5000 }).catch(() => false);
@@ -48,7 +55,8 @@ async function extractCredentials() {
         await page.evaluate(url => window.location.assign(url), targetUrl);
       }
     } else {
-      console.error(`INFO: Already on ${currentUrl} — skipping navigation`);
+      console.error(`INFO: Navigating to ${targetUrl}...`);
+      await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
     }
 
     // Give it time to render SPA content after navigation changes

--- a/scripts/playwright/acg_credentials.js
+++ b/scripts/playwright/acg_credentials.js
@@ -23,7 +23,9 @@ async function extractCredentials() {
     const context = browser.contexts()[0];
     if (!context) throw new Error('No browser context found');
     const allPages = context.pages();
-    let page = allPages.find(p => p.url().includes('pluralsight.com'));
+    let page = allPages.find(p => {
+      try { return new URL(p.url()).hostname.endsWith('.pluralsight.com') || new URL(p.url()).hostname === 'pluralsight.com'; } catch { return false; }
+    });
     if (!page) {
       page = allPages[0];
       if (!page) throw new Error('No page found in the browser context');
@@ -31,7 +33,9 @@ async function extractCredentials() {
 
     // Navigate only if not already on the target URL (hard reload kills SPA auth)
     const currentUrl = page.url();
-    if (!currentUrl.startsWith('https://app.pluralsight.com')) {
+    let currentHostname = '';
+    try { currentHostname = new URL(currentUrl).hostname; } catch { /* non-URL, will navigate */ }
+    if (currentHostname !== 'app.pluralsight.com') {
       console.error(`INFO: Navigating to ${targetUrl}...`);
       await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
     } else if (!currentUrl.includes('cloud-sandboxes')) {

--- a/scripts/playwright/acg_credentials.js
+++ b/scripts/playwright/acg_credentials.js
@@ -19,17 +19,40 @@ async function extractCredentials() {
     // 1. Connect to the running browser via CDP
     browser = await chromium.connectOverCDP('http://localhost:9222');
 
-    // 2. Use the first browser context and page
+    // 2. Find the Pluralsight page by URL (do not assume pages()[0])
     const context = browser.contexts()[0];
     if (!context) throw new Error('No browser context found');
-    const page = context.pages()[0];
-    if (!page) throw new Error('No page found in the first browser context');
+    const allPages = context.pages();
+    let page = allPages.find(p => p.url().includes('pluralsight.com'));
+    if (!page) {
+      page = allPages[0];
+      if (!page) throw new Error('No page found in the browser context');
+    }
 
-    console.error(`INFO: Navigating to ${targetUrl}...`);
-    await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
-    
-    // Give it time to render the SPA content
-    await page.waitForTimeout(5000);
+    // Navigate only if not already on the target URL (hard reload kills SPA auth)
+    const currentUrl = page.url();
+    if (!currentUrl.startsWith('https://app.pluralsight.com')) {
+      console.error(`INFO: Navigating to ${targetUrl}...`);
+      await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    } else if (!currentUrl.includes('cloud-sandboxes')) {
+      console.error(`INFO: SPA-navigating to cloud-sandboxes from ${currentUrl}...`);
+      const navLink = page.locator('a[href*="cloud-sandboxes"]').first();
+      const navVisible = await navLink.isVisible({ timeout: 5000 }).catch(() => false);
+      if (navVisible) {
+        await navLink.click();
+      } else {
+        await page.evaluate(url => window.location.assign(url), targetUrl);
+      }
+    } else {
+      console.error(`INFO: Already on ${currentUrl} — skipping navigation`);
+    }
+
+    // Give it time to render SPA content after navigation changes
+    console.error('INFO: Waiting for page content to load...');
+    await page.waitForFunction(
+      () => !document.querySelector('[aria-busy="true"]'),
+      { timeout: 30000 }
+    ).catch(() => console.error('WARN: Skeleton loaders did not clear within 30s — proceeding anyway'));
 
     // 3. Handle Sandbox Start/Open Flow
     console.error('INFO: Looking for Start/Open button...');
@@ -70,7 +93,7 @@ async function extractCredentials() {
     // The order is typically: Username, Password, Access Key ID, Secret Access Key, [Session Token]
     
     // Wait for the inputs to appear
-    await page.waitForSelector('input[aria-label="Copyable input"]', { timeout: 30000 });
+    await page.waitForSelector('input[aria-label="Copyable input"]', { timeout: 60000 });
     
     const inputs = await page.locator('input[aria-label="Copyable input"]').all();
     console.error(`INFO: Found ${inputs.length} copyable inputs.`);

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -69,7 +69,7 @@ function _antigravity_launch() {
   if _run_command --soft -- curl -sf http://localhost:9222/json >/dev/null 2>&1; then
     return 0
   fi
-  _info "Antigravity not running — launching Chrome with --remote-debugging-port=9222..."
+  _info "Chrome not running — launching with --remote-debugging-port=9222..."
   if _is_mac; then
     open -a "Google Chrome" --args \
       --remote-debugging-port=9222 \

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -73,11 +73,13 @@ function _antigravity_launch() {
   if _is_mac; then
     open -a "Google Chrome" --args \
       --remote-debugging-port=9222 \
-      --password-store=basic
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile"
   else
     google-chrome \
       --remote-debugging-port=9222 \
-      --password-store=basic &
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile" &
   fi
   _antigravity_browser_ready 30
 }

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -73,13 +73,11 @@ function _antigravity_launch() {
   if _is_mac; then
     open -a "Google Chrome" --args \
       --remote-debugging-port=9222 \
-      --password-store=basic \
-      --user-data-dir="${HOME}/.config/acg-chrome-profile"
+      --password-store=basic
   else
     google-chrome \
       --remote-debugging-port=9222 \
-      --password-store=basic \
-      --user-data-dir="${HOME}/.config/acg-chrome-profile" &
+      --password-store=basic &
   fi
   _antigravity_browser_ready 30
 }

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -69,11 +69,17 @@ function _antigravity_launch() {
   if _run_command --soft -- curl -sf http://localhost:9222/json >/dev/null 2>&1; then
     return 0
   fi
-  _info "Antigravity not running — launching with --remote-debugging-port=9222..."
+  _info "Antigravity not running — launching Chrome with --remote-debugging-port=9222..."
   if _is_mac; then
-    open -a "Antigravity" --args --remote-debugging-port=9222
+    open -a "Google Chrome" --args \
+      --remote-debugging-port=9222 \
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile"
   else
-    antigravity --remote-debugging-port=9222 &
+    google-chrome \
+      --remote-debugging-port=9222 \
+      --password-store=basic \
+      --user-data-dir="${HOME}/.config/acg-chrome-profile" &
   fi
   _antigravity_browser_ready 30
 }

--- a/scripts/plugins/antigravity.sh
+++ b/scripts/plugins/antigravity.sh
@@ -76,7 +76,12 @@ function _antigravity_launch() {
       --password-store=basic \
       --user-data-dir="${HOME}/.config/acg-chrome-profile"
   else
-    google-chrome \
+    local _chrome_bin
+    _chrome_bin=$(command -v google-chrome 2>/dev/null || command -v google-chrome-stable 2>/dev/null || command -v chromium-browser 2>/dev/null || command -v chromium 2>/dev/null || true)
+    if [[ -z "${_chrome_bin}" ]]; then
+      _err "[antigravity] Chrome/Chromium not found — install google-chrome, google-chrome-stable, chromium-browser, or chromium"
+    fi
+    "${_chrome_bin}" \
       --remote-debugging-port=9222 \
       --password-store=basic \
       --user-data-dir="${HOME}/.config/acg-chrome-profile" &

--- a/scripts/plugins/shopping_cart.sh
+++ b/scripts/plugins/shopping_cart.sh
@@ -97,25 +97,6 @@ function register_shopping_cart_apps() {
   _run_command -- kubectl apply -f "${argocd_dir}/"
 }
 
-function _ensure_k3sup() {
-  if _command_exist k3sup; then
-    return 0
-  fi
-  if _command_exist brew; then
-    _run_command -- brew install k3sup
-    if _command_exist k3sup; then
-      return 0
-    fi
-  fi
-  if _is_debian_family && _command_exist curl && _sudo_available; then
-    _run_command -- curl -sLS https://get.k3sup.dev | _run_command --prefer-sudo -- sh
-    if _command_exist k3sup; then
-      return 0
-    fi
-  fi
-  _err "[shopping_cart] k3sup not found and automatic installation failed — install manually: brew install k3sup"
-}
-
 function deploy_app_cluster() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     cat <<'HELP'
@@ -151,7 +132,10 @@ HELP
   local kube_context="ubuntu-k3s"
   local kubeconfig_dir="${local_kubeconfig%/*}"
 
-  _ensure_k3sup || return 1
+  if ! command -v k3sup >/dev/null 2>&1; then
+    _err "[shopping_cart] k3sup not found — install with: brew install k3sup"
+    return 1
+  fi
 
   if [[ ! -f "${ssh_key}" ]]; then
     _err "[shopping_cart] SSH key not found: ${ssh_key}"

--- a/scripts/plugins/shopping_cart.sh
+++ b/scripts/plugins/shopping_cart.sh
@@ -97,6 +97,25 @@ function register_shopping_cart_apps() {
   _run_command -- kubectl apply -f "${argocd_dir}/"
 }
 
+function _ensure_k3sup() {
+  if _command_exist k3sup; then
+    return 0
+  fi
+  if _command_exist brew; then
+    _run_command -- brew install k3sup
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  if _is_debian_family && _command_exist curl && _sudo_available; then
+    _run_command -- curl -sLS https://get.k3sup.dev | _run_command --prefer-sudo -- sh
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  _err "[shopping_cart] k3sup not found and automatic installation failed — install manually: brew install k3sup"
+}
+
 function deploy_app_cluster() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     cat <<'HELP'
@@ -132,10 +151,7 @@ HELP
   local kube_context="ubuntu-k3s"
   local kubeconfig_dir="${local_kubeconfig%/*}"
 
-  if ! command -v k3sup >/dev/null 2>&1; then
-    _err "[shopping_cart] k3sup not found — install with: brew install k3sup"
-    return 1
-  fi
+  _ensure_k3sup || return 1
 
   if [[ ! -f "${ssh_key}" ]]; then
     _err "[shopping_cart] SSH key not found: ${ssh_key}"


### PR DESCRIPTION
## Summary
- `_antigravity_launch` now opens Google Chrome with `--remote-debugging-port=9222 --password-store=basic --user-data-dir=~/.config/acg-chrome-profile` — was incorrectly launching the Antigravity IDE (VS Code fork) which does not serve CDP
- `acg_credentials.js` SPA nav guard: skips `page.goto()` when already on `app.pluralsight.com` — hard navigation was destroying in-memory auth state, causing `labs.pluralsight.com/graphql` 403 + permanent skeleton-loading; now finds Pluralsight page by URL, SPA-navigates via nav link click, waits for `aria-busy` to clear
- Verified by Gemini: Chrome cold-start confirmed correct flags in `ps aux`; SPA nav guard confirmed via `INFO: SPA-navigating to cloud-sandboxes` log line (no hard goto)

## Test plan
- [ ] CI green
- [ ] Copilot review comments addressed
- [ ] Gemini live verification: Chrome cold-start ✅, SPA nav guard ✅ (2026-03-29)

## Notes
- `_ensure_k3sup` (originally in this branch) deferred to next release — scope was too broad for v0.9.20
- Follow-on: rename `_antigravity_launch` to `_acg_browser_launch` (next release)
- Follow-on: add `playwright` to `package.json` as local dependency (currently global-only on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)