### PR TITLE
fix(shopping_cart): add _ensure_k3sup auto-install helper to deploy_app_cluster

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,18 @@
 # Changes - k3d-manager
 
+## [v0.9.21] — 2026-03-29 — `_ensure_k3sup` auto-install helper
+
+### Added
+- `_ensure_k3sup` private helper in `scripts/plugins/shopping_cart.sh`: auto-installs k3sup via `brew install k3sup` (macOS/Linuxbrew) or `curl | sudo sh` (Debian/Ubuntu); emits `_err` with manual install guidance if neither installer is available (`11a3ac1`)
+
+### Changed
+- `deploy_app_cluster`: replaces raw `command -v k3sup` hard-error with `_ensure_k3sup` — consistent with `_ensure_node` / `_ensure_copilot_cli` auto-install pattern (`11a3ac1`)
+
+### Tests
+- 2 new BATS tests in `scripts/tests/plugins/shopping_cart.bats`: `_ensure_k3sup` returns 0 when k3sup present; errors when no installer available (`11a3ac1`)
+
+---
+
 ## [v0.9.20] — 2026-03-29 — ACG Chrome launch + SPA navigation fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -269,15 +269,16 @@ Recent entries:
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.21](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.21) | 2026-03-29 | `_ensure_k3sup` auto-install helper — `deploy_app_cluster` now auto-installs k3sup via brew or curl; consistent with `_ensure_node`/`_ensure_copilot_cli` pattern |
 | [v0.9.20](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.20) | 2026-03-29 | ACG Chrome launch fix — `_antigravity_launch` now opens Chrome (not Antigravity IDE) with `--password-store=basic`; `acg_credentials.js` SPA nav guard avoids hard reload |
 | [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP), `acg_import_credentials` (stdin), static `acg_credentials.js`; live-verified against Pluralsight sandbox |
-| [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 
 <details>
 <summary>Older releases</summary>
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | [v0.9.17](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.17) | 2026-03-27 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo` + workspace temp path) |
 | [v0.9.16](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.16) | 2026-03-26 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend`; ldap stdin hardening |
 | [v0.9.11](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.11) | 2026-03-22 | dynamic plugin CI — `detect` job skips cluster tests for docs-only PRs; maps plugin changes to targeted smoke tests |

--- a/docs/plans/roadmap-v1.md
+++ b/docs/plans/roadmap-v1.md
@@ -25,6 +25,8 @@ across clouds.
 
 | Version | Highlights |
 |---------|-----------|
+| v0.9.20 | `_antigravity_launch` Chrome fix + `acg_credentials.js` SPA nav guard — cold-start automation working |
+| v0.9.19 | `acg_get_credentials` + `acg_import_credentials` — static Playwright script extracts AWS credentials from Pluralsight sandbox |
 | v0.9.18 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |
 | v0.9.17 | Antigravity model fallback (`gemini-2.5-flash` first), ACG session check, nested agent fix (`--approval-mode yolo`) |
 | v0.9.16 | Antigravity IDE + CDP browser automation — gemini CLI + Playwright engine; `antigravity_install`, `antigravity_trigger_copilot_review`, `antigravity_acg_extend` |
@@ -44,7 +46,17 @@ across clouds.
 
 ---
 
-## v1.0.0 — Multi-Node k3s Cluster + Samba AD
+## v0.9.21 — `_ensure_k3sup` (upcoming)
+*Focus: k3sup auto-install — prerequisite for v1.0.0 multi-node work*
+
+- `_ensure_k3sup` helper in `scripts/plugins/shopping_cart.sh` — follows `_ensure_node`/`_ensure_copilot_cli` pattern
+- `deploy_app_cluster` replaces raw `command -v k3sup` check with `_ensure_k3sup`
+- Install paths: `brew install k3sup` (macOS/Linuxbrew), `curl | sh` (Debian/Ubuntu + sudo), `_err` guidance if both unavailable
+- BATS coverage: k3sup present → returns 0; absent + brew → installs; absent + no brew → error
+
+---
+
+## v1.0.0 — AWS/ACG: Multi-Node k3s Cluster + Samba AD
 *Focus: 3-node k3sup cluster on ACG — resolves single t3.medium resource exhaustion*
 
 **Motivation:** Single t3.medium (4GB) at 95% capacity is a structural blocker for
@@ -92,6 +104,31 @@ DIRECTORY_SERVICE_PROVIDER=activedirectory ./scripts/k3d-manager deploy_director
 ### Milestone Gate
 
 All 5 shopping-cart pods Running + Playwright E2E green = v1.0.0 done.
+
+---
+
+## v1.0.1 — GCP Cloud Provider
+*Focus: k3s on GCP Compute Engine — second cloud backend*
+
+**New `CLUSTER_PROVIDER` value:** `k3s-gcp`
+
+- `acg_provision` equivalent for GCP: provision Compute Engine VM(s) via `gcloud`
+- k3sup install + kubeconfig merge (same pattern as ACG/k3s-remote)
+- Plugin layer identical — no changes needed above the provider abstraction
+- Credential extraction: GCP service account key → `~/.config/gcloud/`
+- Milestone gate: basket-service Running on GCP-provisioned k3s + `kubectl get nodes` shows Ready
+
+---
+
+## v1.0.2 — Azure Cloud Provider
+*Focus: k3s on Azure VM — third cloud backend*
+
+**New `CLUSTER_PROVIDER` value:** `k3s-azure`
+
+- `acg_provision` equivalent for Azure: provision Azure VM(s) via `az`
+- k3sup install + kubeconfig merge (same pattern as ACG/GCP)
+- Credential extraction: Azure service principal → `~/.azure/`
+- Milestone gate: basket-service Running on Azure-provisioned k3s + `kubectl get nodes` shows Ready
 
 ---
 

--- a/docs/plans/roadmap-v1.md
+++ b/docs/plans/roadmap-v1.md
@@ -153,6 +153,16 @@ CLUSTER_PROVIDER=k3s-remote ./scripts/k3d-manager provision_full_stack
 **Gate:** v1.0.0 multi-node proven. k3d (local) + k3s-remote (ACG) = two backends,
 enough surface for a useful provider-agnostic MCP API.
 
+**Sudo pre-flight requirement:** k3dm-mcp agents run non-interactively — any sudo
+password prompt will hang the agent with no TTY to respond. Before v1.2.0 ships:
+- `deploy_cluster` / `deploy_app_cluster` must include a pre-flight check:
+  `ssh <host> sudo -n true 2>/dev/null` — fail fast with `_err` if passwordless sudo
+  is not configured rather than hanging on a prompt
+- Target node prerequisite documented: "provisioning user must have passwordless sudo
+  (`NOPASSWD:ALL` in `/etc/sudoers.d/`)"
+- ACG EC2 ubuntu user is passwordless by default — no change needed for that path
+- Home lab (Mac Mini M5, v1.3.0) and any self-managed VMs must be pre-configured
+
 **Discrete repo:** `wilddog64/k3dm-mcp`
 
 **MCP tools (initial set):**

--- a/docs/plans/v0.9.21-ensure-k3sup.md
+++ b/docs/plans/v0.9.21-ensure-k3sup.md
@@ -1,0 +1,175 @@
+# Spec: v0.9.21 — `_ensure_k3sup`
+
+## Context
+
+`deploy_app_cluster` in `scripts/plugins/shopping_cart.sh` checks for k3sup with a raw
+`command -v k3sup` and hard-errors with a manual install instruction. Every other tool
+dependency in this codebase uses an `_ensure_*` helper that auto-installs. This spec
+closes that gap.
+
+## Target Files
+
+- `scripts/plugins/shopping_cart.sh` — add `_ensure_k3sup` helper + replace raw check
+- `scripts/tests/plugins/shopping_cart.bats` — update existing test + add 2 new tests
+
+**No other files.**
+
+---
+
+## Before You Start
+
+1. `git pull origin k3d-manager-v0.9.21`
+2. Read `scripts/plugins/shopping_cart.sh` in full
+3. Read `scripts/tests/plugins/shopping_cart.bats` in full
+4. Branch: `k3d-manager-v0.9.21` (already exists — do NOT create a new branch, do NOT commit to `main`)
+
+---
+
+## Change 1 — Add `_ensure_k3sup` to `scripts/plugins/shopping_cart.sh`
+
+Insert immediately **before** the `function deploy_app_cluster()` line (line 100).
+
+**Add this block:**
+
+```bash
+function _ensure_k3sup() {
+  if _command_exist k3sup; then
+    return 0
+  fi
+  _info "[shopping_cart] k3sup not found — installing..."
+  if _command_exist brew; then
+    _run_command -- brew install k3sup
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  if _is_debian_family && _command_exist curl; then
+    _run_command --prefer-sudo -- sh -c "$(curl -sLS https://get.k3sup.dev)"
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  _err "[shopping_cart] k3sup not found and automatic installation failed — install manually: brew install k3sup"
+}
+
+```
+
+---
+
+## Change 2 — Replace raw check in `deploy_app_cluster`
+
+**Old (lines 135–138):**
+
+```bash
+  if ! command -v k3sup >/dev/null 2>&1; then
+    _err "[shopping_cart] k3sup not found — install with: brew install k3sup"
+    return 1
+  fi
+```
+
+**New:**
+
+```bash
+  _ensure_k3sup
+```
+
+---
+
+## Change 3 — Update BATS tests in `scripts/tests/plugins/shopping_cart.bats`
+
+### 3a — Update existing "fails if k3sup not found" test
+
+The existing test title and assertion must stay compatible with the new behavior. With
+`_ensure_k3sup` in place, when k3sup is not found AND brew is not available AND the
+Debian path is not available, `_err` is still called — but the message changes.
+
+**Old test (lines 16–20):**
+
+```bash
+@test "deploy_app_cluster fails if k3sup not found" {
+  run bash -c 'SCRIPT_DIR="$(pwd)/scripts"; PATH=/dev/null; source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh; deploy_app_cluster --confirm'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"k3sup not found"* ]]
+}
+```
+
+**New test — same title and assertion, PATH wipe still covers both brew and k3sup:**
+
+```bash
+@test "deploy_app_cluster fails if k3sup not found" {
+  run bash -c 'SCRIPT_DIR="$(pwd)/scripts"; PATH=/dev/null; source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh; deploy_app_cluster --confirm'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"k3sup not found"* ]]
+}
+```
+
+No change needed here — `PATH=/dev/null` wipes both k3sup and brew, `_err` fires with
+"k3sup not found" in the message. The test passes as-is.
+
+### 3b — Add new test: `_ensure_k3sup` returns 0 when k3sup present
+
+Append after the last `@test` block:
+
+```bash
+@test "_ensure_k3sup returns 0 when k3sup is already installed" {
+  run bash -c '
+    SCRIPT_DIR="$(pwd)/scripts"
+    source scripts/lib/system.sh
+    source scripts/lib/core.sh
+    source scripts/plugins/shopping_cart.sh
+    # Stub k3sup as present
+    k3sup() { return 0; }
+    _command_exist() { [[ "$1" == "k3sup" ]]; }
+    _ensure_k3sup
+  '
+  [ "$status" -eq 0 ]
+}
+```
+
+### 3c — Add new test: `_ensure_k3sup` errors when no installer available
+
+```bash
+@test "_ensure_k3sup errors when k3sup absent and no installer available" {
+  run bash -c 'SCRIPT_DIR="$(pwd)/scripts"; PATH=/dev/null; source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh; _ensure_k3sup'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"k3sup not found"* ]]
+}
+```
+
+---
+
+## Rules
+
+1. Run `shellcheck scripts/plugins/shopping_cart.sh` — zero new warnings
+2. Run `bats scripts/tests/plugins/shopping_cart.bats` — all tests pass
+3. Do NOT modify any other file
+4. Do NOT remove or reorder existing tests — only update + append
+
+---
+
+## Definition of Done
+
+- [ ] `_ensure_k3sup` function added before `deploy_app_cluster` in `shopping_cart.sh`
+- [ ] Raw `command -v k3sup` block replaced with `_ensure_k3sup`
+- [ ] Existing BATS test still passes (no change needed)
+- [ ] 2 new BATS tests added and passing
+- [ ] `shellcheck` clean (zero new warnings)
+- [ ] Committed on branch `k3d-manager-v0.9.21` with exact message:
+
+```
+fix(shopping_cart): add _ensure_k3sup auto-install helper to deploy_app_cluster
+```
+
+- [ ] Pushed: `git push origin k3d-manager-v0.9.21`
+- [ ] Report back: commit SHA + paste the memory-bank lines updated
+
+---
+
+## What NOT to Do
+
+- Do NOT create a PR
+- Do NOT skip pre-commit hooks (`--no-verify`)
+- Do NOT modify files outside `scripts/plugins/shopping_cart.sh` and `scripts/tests/plugins/shopping_cart.bats`
+- Do NOT commit to `main`
+- Do NOT add NODE_PATH or other environment hacks
+- Do NOT refactor existing functions beyond the two targeted changes

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v0.9.21](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.21) | 2026-03-29 | `_ensure_k3sup` auto-install helper — `deploy_app_cluster` now auto-installs k3sup via brew or curl; consistent with `_ensure_node`/`_ensure_copilot_cli` pattern |
 | [v0.9.20](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.20) | 2026-03-29 | ACG Chrome launch fix — `_antigravity_launch` now opens Chrome (not Antigravity IDE) with `--password-store=basic`; `acg_credentials.js` SPA nav guard avoids hard reload |
 | [v0.9.19](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.19) | 2026-03-28 | ACG automated credential extraction — `acg_get_credentials` (Playwright CDP auto-start), `acg_import_credentials` (stdin fallback), static `acg_credentials.js`; live-verified |
 | [v0.9.18](https://github.com/wilddog64/k3d-manager/releases/tag/v0.9.18) | 2026-03-28 | Pluralsight URL migration — `_ACG_SANDBOX_URL` + `_antigravity_ensure_acg_session` updated to `app.pluralsight.com` |

--- a/docs/retro/2026-03-29-v0.9.20-retrospective.md
+++ b/docs/retro/2026-03-29-v0.9.20-retrospective.md
@@ -1,0 +1,42 @@
+# Retrospective — v0.9.20
+
+**Date:** 2026-03-29
+**Milestone:** ACG Chrome launch + SPA navigation fix
+**PR:** #55 — merged to main (`bfd66fe`)
+**Participants:** Claude, Codex, Gemini, Copilot
+
+## What Went Well
+
+- **Root cause diagnosis was accurate** — Confirmed `labs.pluralsight.com/graphql` returns 403 and `prism/api/current-user` returns 401 after hard navigation, exactly as hypothesized. The SPA auth destruction mechanism was fully understood before writing the fix.
+- **Gemini cold-start verification worked** — Chrome launch with correct flags confirmed via `ps aux`; SPA nav guard confirmed via log output. Two-check verification protocol was clean.
+- **Copilot caught real security issues** — URL substring sanitization findings (hostname spoofing via `includes()` and `startsWith()`) were valid CodeQL findings. Both fixed with proper `new URL().hostname` checks before merge.
+- **Copilot also caught doc accuracy issues** — `_ensure_k3sup` marked COMPLETE in memory-bank and spec despite being reverted. Caught and corrected before merge.
+- **Chrome binary probe on Linux** — Copilot flagged hardcoded `google-chrome` binary. Fixed to probe `google-chrome`, `google-chrome-stable`, `chromium-browser`, `chromium` in order with `_err` guidance if none found.
+
+## What Went Wrong
+
+- **`_ensure_k3sup` scope creep** — Included in the spec without telling the user what the plan contained. User correctly pushed back ("why did you include this?"). Reverted. Process rule: always summarize plan scope to user before handing to Codex.
+- **`--user-data-dir` flip-flop** — Dropped it, then had to add it back when the user clarified they had already logged in using the dedicated profile. Two unnecessary commits. Should have asked about the profile state before changing it.
+- **Diagnostic scripts broke the user's Pluralsight session** — Our debug `node -e` scripts called `page.goto()` three times, destroying the in-memory auth state and causing a 401/403 loop. User had to manually reload Chrome to recover. Root cause of the original problem was also `page.goto()` — we caused the same bug while debugging it.
+- **`_antigravity_launch` info log stale** — Said "Antigravity not running" after switching to Chrome. Caught only during manual review, not by any automated check.
+- **NODE_PATH hardcode (again)** — Gemini added `export NODE_PATH=/opt/homebrew/lib/node_modules` to the verification run despite the v0.9.19 retro explicitly calling this out as a process rule violation. Not committed to scripts, but same pattern two milestones in a row.
+- **v0.9.19 live verification was false positive** — The `acg_credentials.js` "live-verified" status from v0.9.19 was based on Chrome that was already running with the right flags manually. Cold-start was never tested. This delayed discovery of the real bug until v0.9.20.
+
+## Process Rules Added
+
+| Rule | Context | Detail |
+|------|---------|--------|
+| Summarize plan scope before handing to Codex | Scope control | Claude must present plan contents for user approval before assigning — never silently add items |
+| Never call `page.goto()` in diagnostic scripts against a live browser session | Playwright safety | Hard navigation destroys Pluralsight SPA auth state; use read-only DOM queries only |
+| Verify cold-start, not warm-start | Testing | "Live-verified" means the automation worked from zero, not from a manually-prepared state |
+
+## Decisions Made
+
+- **`--user-data-dir=~/.config/acg-chrome-profile`** — kept; session is bound to this profile (user logged in via this profile, not the default). Dropping it would lose the session.
+- **`_ensure_k3sup` deferred to v0.9.21** — out of scope for a Chrome/Playwright fix release; own release for `deploy_app_cluster` improvements.
+- **Linux Chrome binary probe order**: `google-chrome` → `google-chrome-stable` → `chromium-browser` → `chromium` → `_err`. Covers major distros without hardcoding paths.
+- **URL hostname check via `new URL()`** — replaces `includes()` / `startsWith()` for all URL comparisons in `acg_credentials.js`; prevents hostname spoofing.
+
+## Theme
+
+v0.9.20 was a debugging sprint that fixed the bugs introduced while debugging v0.9.19. The root problem — `_antigravity_launch` launching the wrong application (Antigravity IDE instead of Chrome) and `acg_credentials.js` calling `page.goto()` unconditionally — were real bugs, but they were obscured by a false-positive live test in v0.9.19 where Chrome was already configured manually. The fix itself was straightforward once the root cause was confirmed via network traffic analysis (401/403 responses after hard navigation). The lesson: "live-verified" only counts if the automation ran from a clean cold-start, not from a pre-warmed session.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -46,7 +46,7 @@ Scope: `_ensure_k3sup` helper + `deploy_app_cluster` replacement of raw `command
 | **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
 | **`_ensure_k3sup`** | **COMPLETE** | Auto-installs via brew/curl + `deploy_app_cluster` guard rewired; commit `11a3ac1`. |
 | **Gemini: smoke test `_ensure_k3sup`** | **COMPLETE** | Verified warm path (returns 0) and cold path (triggers install message when hidden). Ubuntu skip (unreachable). |
-| **Gemini: Ubuntu smoke test `_ensure_k3sup`** | **PENDING** | Run cold-path test on ubuntu-parallels (Parallels Desktop Ubuntu VM) — curl installer path should fire since k3sup not installed there. |
+| **Gemini: Ubuntu smoke test `_ensure_k3sup`** | **COMPLETE** | Verified cold path on `ubuntu-parallels`. `k3sup` correctly installed via `curl | sudo sh` path after providing password. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -44,7 +44,7 @@ Scope: `_ensure_k3sup` helper + `deploy_app_cluster` replacement of raw `command
 | **v0.9.20 spec written** | **COMPLETE** | 3 fixes: Chrome launch, SPA nav, _ensure_k3sup. `b579043`. |
 | **`_antigravity_launch` Chrome fix** | **COMPLETE** | Verified Chrome cold-start with `--password-store=basic` and dedicated profile. |
 | **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
-| **`_ensure_k3sup`** | **DEFERRED → v0.9.21** | Reverted from v0.9.20 (scope creep); not in repo; planned for next release |
+| **`_ensure_k3sup`** | **COMPLETE** | Auto-installs via brew/curl + `deploy_app_cluster` guard rewired; commit `11a3ac1`. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -10,8 +10,9 @@
 **v0.9.17 SHIPPED** — PR #52 merged (`c88ca7a`) 2026-03-28. Tagged v0.9.17. Released.
 **v0.9.18 SHIPPED** — PR #53 merged (`7567a5c`) 2026-03-28. Tagged v0.9.18. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.18-retrospective.md`.
 **v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
-**v0.9.20 ACTIVE** — branch `k3d-manager-v0.9.20` cut from `0f13be1` 2026-03-28.
-**enforce_admins:** restored on main 2026-03-28.
+**v0.9.20 SHIPPED** — PR #55 merged to main (`bfd66fe`) 2026-03-29. Tagged v0.9.20, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-29-v0.9.20-retrospective.md`.
+**v0.9.21 ACTIVE** — branch `k3d-manager-v0.9.21` cut from `bfd66fe` 2026-03-29.
+**enforce_admins:** restored on main 2026-03-29.
 **Branch cleanup:** v0.9.7–v0.9.17 deleted (local + remote) 2026-03-28.
 **v0.9.15 scope:** Antigravity × GitHub Copilot coding agent validation — 3 runs, determinism verdict; spec `docs/plans/v0.9.15-antigravity-copilot-agent.md`. Antigravity plugin rewritten in `b2ba187` per `docs/plans/v0.9.15-antigravity-plugin-impl.md`. Also: ldap-password-rotator `vault kv put` stdin hardening — spec `docs/plans/v0.9.15-ensure-copilot-cli.md` (closes v0.6.2 security debt; `_ensure_copilot_cli`/`_k3d_manager_copilot`/`_ensure_node` already shipped in v0.9.12).
 
@@ -23,7 +24,7 @@
 
 ---
 
-## Current Focus (v0.9.20)
+## Current Focus (v0.9.21)
 
 Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — k3d-manager
 
-## Current Branch: `k3d-manager-v0.9.20` (as of 2026-03-28)
+## Current Branch: `k3d-manager-v0.9.21` (as of 2026-03-29)
 
 **v0.9.12 SHIPPED** — PR #47 merged to main (`f8014bc`) 2026-03-23. Copilot CLI CI integration.
 **v0.9.13 SHIPPED** — PR #48 merged to main (`c54fbe6`) 2026-03-23. Tagged v0.9.13, released.
@@ -18,6 +18,17 @@
 
 ---
 
+## Roadmap Versioning Decision (2026-03-29)
+
+| Version | Scope |
+|---------|-------|
+| v0.9.21 | `_ensure_k3sup` + `deploy_app_cluster` auto-install — prerequisite cleanup |
+| v1.0.0 | AWS/ACG — 3-node k3sup cluster + Samba AD + full automation |
+| v1.0.1 | GCP cloud provider (`k3s-gcp`) |
+| v1.0.2 | Azure cloud provider (`k3s-azure`) |
+
+`v1.0.0` = first release where k3d-manager provisions and fully configures a remote multi-node cluster end-to-end without manual steps.
+
 ## v1.0.0 Design Decisions
 
 - **`acg_get_credentials <sandbox-url>`** — new function; extracts AWS credentials from Pluralsight sandbox "Cloud Access" panel via Antigravity Playwright; writes to `~/.aws/credentials`; stdin paste (`pbpaste | acg_import_credentials`) as fallback. Must run before any `acg_provision` call. Single extract covers all 3 nodes (same sandbox session).
@@ -26,7 +37,7 @@
 
 ## Current Focus (v0.9.21)
 
-Spec: `docs/plans/v0.9.20-acg-automation-fixes.md` (committed `b579043`)
+Scope: `_ensure_k3sup` helper + `deploy_app_cluster` replacement of raw `command -v k3sup` check.
 
 | Item | Status | Notes |
 |---|---|---|

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -45,7 +45,8 @@ Scope: `_ensure_k3sup` helper + `deploy_app_cluster` replacement of raw `command
 | **`_antigravity_launch` Chrome fix** | **COMPLETE** | Verified Chrome cold-start with `--password-store=basic` and dedicated profile. |
 | **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
 | **`_ensure_k3sup`** | **COMPLETE** | Auto-installs via brew/curl + `deploy_app_cluster` guard rewired; commit `11a3ac1`. |
-| **Gemini: smoke test `_ensure_k3sup`** | **PENDING** | Cold-start test: hide k3sup from PATH, call `_ensure_k3sup`, confirm brew installs it. Warm test: k3sup present, confirm returns 0 immediately. |
+| **Gemini: smoke test `_ensure_k3sup`** | **COMPLETE** | Verified warm path (returns 0) and cold path (triggers install message when hidden). Ubuntu skip (unreachable). |
+| **Gemini: Ubuntu smoke test `_ensure_k3sup`** | **PENDING** | Run cold-path test on ubuntu-parallels (Parallels Desktop Ubuntu VM) — curl installer path should fire since k3sup not installed there. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -45,6 +45,7 @@ Scope: `_ensure_k3sup` helper + `deploy_app_cluster` replacement of raw `command
 | **`_antigravity_launch` Chrome fix** | **COMPLETE** | Verified Chrome cold-start with `--password-store=basic` and dedicated profile. |
 | **`acg_credentials.js` SPA nav fix** | **COMPLETE** | Verified SPA-navigation guard avoids hard goto when already on Pluralsight. |
 | **`_ensure_k3sup`** | **COMPLETE** | Auto-installs via brew/curl + `deploy_app_cluster` guard rewired; commit `11a3ac1`. |
+| **Gemini: smoke test `_ensure_k3sup`** | **PENDING** | Cold-start test: hide k3sup from PATH, call `_ensure_k3sup`, confirm brew installs it. Warm test: k3sup present, confirm returns 0 immediately. |
 | **Static acg_credentials.js** | **COMPLETE** | Implemented `scripts/playwright/acg_credentials.js` and updated `acg_get_credentials`. Verified working with live Pluralsight sandbox via Chrome CDP. commit `67a445c`. |
 | **scratch/ cleanup** | **PENDING** | `rm -f scratch/*` — wipe stale Playwright artifacts; policy: wipe at each release cut |
 | **acg_get_credentials + acg_import_credentials** | **COMPLETE** | `3970623` adds credential extractor + stdin import helpers with docs/tests per `docs/plans/v0.9.19-acg-get-credentials.md` |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -26,7 +26,7 @@
 ## v0.9.21 — Active
 
 - [x] **`_ensure_k3sup` helper** — added helper before `deploy_app_cluster`, auto-installs via brew or curl | sudo sh, rewired call site; spec `docs/plans/v0.9.21-ensure-k3sup.md`, commit `11a3ac1`.
-- [x] **Smoke test `_ensure_k3sup`** — **COMPLETE**. Verified warm path (k3sup exists) and cold path (install triggered when hidden). Ubuntu skip (unreachable).
+- [x] **Smoke test `_ensure_k3sup`** — **COMPLETE**. Verified warm path (k3sup exists) and cold path (install triggered when hidden). Ubuntu parallels smoke test confirmed functional.
 - [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
 - [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.
 - [x] **Automation Verification** — Verified Chrome cold-start (flags/profile) and SPA navigation guard in `acg_credentials.js`. Logic confirmed via live verification.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -24,8 +24,8 @@
 
 ## v0.9.21 — Active
 
-- [ ] **`_ensure_k3sup` helper** — add auto-install helper to `scripts/plugins/shopping_cart.sh`; replace raw `command -v k3sup` check in `deploy_app_cluster`
-- [ ] **BATS coverage** — k3sup present → 0; absent + brew → installs; absent + no brew → `_err`
+- [x] **`_ensure_k3sup` helper** — added helper before `deploy_app_cluster`, auto-installs via brew or curl | sudo sh, rewired call site; spec `docs/plans/v0.9.21-ensure-k3sup.md`, commit `11a3ac1`.
+- [x] **BATS coverage** — `scripts/tests/plugins/shopping_cart.bats` gained `_ensure_k3sup` success/failure tests; suite run via `bats scripts/tests/plugins/shopping_cart.bats` green.
 
 ## v0.9.20 — Shipped
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -19,9 +19,15 @@
 **v0.9.17 SHIPPED** — PR #52 merged to main (`c88ca7a`) 2026-03-28. Tagged v0.9.17, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.17-retrospective.md`. Branches v0.9.7–v0.9.17 deleted.
 **v0.9.18 SHIPPED** — PR #53 merged (`7567a5c`) 2026-03-28. Tagged v0.9.18. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.18-retrospective.md`.
 **v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
-**v0.9.20 ACTIVE** — branch `k3d-manager-v0.9.20` cut from `0f13be1` 2026-03-28.
+**v0.9.20 SHIPPED** — PR #55 merged to main (`bfd66fe`) 2026-03-29. Tagged v0.9.20, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-29-v0.9.20-retrospective.md`.
+**v0.9.21 ACTIVE** — branch `k3d-manager-v0.9.21` cut from `bfd66fe` 2026-03-29.
 
-## v0.9.20 — Active
+## v0.9.21 — Active
+
+- [ ] **`_ensure_k3sup` helper** — add auto-install helper to `scripts/plugins/shopping_cart.sh`; replace raw `command -v k3sup` check in `deploy_app_cluster`
+- [ ] **BATS coverage** — k3sup present → 0; absent + brew → installs; absent + no brew → `_err`
+
+## v0.9.20 — Shipped
 
 - [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
 - [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -20,19 +20,19 @@
 **v0.9.18 SHIPPED** — PR #53 merged (`7567a5c`) 2026-03-28. Tagged v0.9.18. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.18-retrospective.md`.
 **v0.9.19 SHIPPED** — PR #54 merged (`0f13be1`) 2026-03-28. Tagged v0.9.19. Released. `enforce_admins` restored. Retro: `docs/retro/2026-03-28-v0.9.19-retrospective.md`.
 **v0.9.20 SHIPPED** — PR #55 merged to main (`bfd66fe`) 2026-03-29. Tagged v0.9.20, released. `enforce_admins` restored. Retro: `docs/retro/2026-03-29-v0.9.20-retrospective.md`.
-**v0.9.21 ACTIVE** — branch `k3d-manager-v0.9.21` cut from `bfd66fe` 2026-03-29.
+
+---
 
 ## v0.9.21 — Active
 
 - [x] **`_ensure_k3sup` helper** — added helper before `deploy_app_cluster`, auto-installs via brew or curl | sudo sh, rewired call site; spec `docs/plans/v0.9.21-ensure-k3sup.md`, commit `11a3ac1`.
-- [x] **BATS coverage** — `scripts/tests/plugins/shopping_cart.bats` gained `_ensure_k3sup` success/failure tests; suite run via `bats scripts/tests/plugins/shopping_cart.bats` green.
-
-## v0.9.20 — Shipped
-
+- [x] **Smoke test `_ensure_k3sup`** — **COMPLETE**. Verified warm path (k3sup exists) and cold path (install triggered when hidden). Ubuntu skip (unreachable).
 - [x] **Antigravity Chrome launch** — `_antigravity_launch` now opens Google Chrome with `--password-store=basic` and dedicated user data dir so CDP probe works without manual browser start. Spec: `docs/plans/v0.9.20-acg-automation-fixes.md`, commit `8dd9cbb`.
 - [x] **`acg_credentials.js` SPA nav fix** — Script finds the Pluralsight tab, avoids hard `page.goto` when already on `app.pluralsight.com`, SPA-navigates when needed, waits for `aria-busy` to clear, and increases credential selector timeout to 60s. Commit `8dd9cbb`.
-- [ ] **`_ensure_k3sup` helper** — DEFERRED to v0.9.21; reverted from v0.9.20 (scope creep); not in repo.
 - [x] **Automation Verification** — Verified Chrome cold-start (flags/profile) and SPA navigation guard in `acg_credentials.js`. Logic confirmed via live verification.
+- [x] **BATS coverage** — `scripts/tests/plugins/shopping_cart.bats` gained `_ensure_k3sup` success/failure tests; suite run via `bats scripts/tests/plugins/shopping_cart.bats` green.
+
+---
 
 ## v0.9.19 — Shipped
 
@@ -42,6 +42,8 @@
 - [x] **Copilot PR #54 findings** — 9 findings addressed in `392dae5`: session token optional, playwright guard, null parent, chmod trace suppression, docs fixes, spec status, issue doc resolution, BATS AKIA test.
 - [x] **GitGuardian false positive** — `.gitguardian.yaml` added to exclude `scripts/tests/` from scanning.
 - [ ] **scratch/ cleanup** — `rm -rf scratch/*` — wipe stale Playwright artifacts at release cut
+
+---
 
 ## v0.9.17 — Shipped
 

--- a/scripts/plugins/shopping_cart.sh
+++ b/scripts/plugins/shopping_cart.sh
@@ -97,6 +97,26 @@ function register_shopping_cart_apps() {
   _run_command -- kubectl apply -f "${argocd_dir}/"
 }
 
+function _ensure_k3sup() {
+  if _command_exist k3sup; then
+    return 0
+  fi
+  _info "[shopping_cart] k3sup not found — installing..."
+  if _command_exist brew; then
+    _run_command -- brew install k3sup
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  if _is_debian_family && _command_exist curl; then
+    _run_command --prefer-sudo -- sh -c "$(curl -sLS https://get.k3sup.dev)"
+    if _command_exist k3sup; then
+      return 0
+    fi
+  fi
+  _err "[shopping_cart] k3sup not found and automatic installation failed — install manually: brew install k3sup"
+}
+
 function deploy_app_cluster() {
   if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     cat <<'HELP'
@@ -132,10 +152,7 @@ HELP
   local kube_context="ubuntu-k3s"
   local kubeconfig_dir="${local_kubeconfig%/*}"
 
-  if ! command -v k3sup >/dev/null 2>&1; then
-    _err "[shopping_cart] k3sup not found — install with: brew install k3sup"
-    return 1
-  fi
+  _ensure_k3sup
 
   if [[ ! -f "${ssh_key}" ]]; then
     _err "[shopping_cart] SSH key not found: ${ssh_key}"

--- a/scripts/plugins/shopping_cart.sh
+++ b/scripts/plugins/shopping_cart.sh
@@ -103,13 +103,20 @@ function _ensure_k3sup() {
   fi
   _info "[shopping_cart] k3sup not found — installing..."
   if _command_exist brew; then
-    _run_command -- brew install k3sup
+    _run_command --soft -- brew install k3sup
     if _command_exist k3sup; then
       return 0
     fi
   fi
   if _is_debian_family && _command_exist curl; then
-    _run_command --prefer-sudo -- sh -c "$(curl -sLS https://get.k3sup.dev)"
+    local _k3sup_installer
+    _k3sup_installer="$(mktemp)"
+    if ! curl -fsSL -o "${_k3sup_installer}" https://get.k3sup.dev; then
+      rm -f "${_k3sup_installer}"
+      _err "[shopping_cart] Failed to download k3sup installer from https://get.k3sup.dev"
+    fi
+    _run_command --soft --prefer-sudo -- sh "${_k3sup_installer}"
+    rm -f "${_k3sup_installer}"
     if _command_exist k3sup; then
       return 0
     fi

--- a/scripts/tests/plugins/shopping_cart.bats
+++ b/scripts/tests/plugins/shopping_cart.bats
@@ -47,3 +47,42 @@
   [ "$status" -ne 0 ]
   [[ "$output" == *"k3sup not found"* ]]
 }
+
+@test "_ensure_k3sup returns 0 after successful brew install" {
+  run bash -c '
+    SCRIPT_DIR="$(pwd)/scripts"
+    source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh
+    _state="$(mktemp)"
+    _command_exist() {
+      case "$1" in
+        k3sup) [[ -s "$_state" ]] ;;
+        brew)  return 0 ;;
+        *)     return 1 ;;
+      esac
+    }
+    _run_command() { [[ "$*" == *"brew"* ]] && echo 1 > "$_state"; return 0; }
+    _ensure_k3sup; rc=$?; rm -f "$_state"; exit $rc
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "_ensure_k3sup returns 0 after successful curl install on debian" {
+  run bash -c '
+    SCRIPT_DIR="$(pwd)/scripts"
+    source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh
+    _state="$(mktemp)"
+    _command_exist() {
+      case "$1" in
+        k3sup) [[ -s "$_state" ]] ;;
+        brew)  return 1 ;;
+        curl)  return 0 ;;
+        *)     return 1 ;;
+      esac
+    }
+    _is_debian_family() { return 0; }
+    curl() { return 0; }
+    _run_command() { [[ "$*" == *"sh "* ]] && echo 1 > "$_state"; return 0; }
+    _ensure_k3sup; rc=$?; rm -f "$_state"; exit $rc
+  '
+  [ "$status" -eq 0 ]
+}

--- a/scripts/tests/plugins/shopping_cart.bats
+++ b/scripts/tests/plugins/shopping_cart.bats
@@ -28,3 +28,22 @@
   run bash -c 'SCRIPT_DIR="$(pwd)/scripts"; source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh; register_shopping_cart_apps'
   [ "$status" -ne 0 ]
 }
+
+@test "_ensure_k3sup returns 0 when k3sup is already installed" {
+  run bash -c '
+    SCRIPT_DIR="$(pwd)/scripts"
+    source scripts/lib/system.sh
+    source scripts/lib/core.sh
+    source scripts/plugins/shopping_cart.sh
+    k3sup() { return 0; }
+    _command_exist() { [[ "$1" == "k3sup" ]]; }
+    _ensure_k3sup
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "_ensure_k3sup errors when k3sup absent and no installer available" {
+  run bash -c 'SCRIPT_DIR="$(pwd)/scripts"; PATH=/dev/null; source scripts/lib/system.sh; source scripts/lib/core.sh; source scripts/plugins/shopping_cart.sh; _ensure_k3sup'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"k3sup not found"* ]]
+}


### PR DESCRIPTION
## Summary
- Adds `_ensure_k3sup` private helper to `scripts/plugins/shopping_cart.sh` — auto-installs k3sup via `brew install k3sup` (macOS/Linuxbrew) or `curl | sudo sh` (Debian/Ubuntu); fails with clear guidance if neither available
- Replaces raw `command -v k3sup` hard-error in `deploy_app_cluster` with `_ensure_k3sup` — consistent with `_ensure_node` / `_ensure_copilot_cli` auto-install pattern
- Prerequisite for v1.0.0 multi-node k3sup cluster work

## Test plan
- [ ] CI green
- [ ] Copilot review comments addressed
- [ ] BATS: 6 tests pass (`deploy_app_cluster --help`, `--confirm` guard, k3sup-absent error, argocd dir, `_ensure_k3sup` warm path, `_ensure_k3sup` cold path)
- [ ] Gemini smoke test verified: warm path (returns 0 immediately) on macOS; cold path (install triggered) on ubuntu-parallels via curl installer

## Notes
- Ubuntu passwordless sudo is a prerequisite for the curl install path — ACG EC2 ubuntu user is passwordless by default; documented as v1.2.0 k3dm-mcp gate in `docs/plans/roadmap-v1.md`
- `docs/plans/roadmap-v1.md` updated with v0.9.21 section, v1.0.x versioning (AWS/GCP/Azure), and sudo pre-flight requirement for k3dm-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)